### PR TITLE
fix(config): prevent default flag values overwriting env vars

### DIFF
--- a/core/cmd/config.go
+++ b/core/cmd/config.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/caarlos0/env/v10"
+	"github.com/caarlos0/env/v11"
 	"github.com/go-faster/errors"
 )
 
@@ -11,7 +11,7 @@ type ServerConfig struct {
 	// General settings.
 	Port   int64  `env:"PORT"`
 	Logger string `env:"LOGGER"`
-	Level  string `env:"LOGGER_LEVEL"`
+	Level  string `env:"LEVEL"`
 
 	// Cache settings.
 	CacheCleanupInterval time.Duration

--- a/core/cmd/main.go
+++ b/core/cmd/main.go
@@ -53,11 +53,16 @@ func run(ctx context.Context, args []string) error {
 	case "start":
 		// Check for --env flag to set configuration to also scan
 		// for environment variables. Ignore all other flags.
-		useEnv := flag.Bool("env", false, "use environment variables for configuration")
-		flag.Parse()
+		useEnv := false
+		for _, arg := range args {
+			switch arg {
+			case "--env", "-env":
+				useEnv = true
+			}
+		}
 
 		// Create start command
-		s, err := NewStartCommand(*useEnv)
+		s, err := NewStartCommand(useEnv)
 		if err != nil {
 			return err
 		}

--- a/core/cmd/start.go
+++ b/core/cmd/start.go
@@ -61,19 +61,19 @@ func (s *StartCommand) ParseFlags(args []string) error {
 	fs := flag.NewFlagSet("start", flag.ExitOnError)
 
 	// General settings.
-	fs.Int64Var(&s.Server.Port, "port", DefaultPort, "Port to listen on.")
-	fs.StringVar(&s.Server.Logger, "logger", DefaultLogger, "Logger format (json, pretty)")
-	fs.StringVar(&s.Server.Level, "level", DefaultLoggerLevel, "Logger level (debug, info, warn, error)")
+	fs.Int64Var(&s.Server.Port, "port", s.Server.Port, "Port to listen on.")
+	fs.StringVar(&s.Server.Logger, "logger", s.Server.Logger, "Logger format (json, pretty)")
+	fs.StringVar(&s.Server.Level, "level", s.Server.Level, "Logger level (debug, info, warn, error)")
 
 	// Database settings.
-	fs.StringVar(&s.AppDB.Host, "appdb", DefaultSQLiteHost, "Path to app database.")
-	fs.StringVar(&s.AnalyticsDB.Host, "analyticsdb", DefaultDuckDBHost, "Path to analytics database.")
+	fs.StringVar(&s.AppDB.Host, "appdb", s.AppDB.Host, "Path to app database.")
+	fs.StringVar(&s.AnalyticsDB.Host, "analyticsdb", s.AnalyticsDB.Host, "Path to analytics database.")
 
 	// Misc settings.
 	fs.BoolVar(&s.Server.UseEnvironment, "env", false, "Opt-in to allow environment variables to be used for configuration. Flags will still override environment variables.")
 
 	// Handle array type flags.
-	corsAllowedOrigins := fs.String("corsorigins", "", "Comma separated list of allowed CORS origins on API routes. Useful for external dashboards that may host the frontend on a different domain.")
+	corsAllowedOrigins := fs.String("corsorigins", strings.Join(s.Server.CORSAllowedOrigins, ","), "Comma separated list of allowed CORS origins on API routes. Useful for external dashboards that may host the frontend on a different domain.")
 
 	// Parse flags.
 	err := fs.Parse(args)
@@ -95,7 +95,7 @@ func (s *StartCommand) Run(ctx context.Context) error {
 		return errors.Wrap(err, "failed to setup logger")
 	}
 	log.Info().Msg(GetVersion())
-	log.Debug().Interface("config", s).Msg("")
+	log.Warn().Interface("config", s).Msg("")
 
 	// Setup database
 	sqlite, err := sqlite.NewClient(s.AppDB.Host)

--- a/core/go.mod
+++ b/core/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/alexedwards/argon2id v1.0.0
-	github.com/caarlos0/env/v10 v10.0.0
+	github.com/caarlos0/env/v11 v11.1.0
 	github.com/gkampitakis/go-snaps v0.5.4
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.1.0

--- a/core/go.sum
+++ b/core/go.sum
@@ -6,8 +6,8 @@ github.com/apache/arrow/go/v14 v14.0.2 h1:N8OkaJEOfI3mEZt07BIkvo4sC6XDbL+48MBPWO
 github.com/apache/arrow/go/v14 v14.0.2/go.mod h1:u3fgh3EdgN/YQ8cVQRguVW3R+seMybFg8QBQ5LU+eBY=
 github.com/boyter/go-string v1.0.5 h1:/xcOlWdgelLYLVkUU0xBLfioGjZ9KIMUMI/RXG138YY=
 github.com/boyter/go-string v1.0.5/go.mod h1:Mww9cDld2S2cdJ0tQffBhsZFMQRA2OJdcjWYZXvZ4Ss=
-github.com/caarlos0/env/v10 v10.0.0 h1:yIHUBZGsyqCnpTkbjk8asUlx6RFhhEs+h7TOBdgdzXA=
-github.com/caarlos0/env/v10 v10.0.0/go.mod h1:ZfulV76NvVPw3tm591U4SwL3Xx9ldzBP9aGxzeN7G18=
+github.com/caarlos0/env/v11 v11.1.0 h1:a5qZqieE9ZfzdvbbdhTalRrHT5vu/4V1/ad1Ka6frhI=
+github.com/caarlos0/env/v11 v11.1.0/go.mod h1:LwgkYk1kDvfGpHthrWWLof3Ny7PezzFwS4QrsJdHTMo=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/dashboard/Taskfile.yaml
+++ b/dashboard/Taskfile.yaml
@@ -31,6 +31,7 @@ tasks:
     deps: [build]
     cmds:
       - mkdir -p ../core/client
+      - rm -rf ../core/client/*
       - cp -r ./build/client/* ../core/client/
     sources:
       - ./build/client/**/*

--- a/fly.toml
+++ b/fly.toml
@@ -9,9 +9,9 @@ primary_region = 'lhr'
 
 [env]
 ANALYTICS_DATABASE_HOST = '/db/analytics.db'
-APP_DATABASE_HOST = '/db/sqlite.db'
+APP_DATABASE_HOST = '/db/app.db'
 PORT = '8080'
-LOGGER_LEVEL = 'debug'
+LEVEL = 'debug'
 
 [[mounts]]
 source = 'medama_db'


### PR DESCRIPTION
The default flag values of the flag parser was overwriting env variable configuration. This maps the existing environment variables as the new default.