### PR TITLE
feat(core): add demo mode

### DIFF
--- a/core/api/oas_response_encoders_gen.go
+++ b/core/api/oas_response_encoders_gen.go
@@ -44,9 +44,9 @@ func encodeDeleteUserResponse(response DeleteUserRes, w http.ResponseWriter) err
 
 		return nil
 
-	case *NotFoundError:
+	case *ForbiddenError:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(404)
+		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
 		response.Encode(e)
@@ -56,9 +56,9 @@ func encodeDeleteUserResponse(response DeleteUserRes, w http.ResponseWriter) err
 
 		return nil
 
-	case *ConflictError:
+	case *NotFoundError:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(409)
+		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
 		response.Encode(e)
@@ -107,6 +107,18 @@ func encodeDeleteWebsitesIDResponse(response DeleteWebsitesIDRes, w http.Respons
 	case *UnauthorisedError:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(401)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *ForbiddenError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
 		response.Encode(e)
@@ -1486,6 +1498,18 @@ func encodePatchUserResponse(response PatchUserRes, w http.ResponseWriter) error
 
 		return nil
 
+	case *ForbiddenError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(403)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	case *NotFoundError:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(404)
@@ -1564,6 +1588,18 @@ func encodePatchWebsitesIDResponse(response PatchWebsitesIDRes, w http.ResponseW
 	case *UnauthorisedError:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(401)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *ForbiddenError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
 		response.Encode(e)
@@ -1803,6 +1839,18 @@ func encodePostWebsitesResponse(response PostWebsitesRes, w http.ResponseWriter)
 	case *UnauthorisedError:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(401)
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *ForbiddenError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
 		response.Encode(e)

--- a/core/api/oas_schemas_gen.go
+++ b/core/api/oas_schemas_gen.go
@@ -114,7 +114,6 @@ func (s *ConflictError) SetError(val ConflictErrorError) {
 	s.Error = val
 }
 
-func (*ConflictError) deleteUserRes()   {}
 func (*ConflictError) patchUserRes()    {}
 func (*ConflictError) postWebsitesRes() {}
 
@@ -477,6 +476,8 @@ func (s *ForbiddenError) SetError(val ForbiddenErrorError) {
 	s.Error = val
 }
 
+func (*ForbiddenError) deleteUserRes()            {}
+func (*ForbiddenError) deleteWebsitesIDRes()      {}
 func (*ForbiddenError) getWebsiteIDBrowsersRes()  {}
 func (*ForbiddenError) getWebsiteIDCampaignsRes() {}
 func (*ForbiddenError) getWebsiteIDCountryRes()   {}
@@ -486,6 +487,9 @@ func (*ForbiddenError) getWebsiteIDMediumsRes()   {}
 func (*ForbiddenError) getWebsiteIDOsRes()        {}
 func (*ForbiddenError) getWebsiteIDReferrersRes() {}
 func (*ForbiddenError) getWebsiteIDSourcesRes()   {}
+func (*ForbiddenError) patchUserRes()             {}
+func (*ForbiddenError) patchWebsitesIDRes()       {}
+func (*ForbiddenError) postWebsitesRes()          {}
 
 type ForbiddenErrorError struct {
 	Code    int32  `json:"code"`

--- a/core/cmd/config.go
+++ b/core/cmd/config.go
@@ -26,6 +26,7 @@ type ServerConfig struct {
 
 	// Misc settings.
 	UseEnvironment bool
+	DemoMode       bool `env:"DEMO_MODE"`
 }
 
 type AppDBConfig struct {
@@ -55,6 +56,9 @@ const (
 	// Logging constants.
 	DefaultLogger      = "json"
 	DefaultLoggerLevel = "info"
+
+	// Misc constants.
+	DefaultDemoMode = false
 )
 
 // NewServerConfig creates a new server config.
@@ -68,6 +72,7 @@ func NewServerConfig(useEnv bool) (*ServerConfig, error) {
 		TimeoutWrite:         DefaultTimeoutWrite,
 		TimeoutIdle:          DefaultTimeoutIdle,
 		UseEnvironment:       useEnv,
+		DemoMode:             DefaultDemoMode,
 	}
 
 	// Load config from environment variables.

--- a/core/cmd/start.go
+++ b/core/cmd/start.go
@@ -71,6 +71,7 @@ func (s *StartCommand) ParseFlags(args []string) error {
 
 	// Misc settings.
 	fs.BoolVar(&s.Server.UseEnvironment, "env", false, "Opt-in to allow environment variables to be used for configuration. Flags will still override environment variables.")
+	fs.BoolVar(&s.Server.DemoMode, "demo", s.Server.DemoMode, "Enable demo mode restricting all POST/PATCH/DELETE actions (except login).")
 
 	// Handle array type flags.
 	corsAllowedOrigins := fs.String("corsorigins", strings.Join(s.Server.CORSAllowedOrigins, ","), "Comma separated list of allowed CORS origins on API routes. Useful for external dashboards that may host the frontend on a different domain.")
@@ -121,7 +122,7 @@ func (s *StartCommand) Run(ctx context.Context) error {
 	}
 
 	// Setup auth service
-	auth, err := util.NewAuthService(ctx)
+	auth, err := util.NewAuthService(ctx, s.Server.DemoMode)
 	if err != nil {
 		return errors.Wrap(err, "failed to create auth service")
 	}

--- a/core/migrations/0001_sqlite_schema.go
+++ b/core/migrations/0001_sqlite_schema.go
@@ -71,7 +71,7 @@ func Up0001(c *sqlite.Client) error {
 	id := typeid.String()
 
 	// Hash default password
-	auth, err := util.NewAuthService(context.Background())
+	auth, err := util.NewAuthService(context.Background(), false)
 	if err != nil {
 		return err
 	}

--- a/core/model/errors.go
+++ b/core/model/errors.go
@@ -12,6 +12,8 @@ var (
 	ErrInternalServerError = errors.New("internal server error")
 
 	// Authentication
+	// ErrDemoMode is returned when a user tries to perform an action in demo mode.
+	ErrDemoMode = errors.New("user in demo mode")
 	// ErrInvalidSession is returned when a session is invalid.
 	ErrInvalidSession = errors.New("invalid session")
 	// ErrSessionNotFound is returned when a session is not found.

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -222,6 +222,8 @@ paths:
           $ref: "#/components/responses/BadRequestError"
         "401":
           $ref: "#/components/responses/UnauthorisedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
         "404":
           $ref: "#/components/responses/NotFoundError"
         "409":
@@ -248,10 +250,10 @@ paths:
           $ref: "#/components/responses/BadRequestError"
         "401":
           $ref: "#/components/responses/UnauthorisedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
         "404":
           $ref: "#/components/responses/NotFoundError"
-        "409":
-          $ref: "#/components/responses/ConflictError"
         "500":
           $ref: "#/components/responses/InternalServerError"
       servers:
@@ -327,6 +329,8 @@ paths:
           $ref: "#/components/responses/BadRequestError"
         "401":
           $ref: "#/components/responses/UnauthorisedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
         "409":
           $ref: "#/components/responses/ConflictError"
         "500":
@@ -393,6 +397,8 @@ paths:
           $ref: "#/components/responses/BadRequestError"
         "401":
           $ref: "#/components/responses/UnauthorisedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
         "404":
           $ref: "#/components/responses/NotFoundError"
         "500":
@@ -418,6 +424,8 @@ paths:
           $ref: "#/components/responses/BadRequestError"
         "401":
           $ref: "#/components/responses/UnauthorisedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
         "404":
           $ref: "#/components/responses/NotFoundError"
         "500":

--- a/core/services/users.go
+++ b/core/services/users.go
@@ -40,6 +40,11 @@ func (h *Handler) GetUser(ctx context.Context, params api.GetUserParams) (api.Ge
 
 func (h *Handler) PatchUser(ctx context.Context, req *api.UserPatch, params api.PatchUserParams) (api.PatchUserRes, error) {
 	log := logger.Get()
+	if h.auth.IsDemoMode {
+		log.Debug().Msg("patch user rejected in demo mode")
+		return ErrForbidden(model.ErrDemoMode), nil
+	}
+
 	// Get user id from request context and check if user exists
 	userId, ok := ctx.Value(model.ContextKeyUserID).(string)
 	if !ok {
@@ -108,6 +113,11 @@ func (h *Handler) PatchUser(ctx context.Context, req *api.UserPatch, params api.
 
 func (h *Handler) DeleteUser(ctx context.Context, params api.DeleteUserParams) (api.DeleteUserRes, error) {
 	log := logger.Get()
+	if h.auth.IsDemoMode {
+		log.Debug().Msg("delete user rejected in demo mode")
+		return ErrForbidden(model.ErrDemoMode), nil
+	}
+
 	// Get user id from request context and check if user exists
 	userId, ok := ctx.Value(model.ContextKeyUserID).(string)
 	if !ok {

--- a/core/services/websites.go
+++ b/core/services/websites.go
@@ -7,9 +7,16 @@ import (
 	"github.com/go-faster/errors"
 	"github.com/medama-io/medama/api"
 	"github.com/medama-io/medama/model"
+	"github.com/medama-io/medama/util/logger"
 )
 
 func (h *Handler) DeleteWebsitesID(ctx context.Context, params api.DeleteWebsitesIDParams) (api.DeleteWebsitesIDRes, error) {
+	log := logger.Get()
+	if h.auth.IsDemoMode {
+		log.Debug().Msg("delete website rejected in demo mode")
+		return ErrForbidden(model.ErrDemoMode), nil
+	}
+
 	// Check if user owns website
 	userId, ok := ctx.Value(model.ContextKeyUserID).(string)
 	if !ok {
@@ -138,6 +145,12 @@ func (h *Handler) GetWebsitesID(ctx context.Context, params api.GetWebsitesIDPar
 }
 
 func (h *Handler) PatchWebsitesID(ctx context.Context, req *api.WebsitePatch, params api.PatchWebsitesIDParams) (api.PatchWebsitesIDRes, error) {
+	log := logger.Get()
+	if h.auth.IsDemoMode {
+		log.Debug().Msg("patch website rejected in demo mode")
+		return ErrForbidden(model.ErrDemoMode), nil
+	}
+
 	// Get user ID from context
 	userId, ok := ctx.Value(model.ContextKeyUserID).(string)
 	if !ok {
@@ -187,6 +200,12 @@ func (h *Handler) PatchWebsitesID(ctx context.Context, req *api.WebsitePatch, pa
 }
 
 func (h *Handler) PostWebsites(ctx context.Context, req *api.WebsiteCreate) (api.PostWebsitesRes, error) {
+	log := logger.Get()
+	if h.auth.IsDemoMode {
+		log.Debug().Msg("post website rejected in demo mode")
+		return ErrForbidden(model.ErrDemoMode), nil
+	}
+
 	// Get user ID from context
 	userId, ok := ctx.Value(model.ContextKeyUserID).(string)
 	if !ok {

--- a/core/util/auth.go
+++ b/core/util/auth.go
@@ -28,10 +28,12 @@ type AuthService struct {
 	Cache *Cache
 	// Key used to encrypt session tokens.
 	aes32Key []byte
+	// Demo mode flag.
+	IsDemoMode bool
 }
 
 // NewAuthService returns a new instance of AuthService.
-func NewAuthService(ctx context.Context) (*AuthService, error) {
+func NewAuthService(ctx context.Context, isDemoMode bool) (*AuthService, error) {
 	// Generate a new random key for encrypting session tokens.
 	// Since we store sessions in an in-memory cache, it doesn't
 	// matter if the key doesn't persist as sessions will be
@@ -43,8 +45,9 @@ func NewAuthService(ctx context.Context) (*AuthService, error) {
 	}
 
 	return &AuthService{
-		aes32Key: key,
-		Cache:    NewCache(ctx, model.SessionDuration),
+		aes32Key:   key,
+		Cache:      NewCache(ctx, model.SessionDuration),
+		IsDemoMode: isDemoMode,
 	}, nil
 }
 

--- a/core/util/auth_test.go
+++ b/core/util/auth_test.go
@@ -18,7 +18,7 @@ func SetupAuthTest(t *testing.T) (*assert.Assertions, *require.Assertions, conte
 	require := require.New(t)
 	ctx := context.Background()
 
-	auth, err := util.NewAuthService(ctx)
+	auth, err := util.NewAuthService(ctx, false)
 	require.NoError(err)
 	assert.NotNil(auth)
 

--- a/dashboard/app/api/types.d.ts
+++ b/dashboard/app/api/types.d.ts
@@ -789,8 +789,8 @@ export interface operations {
       };
       400: components["responses"]["BadRequestError"];
       401: components["responses"]["UnauthorisedError"];
+      403: components["responses"]["ForbiddenError"];
       404: components["responses"]["NotFoundError"];
-      409: components["responses"]["ConflictError"];
       500: components["responses"]["InternalServerError"];
     };
   };
@@ -819,6 +819,7 @@ export interface operations {
       };
       400: components["responses"]["BadRequestError"];
       401: components["responses"]["UnauthorisedError"];
+      403: components["responses"]["ForbiddenError"];
       404: components["responses"]["NotFoundError"];
       409: components["responses"]["ConflictError"];
       500: components["responses"]["InternalServerError"];
@@ -869,6 +870,7 @@ export interface operations {
       };
       400: components["responses"]["BadRequestError"];
       401: components["responses"]["UnauthorisedError"];
+      403: components["responses"]["ForbiddenError"];
       409: components["responses"]["ConflictError"];
       500: components["responses"]["InternalServerError"];
     };
@@ -919,6 +921,7 @@ export interface operations {
       };
       400: components["responses"]["BadRequestError"];
       401: components["responses"]["UnauthorisedError"];
+      403: components["responses"]["ForbiddenError"];
       404: components["responses"]["NotFoundError"];
       500: components["responses"]["InternalServerError"];
     };
@@ -951,6 +954,7 @@ export interface operations {
       };
       400: components["responses"]["BadRequestError"];
       401: components["responses"]["UnauthorisedError"];
+      403: components["responses"]["ForbiddenError"];
       404: components["responses"]["NotFoundError"];
       500: components["responses"]["InternalServerError"];
     };

--- a/dashboard/app/components/layout/Error.tsx
+++ b/dashboard/app/components/layout/Error.tsx
@@ -25,6 +25,32 @@ const ErrorPage = ({ label, title, description }: ErrorPageProps) => {
 	);
 };
 
+const ForbiddenError = () => {
+	// Check if hostname is demo.medama.io or medama.fly.dev to display a different message.
+	const hostname = window.location.hostname;
+	const isDemo = hostname === 'demo.medama.io' || hostname === 'medama.fly.dev';
+
+	const description = isDemo ? (
+		<>
+			You are currently in demo mode. You can't access this page or perform this
+			action.
+		</>
+	) : (
+		<>
+			You don't have permission to view this page or perform this action. Please
+			contact your administrator if you believe this is an error.
+		</>
+	);
+
+	return (
+		<ErrorPage
+			label="403"
+			title="You are not allowed to access this page."
+			description={description}
+		/>
+	);
+};
+
 const NotFoundError = () => (
 	<ErrorPage
 		label="404"
@@ -65,4 +91,4 @@ const InternalServerError = ({ error }: InternalServerErrorProps) => (
 	/>
 );
 
-export { NotFoundError, InternalServerError };
+export { NotFoundError, ForbiddenError, InternalServerError };

--- a/dashboard/app/root.tsx
+++ b/dashboard/app/root.tsx
@@ -61,7 +61,11 @@ import {
 
 import { API_BASE } from '@/api/client';
 import { AppShell } from '@/components/layout/AppShell';
-import { InternalServerError, NotFoundError } from '@/components/layout/Error';
+import {
+	ForbiddenError,
+	InternalServerError,
+	NotFoundError,
+} from '@/components/layout/Error';
 import theme from '@/styles/theme';
 import { hasSession } from '@/utils/cookies';
 
@@ -171,6 +175,13 @@ export const ErrorBoundary = () => {
 
 	if (isRouteErrorResponse(error)) {
 		switch (error.status) {
+			case 403: {
+				return (
+					<Document>
+						<ForbiddenError />
+					</Document>
+				);
+			}
 			case 404: {
 				return (
 					<Document>

--- a/dashboard/app/routes/login._index.tsx
+++ b/dashboard/app/routes/login._index.tsx
@@ -20,6 +20,29 @@ export const meta: MetaFunction = () => {
 };
 
 export const clientLoader = async () => {
+	// If the user is in demo mode (hostname matches demo.medama.io or medama.fly.dev), automatically
+	// log them into the demo account.
+	const hostname = window.location.hostname;
+	const isDemo = hostname === 'demo.medama.io' || hostname === 'medama.fly.dev';
+	if (isDemo) {
+		const { res } = await authLogin({
+			body: {
+				username: 'admin',
+				password: 'CHANGE_ME_ON_FIRST_LOGIN',
+			},
+			noThrow: true,
+		});
+
+		if (!res.ok) {
+			throw new Error('Failed to login to demo account.');
+		}
+
+		// Set logged in cookie
+		document.cookie = LOGGED_IN_COOKIE;
+
+		return redirect('/');
+	}
+
 	// If the user is already logged in, redirect them to the dashboard.
 	if (hasSession()) {
 		// Check if session hasn't been revoked

--- a/dashboard/app/routes/settings.account.tsx
+++ b/dashboard/app/routes/settings.account.tsx
@@ -99,7 +99,7 @@ export const clientAction = async ({ request }: ClientActionFunctionArgs) => {
 	}
 
 	if (!res.ok) {
-		throw new Response(await res.text(), {
+		throw new Response(res.statusText, {
 			status: res.status,
 		});
 	}

--- a/fly.toml
+++ b/fly.toml
@@ -12,6 +12,7 @@ ANALYTICS_DATABASE_HOST = '/db/analytics.db'
 APP_DATABASE_HOST = '/db/app.db'
 PORT = '8080'
 LEVEL = 'debug'
+DEMO_MODE = 'true'
 
 [[mounts]]
 source = 'medama_db'


### PR DESCRIPTION
### Overview 
This adds a demo mode flag that automatically authenticates the user when they visit the demo domains, but also locks all POST/PATCH/DELETE actions behind a 403 error to prevent the user from modifying the demo website.

This would let users get a good look at the application quickly without maintaining a separate version of the app.