### PR TITLE
feat(core): add use env flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@
 **/go.work
 
 # DBs
-**/*.dev.db
+**/*.db
 **/*.wal
 
 # Runtime data

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM jdxcode/mise:latest AS build
 # Install unzip dependency for bun
 RUN apt-get update && apt-get install -y unzip
 
-# Install runtimes
+# Install runtimes - Temporarily include node for google-closure-compiler for tracker
 RUN mise use -g node@20
 RUN mise use -g bun@latest
 RUN mise use -g go@1.22
@@ -43,12 +43,15 @@ LABEL org.opencontainers.image.source=https://github.com/medama-io/medama
 LABEL org.opencontainers.image.description="Cookie-free, privacy-focused website analytics."
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
+ENV PORT=8080
+ENV ANALYTICS_DATABASE_HOST=/app/data/me_analytics.db
+ENV APP_DATABASE_HOST=/app/data/me_app.db
+
 WORKDIR /app
 
 # Copy the binary
 COPY --from=build /app/core/bin/main /app/bin/main
 
-# Run the binary
-EXPOSE 8080
-CMD ["/app/bin/main", "start", "-level=debug"]
+EXPOSE ${PORT}
+CMD ["/app/bin/main", "start", "-env"]
 

--- a/core/cmd/config.go
+++ b/core/cmd/config.go
@@ -8,22 +8,24 @@ import (
 )
 
 type ServerConfig struct {
-	Port int64 `env:"PORT"`
-
-	// Cache settings
-	CacheCleanupInterval time.Duration
-
-	// CORS Settings
-	CORSAllowedOrigins []string `env:"CORS_ALLOWED_ORIGINS" envSeparator:","`
-
-	// Logging settings
+	// General settings.
+	Port   int64  `env:"PORT"`
 	Logger string `env:"LOGGER"`
 	Level  string `env:"LOGGER_LEVEL"`
 
-	// Timeout settings
+	// Cache settings.
+	CacheCleanupInterval time.Duration
+
+	// CORS Settings.
+	CORSAllowedOrigins []string `env:"CORS_ALLOWED_ORIGINS" envSeparator:","`
+
+	// Timeout settings.
 	TimeoutRead  time.Duration
 	TimeoutWrite time.Duration
 	TimeoutIdle  time.Duration
+
+	// Misc settings.
+	UseEnvironment bool
 }
 
 type AppDBConfig struct {
@@ -47,8 +49,8 @@ const (
 	DefaultTimeoutIdle  = 15 * time.Second
 
 	// Database constants.
-	DefaultSQLiteHost = "./sqlite.dev.db"
-	DefaultDuckDBHost = "./duckdb.dev.db"
+	DefaultSQLiteHost = "./me_meta.db"
+	DefaultDuckDBHost = "./me_analytics.db"
 
 	// Logging constants.
 	DefaultLogger      = "json"
@@ -56,7 +58,7 @@ const (
 )
 
 // NewServerConfig creates a new server config.
-func NewServerConfig() (*ServerConfig, error) {
+func NewServerConfig(useEnv bool) (*ServerConfig, error) {
 	config := &ServerConfig{
 		Port:                 DefaultPort,
 		CacheCleanupInterval: DefaultCacheCleanupInterval,
@@ -65,39 +67,46 @@ func NewServerConfig() (*ServerConfig, error) {
 		TimeoutRead:          DefaultTimeoutRead,
 		TimeoutWrite:         DefaultTimeoutWrite,
 		TimeoutIdle:          DefaultTimeoutIdle,
+		UseEnvironment:       useEnv,
 	}
 
 	// Load config from environment variables.
-	if err := env.Parse(config); err != nil {
-		return nil, errors.Wrap(err, "config")
+	if useEnv {
+		if err := env.Parse(config); err != nil {
+			return nil, errors.Wrap(err, "config")
+		}
 	}
 
 	return config, nil
 }
 
 // NewAppDBConfig creates a new app database config.
-func NewAppDBConfig() (*AppDBConfig, error) {
+func NewAppDBConfig(useEnv bool) (*AppDBConfig, error) {
 	config := &AppDBConfig{
 		Host: DefaultSQLiteHost,
 	}
 
 	// Load config from environment variables.
-	if err := env.Parse(config); err != nil {
-		return nil, errors.Wrap(err, "config")
+	if useEnv {
+		if err := env.Parse(config); err != nil {
+			return nil, errors.Wrap(err, "config")
+		}
 	}
 
 	return config, nil
 }
 
 // NewAnalyticsDBConfig creates a new analytics database config.
-func NewAnalyticsDBConfig() (*AnalyticsDBConfig, error) {
+func NewAnalyticsDBConfig(useEnv bool) (*AnalyticsDBConfig, error) {
 	config := &AnalyticsDBConfig{
 		Host: DefaultDuckDBHost,
 	}
 
 	// Load config from environment variables.
-	if err := env.Parse(config); err != nil {
-		return nil, errors.Wrap(err, "config")
+	if useEnv {
+		if err := env.Parse(config); err != nil {
+			return nil, errors.Wrap(err, "config")
+		}
 	}
 
 	return config, nil

--- a/core/cmd/main.go
+++ b/core/cmd/main.go
@@ -51,7 +51,13 @@ func run(ctx context.Context, args []string) error {
 
 	switch cmd {
 	case "start":
-		s, err := NewStartCommand()
+		// Check for --env flag to set configuration to also scan
+		// for environment variables. Ignore all other flags.
+		useEnv := flag.Bool("env", false, "use environment variables for configuration")
+		flag.Parse()
+
+		// Create start command
+		s, err := NewStartCommand(*useEnv)
 		if err != nil {
 			return err
 		}

--- a/fly.toml
+++ b/fly.toml
@@ -11,6 +11,7 @@ primary_region = 'lhr'
 ANALYTICS_DATABASE_HOST = '/db/analytics.db'
 APP_DATABASE_HOST = '/db/sqlite.db'
 PORT = '8080'
+LOGGER_LEVEL = 'debug'
 
 [[mounts]]
 source = 'medama_db'


### PR DESCRIPTION
This adds a new `-env` flag to deployments which makes configuration via environment flags opt-in. Typically you would want to configure the application using CLI flags, however, sometimes that can be difficult such as when using Docker images with pre-defined startup commands. 

With this new flag, published Docker images will use this flag to configure themselves via environment flags. Other deployments can choose to use normal flags or opt-in with this. 