### PR TITLE
feat(core): allow custom cors handlers for external dashboards

### DIFF
--- a/core/Taskfile.yaml
+++ b/core/Taskfile.yaml
@@ -16,7 +16,7 @@ tasks:
   dev:
     deps: [generate]
     cmds:
-      - go run -tags "no_duckdb_arrow" ./cmd/ {{.CLI_ARGS}} -logger=pretty -level=debug
+      - go run -tags "no_duckdb_arrow" ./cmd/ {{.CLI_ARGS}} -logger=pretty -level=debug -corsorigins=http://localhost:8080,http://localhost:5173
     env:
       CGO_ENABLED: "1"
 

--- a/core/cmd/config.go
+++ b/core/cmd/config.go
@@ -13,6 +13,9 @@ type ServerConfig struct {
 	// Cache settings
 	CacheCleanupInterval time.Duration
 
+	// CORS Settings
+	CORSAllowedOrigins []string `env:"CORS_ALLOWED_ORIGINS" envSeparator:","`
+
 	// Logging settings
 	Logger string `env:"LOGGER"`
 	Level  string `env:"LOGGER_LEVEL"`

--- a/core/middlewares/cors.go
+++ b/core/middlewares/cors.go
@@ -1,0 +1,41 @@
+package middlewares
+
+import (
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/medama-io/medama/util/logger"
+	"github.com/rs/cors"
+)
+
+// CORSAllowedOriginsMiddleware creates a middleware to apply CORS headers based on the allowed origins.
+// Typically this won't need a custom list of allowed origins as the client will be served from the same domain.
+// But it is useful for development and external dashboards as we need to pass credentials from different domains.
+func CORSAllowedOriginsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
+	// Create a CORS handler with custom options for the allowed origins
+	customCORS := cors.New(cors.Options{
+		AllowedOrigins:   allowedOrigins,
+		AllowCredentials: true,
+		Debug:            true,
+	})
+
+	// Create a default CORS handler
+	defaultCORS := cors.Default()
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			uPath := path.Clean(r.URL.Path)
+			log := logger.Get()
+
+			if allowedOrigins != nil && strings.HasPrefix(uPath, "/api") && !strings.HasPrefix(uPath, "/api/event") {
+				// Apply modified CORS headers for API routes.
+				log.Debug().Str("allowed_origins", strings.Join(allowedOrigins, ",")).Str("path", uPath).Msg("Applying custom CORS")
+				customCORS.Handler(next).ServeHTTP(w, r)
+			} else {
+				// Apply default CORS headers
+				defaultCORS.Handler(next).ServeHTTP(w, r)
+			}
+		})
+	}
+}


### PR DESCRIPTION
While `Access-Control-Allow-Origin: *` is sufficient for CORS, especially since our dashboard is hosted on the same domain as the API, sometimes users may want to use external dashboards (or in our case a development dashboard) that is hosted on another domain. This triggers a bunch of CORS errors and needs custom configuration of `Access-Control-Allow-Origin` for it to successfully pass. This PR adds an optional flag `-corsorigins` to add a list of allowed origins.

Note this custom configuration only applies to API endpoints that do not have the prefix `/api/event`. All other endpoints will continue to use `*` for allowed origins.
