### PR TITLE
feat(dashboard): allow users to select filters by clicking the stats table

### DIFF
--- a/dashboard/app/api/client.ts
+++ b/dashboard/app/api/client.ts
@@ -60,23 +60,21 @@ const client = async (
 		query,
 	}: ClientOptions,
 ): Promise<Response> => {
-	let newPath: string | undefined;
-	// Replace any path closed in curly braces with the pathKey
-	if (pathKey !== undefined) {
-		newPath = path.replace(/{.*}/, pathKey);
-	}
+	const url = new URL(
+		// Replace any path closed in curly braces with the pathKey.
+		// e.g. /website/{hostname}/mediums -> /website/example.com/mediums
+		`${API_URL}${pathKey ? path.replace(/{.*}/, pathKey) : path}`,
+	);
 
-	// Add the query to the path
-	const url = new URL(`${API_URL}${newPath ?? path}`);
+	// Add the query to the path.
 	if (query !== undefined) {
 		for (const [key, value] of Object.entries(query)) {
 			if (value !== undefined) {
-				// Handle filter for empty values
-				if (value === 'Direct/None') {
-					url.searchParams.append(key, '');
-				} else {
-					url.searchParams.append(key, String(value));
-				}
+				// Handle empty filter values.
+				url.searchParams.append(
+					key,
+					value === 'Direct/None' ? '' : String(value),
+				);
 			}
 		}
 	}

--- a/dashboard/app/api/client.ts
+++ b/dashboard/app/api/client.ts
@@ -71,7 +71,12 @@ const client = async (
 	if (query !== undefined) {
 		for (const [key, value] of Object.entries(query)) {
 			if (value !== undefined) {
-				url.searchParams.append(key, String(value));
+				// Handle filter for empty values
+				if (value === 'Direct/None') {
+					url.searchParams.append(key, '');
+				} else {
+					url.searchParams.append(key, String(value));
+				}
 			}
 		}
 	}

--- a/dashboard/app/components/stats/Chart.tsx
+++ b/dashboard/app/components/stats/Chart.tsx
@@ -11,36 +11,39 @@ import {
 	YAxis,
 } from 'recharts';
 
-interface StackedBarChartProps {
-	data: Array<{
-		date: string;
-		value: number;
-		stackValue?: number;
-	}>;
+interface ChartData {
+	date: string;
+	value: number;
+	stackValue?: number;
 }
 
-const error = console.error;
+interface StackedBarChartProps {
+	data: ChartData[];
+}
+
+// Move this outside the component to avoid recreation on each render
+const intlFormatter = new Intl.DateTimeFormat('en', {
+	year: 'numeric',
+	month: 'short',
+	day: 'numeric',
+	hour: 'numeric',
+	minute: 'numeric',
+});
+
+// Suppress specific console errors
 /* biome-ignore lint/suspicious/noExplicitAny: This is a hack to suppress the warning about missing defaultProps in recharts
 library as of version 2.12. @link https://github.com/recharts/recharts/issues/3615 */
-console.error = (...args: any) => {
-	if (/defaultProps/.test(args[0])) return;
-	error(...args);
+console.error = (...args: any[]) => {
+	if (!/defaultProps/.test(args[0])) {
+		console.error(...args);
+	}
 };
 
 export const StackedBarChart = ({ data }: StackedBarChartProps) => {
 	const [searchParams] = useSearchParams();
-
-	const intlFormatter = new Intl.DateTimeFormat('en', {
-		year: 'numeric',
-		month: 'short',
-		day: 'numeric',
-		hour: 'numeric',
-		minute: 'numeric',
-	});
-
-	// eslint-disable-next-line unicorn/consistent-function-scoping
-	let dateFormatter = (date: Date) => format(date, 'MMM, yyyy');
 	const period = searchParams.get('period');
+
+	let dateFormatter = (date: Date) => format(date, 'MMM, yyyy');
 	switch (true) {
 		case period === null:
 		case period === undefined:

--- a/dashboard/app/components/stats/Chart.tsx
+++ b/dashboard/app/components/stats/Chart.tsx
@@ -21,7 +21,6 @@ interface StackedBarChartProps {
 	data: ChartData[];
 }
 
-// Move this outside the component to avoid recreation on each render
 const intlFormatter = new Intl.DateTimeFormat('en', {
 	year: 'numeric',
 	month: 'short',

--- a/dashboard/app/components/stats/Filter.tsx
+++ b/dashboard/app/components/stats/Filter.tsx
@@ -291,7 +291,13 @@ export const Filters = () => {
 						<CloseButton
 							onClick={() => {
 								const params = new URLSearchParams(searchParams);
-								params.delete(`${label.toLowerCase()}[${type}]`, value);
+								const filterMap: Record<string, string> = {
+									'UTM Source': 'utm_source',
+									'UTM Medium': 'utm_medium',
+									'UTM Campaign': 'utm_campaign',
+								};
+								const filter = filterMap[label] ?? label.toLowerCase();
+								params.delete(`${filter}[${type}]`, value);
 								setSearchParams(params, {
 									preventScrollReset: true,
 								});

--- a/dashboard/app/components/stats/Filter.tsx
+++ b/dashboard/app/components/stats/Filter.tsx
@@ -11,7 +11,7 @@ import {
 	useCombobox,
 } from '@mantine/core';
 import { useSearchParams } from '@remix-run/react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { IconChevronDown } from '@/components/icons/chevrondown';
 import { IconPlus } from '@/components/icons/plus';
@@ -50,7 +50,7 @@ const filterOptions: FilterOptions = {
 	},
 	referrer: {
 		label: 'Referrer',
-		placeholder: 'e.g. /blog',
+		placeholder: 'e.g. example.com',
 	},
 	utm_source: {
 		label: 'UTM Source',
@@ -158,7 +158,7 @@ export const Filters = () => {
 	const [type, setType] = useState('eq');
 	const [value, setValue] = useState('');
 
-	const chosenFilter = filterOptions[filter];
+	const chosenFilter = useMemo(() => filterOptions[filter], [filter]);
 
 	// If the filter changes, reset the type
 	// We only reset the value if there is a change in filter type
@@ -171,29 +171,46 @@ export const Filters = () => {
 	const [searchParams, setSearchParams] = useSearchParams();
 	// Convert the search params to an array of label-type-value tuples
 	// This is used to render the current filters.
-	const paramsArr: Array<[string, string, string]> = [];
-	for (const [key, value] of searchParams.entries()) {
-		const [filter, type] = key.split('['); // e.g. path[eq]
-		// If the filter is not in the filter options, don't render it
-		if (!filter || !filterOptions[filter]) {
-			continue;
+	const paramsArr = useMemo(() => {
+		const arr: Array<[string, string, string]> = [];
+		for (const [key, value] of searchParams.entries()) {
+			const [filter, type] = key.split('['); // e.g. path[eq]
+			// If the filter is not in the filter options, don't render it
+			if (filter && filterOptions[filter]) {
+				const { label = 'N/A' } = filterOptions[filter] ?? {};
+				arr.push([label, type?.replace(']', '') ?? 'Unknown', value]);
+			}
 		}
-
-		const { label = 'N/A' } = filterOptions[filter] ?? {};
-		paramsArr.push([label, type?.replace(']', '') ?? 'Unknown', value]);
-	}
+		return arr;
+	}, [searchParams]);
 
 	// Apply the filters to the search params and close the popover
 	// This should trigger a reload of data on the page with new
 	// data from the server.
-	const applyFilters = () => {
+	const applyFilters = useCallback(() => {
 		const params = new URLSearchParams(searchParams);
 		params.append(`${filter}[${type}]`, value);
-		setSearchParams(params, {
-			preventScrollReset: true,
-		});
+		setSearchParams(params, { preventScrollReset: true });
 		setOpened(false);
-	};
+	}, [filter, type, value, searchParams, setSearchParams]);
+
+	// Remove a filter.
+	const removeFilter = useCallback(
+		(label: string, type: string, value: string) => {
+			return () => {
+				const params = new URLSearchParams(searchParams);
+				const filterMap: Record<string, string> = {
+					'UTM Source': 'utm_source',
+					'UTM Medium': 'utm_medium',
+					'UTM Campaign': 'utm_campaign',
+				};
+				const filterKey = filterMap[label] ?? label.toLowerCase();
+				params.delete(`${filterKey}[${type}]`, value);
+				setSearchParams(params, { preventScrollReset: true });
+			};
+		},
+		[searchParams, setSearchParams],
+	);
 
 	return (
 		<Group mt={-40}>
@@ -288,21 +305,7 @@ export const Filters = () => {
 							{filterTypes[type]?.label ?? 'Unknown'}&nbsp;
 						</Text>
 						<Text fz={14}>{value}</Text>
-						<CloseButton
-							onClick={() => {
-								const params = new URLSearchParams(searchParams);
-								const filterMap: Record<string, string> = {
-									'UTM Source': 'utm_source',
-									'UTM Medium': 'utm_medium',
-									'UTM Campaign': 'utm_campaign',
-								};
-								const filter = filterMap[label] ?? label.toLowerCase();
-								params.delete(`${filter}[${type}]`, value);
-								setSearchParams(params, {
-									preventScrollReset: true,
-								});
-							}}
-						/>
+						<CloseButton onClick={removeFilter(label, type, value)} />
 					</Group>
 				);
 			})}

--- a/dashboard/app/components/stats/StatsDisplay.module.css
+++ b/dashboard/app/components/stats/StatsDisplay.module.css
@@ -8,12 +8,13 @@
 	border-radius: 16px;
 }
 
-.tab-root {
+.root {
+	min-height: 393px;
 	background-color: var(--me-color-text-light);
 	border-radius: 8px;
 }
 
-.tab-list {
+.list {
 	padding: 8px;
 	border-bottom: 1px solid var(--me-color-border-light);
 }
@@ -50,21 +51,21 @@
 	border: 1px solid var(--me-color-border-violet);
 }
 
-.button-wrapper {
+.more {
 	width: 100%;
 	padding: 8px 16px;
-}
 
-.button {
-	width: 100%;
-	height: 40px;
-	display: flex;
-	justify-content: center;
-	align-items: center;
+	a {
+		width: 100%;
+		height: 40px;
+		display: flex;
+		justify-content: center;
+		align-items: center;
 
-	border: 1px solid var(--me-color-border-light);
-	border-radius: 8px;
+		border: 1px solid var(--me-color-border-light);
+		border-radius: 8px;
 
-	font-size: 14px;
-	text-align: center;
+		font-size: 14px;
+		text-align: center;
+	}
 }

--- a/dashboard/app/components/stats/StatsDisplay.module.css
+++ b/dashboard/app/components/stats/StatsDisplay.module.css
@@ -33,6 +33,7 @@
 	height: 50px;
 	margin: 6px 8px;
 	padding: 7px 16px;
+	width: calc(100% - 16px);
 
 	border-radius: 8px;
 

--- a/dashboard/app/components/stats/StatsDisplay.tsx
+++ b/dashboard/app/components/stats/StatsDisplay.tsx
@@ -1,7 +1,5 @@
-import { ActionIcon, Group, Tabs, Text, UnstyledButton } from '@mantine/core';
+import { Group, Tabs, Text, UnstyledButton } from '@mantine/core';
 import { Link, useSearchParams } from '@remix-run/react';
-
-import { IconDots } from '@/components/icons/dots';
 
 import { formatCount, formatDuration } from './formatter';
 import classes from './StatsDisplay.module.css';
@@ -49,33 +47,31 @@ export const StatsDisplay = ({ data }: StatsDisplayProps) => {
 			variant="unstyled"
 			defaultValue={data[0]?.label}
 			classNames={{
-				root: classes['tab-root'],
+				root: classes.root,
 				tab: classes.tab,
+				list: classes.list,
 			}}
 		>
-			<Group justify="space-between" className={classes['tab-list']}>
-				<Tabs.List>
-					{data.map((tab) => (
-						<Tabs.Tab key={tab.label} value={tab.label}>
-							{tab.label}
-						</Tabs.Tab>
-					))}
-				</Tabs.List>
-				<ActionIcon variant="transparent">
-					<IconDots />
-				</ActionIcon>
-			</Group>
+			<Tabs.List>
+				{data.map((tab) => (
+					<Tabs.Tab key={tab.label} value={tab.label}>
+						{tab.label}
+					</Tabs.Tab>
+				))}
+			</Tabs.List>
 
 			{data.map((tab) => (
 				<Tabs.Panel key={tab.label} value={tab.label}>
-					{tab.items.map((item) => (
-						<StatsItem
-							key={item.label}
-							isTime={tab.label === 'Time'}
-							{...item}
-						/>
-					))}
-					<div className={classes['button-wrapper']}>
+					<div style={{ minHeight: 280 }}>
+						{tab.items.map((item) => (
+							<StatsItem
+								key={item.label}
+								isTime={tab.label === 'Time'}
+								{...item}
+							/>
+						))}
+					</div>
+					<div className={classes.more}>
 						<UnstyledButton
 							component={Link}
 							to={{

--- a/dashboard/app/components/stats/StatsDisplay.tsx
+++ b/dashboard/app/components/stats/StatsDisplay.tsx
@@ -1,4 +1,4 @@
-import { Box, Group, Tabs, Text, UnstyledButton } from '@mantine/core';
+import { Group, Tabs, Text, UnstyledButton } from '@mantine/core';
 import { Link, useSearchParams } from '@remix-run/react';
 
 import { formatCount, formatDuration } from './formatter';
@@ -91,7 +91,7 @@ export const StatsDisplay = ({ data }: StatsDisplayProps) => {
 
 			{data.map((tab) => (
 				<Tabs.Panel key={tab.label} value={tab.label}>
-					<div style={{ minHeight: 280 }}>
+					<div style={{ minHeight: 306 }}>
 						{tab.items.map((item) => (
 							<StatsItem key={item.label} tab={tab.label} {...item} />
 						))}

--- a/dashboard/app/components/stats/StatsDisplay.tsx
+++ b/dashboard/app/components/stats/StatsDisplay.tsx
@@ -1,5 +1,6 @@
 import { Tabs, UnstyledButton } from '@mantine/core';
 import { Link, useSearchParams } from '@remix-run/react';
+import { useMemo } from 'react';
 
 import classes from './StatsDisplay.module.css';
 import { StatsItem } from './StatsItem';
@@ -21,7 +22,7 @@ interface StatsDisplayProps {
 
 export const StatsDisplay = ({ data }: StatsDisplayProps) => {
 	const [searchParams] = useSearchParams();
-	const defaultValue = data[0]?.label ?? '';
+	const defaultValue = useMemo(() => data[0]?.label ?? '', [data]);
 
 	return (
 		<Tabs
@@ -40,7 +41,6 @@ export const StatsDisplay = ({ data }: StatsDisplayProps) => {
 					</Tabs.Tab>
 				))}
 			</Tabs.List>
-
 			{data.map((tab) => (
 				<Tabs.Panel key={tab.label} value={tab.label}>
 					<div style={{ minHeight: 306 }}>
@@ -48,23 +48,32 @@ export const StatsDisplay = ({ data }: StatsDisplayProps) => {
 							<StatsItem key={item.label} tab={tab.label} {...item} />
 						))}
 					</div>
-					<div className={classes.more}>
-						<UnstyledButton
-							component={Link}
-							to={{
-								pathname: `./${tab.label.toLowerCase()}`,
-								search: `?${searchParams.toString()}`,
-							}}
-							prefetch="intent"
-							preventScrollReset
-							className={classes.button}
-							aria-label={`Load more ${tab.label} stats.`}
-						>
-							Load More
-						</UnstyledButton>
-					</div>
+					<LoadMoreButton tab={tab} searchParams={searchParams} />
 				</Tabs.Panel>
 			))}
 		</Tabs>
 	);
 };
+
+interface LoadMoreButtonProps {
+	tab: StatsTab;
+	searchParams: URLSearchParams;
+}
+
+const LoadMoreButton = ({ tab, searchParams }: LoadMoreButtonProps) => (
+	<div className={classes.more}>
+		<UnstyledButton
+			component={Link}
+			to={{
+				pathname: `./${tab.label.toLowerCase()}`,
+				search: searchParams.toString(),
+			}}
+			prefetch="intent"
+			preventScrollReset
+			className={classes.button}
+			aria-label={`Load more ${tab.label} stats.`}
+		>
+			Load More
+		</UnstyledButton>
+	</div>
+);

--- a/dashboard/app/components/stats/StatsDisplay.tsx
+++ b/dashboard/app/components/stats/StatsDisplay.tsx
@@ -1,22 +1,60 @@
-import { Group, Tabs, Text, UnstyledButton } from '@mantine/core';
+import { Box, Group, Tabs, Text, UnstyledButton } from '@mantine/core';
 import { Link, useSearchParams } from '@remix-run/react';
 
 import { formatCount, formatDuration } from './formatter';
 import classes from './StatsDisplay.module.css';
 
-interface StatsItemProps {
+interface StatsItem {
 	label: string;
 	count: number | undefined;
 	percentage: number | undefined;
-	isTime?: boolean;
 }
 
-const StatsItem = ({ label, count, percentage, isTime }: StatsItemProps) => {
-	const formattedValue = isTime
-		? formatDuration(count ?? 0)
-		: formatCount(count ?? 0);
+interface StatsItemProps extends StatsItem {
+	tab: string;
+}
+
+export interface StatsTab {
+	label: string;
+	items: StatsItem[];
+}
+
+interface StatsDisplayProps {
+	data: StatsTab[];
+}
+
+const StatsItem = ({ label, count, percentage, tab }: StatsItemProps) => {
+	const [searchParams, setSearchParams] = useSearchParams();
+
+	const formattedValue =
+		tab === 'Time' ? formatDuration(count ?? 0) : formatCount(count ?? 0);
+
+	const handleFilter = () => {
+		if (tab !== 'Time') {
+			const params = new URLSearchParams(searchParams);
+
+			const filterMap: Record<string, string> = {
+				Referrers: 'referrer',
+				Sources: 'utm_source',
+				Mediums: 'utm_medium',
+				Campaigns: 'utm_campaign',
+				Browsers: 'browser',
+				OS: 'os',
+				Devices: 'device',
+				Countries: 'country',
+				Languages: 'language',
+			};
+			const filter = filterMap[tab] ?? 'path';
+
+			params.append(`${filter}[eq]`, label);
+			setSearchParams(params, {
+				preventScrollReset: true,
+			});
+		}
+	};
+
 	return (
-		<div className={classes['stat-item']}>
+		<UnstyledButton className={classes['stat-item']} onClick={handleFilter}>
 			<Group justify="space-between" pb={6}>
 				<Text fz={14}>{label}</Text>
 				<Text fw={600} fz={14}>
@@ -27,18 +65,9 @@ const StatsItem = ({ label, count, percentage, isTime }: StatsItemProps) => {
 				className={classes.bar}
 				style={{ width: `${(percentage ?? 0) * 100}%` }}
 			/>
-		</div>
+		</UnstyledButton>
 	);
 };
-
-export interface StatsTab {
-	label: string;
-	items: StatsItemProps[];
-}
-
-interface StatsDisplayProps {
-	data: StatsTab[];
-}
 
 export const StatsDisplay = ({ data }: StatsDisplayProps) => {
 	const [searchParams] = useSearchParams();
@@ -64,11 +93,7 @@ export const StatsDisplay = ({ data }: StatsDisplayProps) => {
 				<Tabs.Panel key={tab.label} value={tab.label}>
 					<div style={{ minHeight: 280 }}>
 						{tab.items.map((item) => (
-							<StatsItem
-								key={item.label}
-								isTime={tab.label === 'Time'}
-								{...item}
-							/>
+							<StatsItem key={item.label} tab={tab.label} {...item} />
 						))}
 					</div>
 					<div className={classes.more}>

--- a/dashboard/app/components/stats/StatsDisplay.tsx
+++ b/dashboard/app/components/stats/StatsDisplay.tsx
@@ -1,80 +1,32 @@
-import { Group, Tabs, Text, UnstyledButton } from '@mantine/core';
+import { Tabs, UnstyledButton } from '@mantine/core';
 import { Link, useSearchParams } from '@remix-run/react';
 
-import { formatCount, formatDuration } from './formatter';
 import classes from './StatsDisplay.module.css';
+import { StatsItem } from './StatsItem';
 
-interface StatsItem {
+interface StatsValue {
 	label: string;
-	count: number | undefined;
-	percentage: number | undefined;
-}
-
-interface StatsItemProps extends StatsItem {
-	tab: string;
+	count?: number;
+	percentage?: number;
 }
 
 export interface StatsTab {
 	label: string;
-	items: StatsItem[];
+	items: StatsValue[];
 }
 
 interface StatsDisplayProps {
 	data: StatsTab[];
 }
 
-const StatsItem = ({ label, count, percentage, tab }: StatsItemProps) => {
-	const [searchParams, setSearchParams] = useSearchParams();
-
-	const formattedValue =
-		tab === 'Time' ? formatDuration(count ?? 0) : formatCount(count ?? 0);
-
-	const handleFilter = () => {
-		if (tab !== 'Time') {
-			const params = new URLSearchParams(searchParams);
-
-			const filterMap: Record<string, string> = {
-				Referrers: 'referrer',
-				Sources: 'utm_source',
-				Mediums: 'utm_medium',
-				Campaigns: 'utm_campaign',
-				Browsers: 'browser',
-				OS: 'os',
-				Devices: 'device',
-				Countries: 'country',
-				Languages: 'language',
-			};
-			const filter = filterMap[tab] ?? 'path';
-
-			params.append(`${filter}[eq]`, label);
-			setSearchParams(params, {
-				preventScrollReset: true,
-			});
-		}
-	};
-
-	return (
-		<UnstyledButton className={classes['stat-item']} onClick={handleFilter}>
-			<Group justify="space-between" pb={6}>
-				<Text fz={14}>{label}</Text>
-				<Text fw={600} fz={14}>
-					{formattedValue}
-				</Text>
-			</Group>
-			<div
-				className={classes.bar}
-				style={{ width: `${(percentage ?? 0) * 100}%` }}
-			/>
-		</UnstyledButton>
-	);
-};
-
 export const StatsDisplay = ({ data }: StatsDisplayProps) => {
 	const [searchParams] = useSearchParams();
+	const defaultValue = data[0]?.label ?? '';
+
 	return (
 		<Tabs
 			variant="unstyled"
-			defaultValue={data[0]?.label}
+			defaultValue={defaultValue}
 			classNames={{
 				root: classes.root,
 				tab: classes.tab,
@@ -83,7 +35,7 @@ export const StatsDisplay = ({ data }: StatsDisplayProps) => {
 		>
 			<Tabs.List>
 				{data.map((tab) => (
-					<Tabs.Tab key={tab.label} value={tab.label}>
+					<Tabs.Tab key={tab.label} value={tab.label} aria-label={tab.label}>
 						{tab.label}
 					</Tabs.Tab>
 				))}
@@ -106,6 +58,7 @@ export const StatsDisplay = ({ data }: StatsDisplayProps) => {
 							prefetch="intent"
 							preventScrollReset
 							className={classes.button}
+							aria-label={`Load more ${tab.label} stats.`}
 						>
 							Load More
 						</UnstyledButton>

--- a/dashboard/app/components/stats/StatsDisplay.tsx
+++ b/dashboard/app/components/stats/StatsDisplay.tsx
@@ -1,6 +1,5 @@
 import { Tabs, UnstyledButton } from '@mantine/core';
 import { Link, useSearchParams } from '@remix-run/react';
-import { useMemo } from 'react';
 
 import classes from './StatsDisplay.module.css';
 import { StatsItem } from './StatsItem';
@@ -22,12 +21,11 @@ interface StatsDisplayProps {
 
 export const StatsDisplay = ({ data }: StatsDisplayProps) => {
 	const [searchParams] = useSearchParams();
-	const defaultValue = useMemo(() => data[0]?.label ?? '', [data]);
 
 	return (
 		<Tabs
 			variant="unstyled"
-			defaultValue={defaultValue}
+			defaultValue={data[0]?.label}
 			classNames={{
 				root: classes.root,
 				tab: classes.tab,

--- a/dashboard/app/components/stats/StatsItem.tsx
+++ b/dashboard/app/components/stats/StatsItem.tsx
@@ -1,0 +1,63 @@
+import { Group, Text, UnstyledButton } from '@mantine/core';
+import { useSearchParams } from '@remix-run/react';
+
+import { formatCount, formatDuration } from './formatter';
+import classes from './StatsDisplay.module.css';
+
+interface StatsItemProps {
+	label: string;
+	count?: number;
+	percentage?: number;
+	tab: string;
+}
+
+const filterMap: Record<string, string> = {
+	Referrers: 'referrer',
+	Sources: 'utm_source',
+	Mediums: 'utm_medium',
+	Campaigns: 'utm_campaign',
+	Browsers: 'browser',
+	OS: 'os',
+	Devices: 'device',
+	Countries: 'country',
+	Languages: 'language',
+};
+
+const StatsItem = ({ label, count, percentage, tab }: StatsItemProps) => {
+	const [searchParams, setSearchParams] = useSearchParams();
+
+	const formattedValue =
+		tab === 'Time' ? formatDuration(count ?? 0) : formatCount(count ?? 0);
+
+	const handleFilter = () => {
+		if (tab !== 'Time') {
+			const params = new URLSearchParams(searchParams);
+			const filter = filterMap[tab] ?? 'path';
+
+			params.append(`${filter}[eq]`, label);
+			setSearchParams(params, { preventScrollReset: true });
+		}
+	};
+
+	return (
+		<UnstyledButton
+			className={classes['stat-item']}
+			onClick={handleFilter}
+			aria-label={`Filter by ${label}`}
+		>
+			<Group justify="space-between" pb={6}>
+				<Text fz={14}>{label}</Text>
+				<Text fw={600} fz={14}>
+					{formattedValue}
+				</Text>
+			</Group>
+			<div
+				className={classes.bar}
+				style={{ width: `${(percentage ?? 0) * 100}%` }}
+				aria-hidden="true"
+			/>
+		</UnstyledButton>
+	);
+};
+
+export { StatsItem };

--- a/dashboard/app/components/stats/StatsTable.tsx
+++ b/dashboard/app/components/stats/StatsTable.tsx
@@ -78,18 +78,20 @@ const visitors: DataTableColumn = {
 const visitorsPercentage: DataTableColumn = {
 	accessor: 'visitors_percentage',
 	title: 'Visitors %',
-	render: (record: DataRow) => formatPercentage(record.visitors_percentage),
+	render: (record: DataRow) =>
+		formatPercentage(record.visitors_percentage ?? 0),
 };
 const pageviews: DataTableColumn = {
 	accessor: 'pageviews',
 	title: 'Views',
 	sortable: true,
-	render: (record: DataRow) => formatCount(record.pageviews),
+	render: (record: DataRow) => formatCount(record.pageviews ?? 0),
 };
 const pageviewsPercentage: DataTableColumn = {
 	accessor: 'pageviews_percentage',
 	title: 'Views %',
-	render: (record: DataRow) => formatPercentage(record.pageviews_percentage),
+	render: (record: DataRow) =>
+		formatPercentage(record.pageviews_percentage ?? 0),
 };
 const bounceRate: DataTableColumn = {
 	accessor: 'bounce_rate',
@@ -101,7 +103,7 @@ const duration: DataTableColumn = {
 	accessor: 'duration',
 	title: 'Duration',
 	sortable: true,
-	render: (record: DataRow) => formatDuration(record.duration),
+	render: (record: DataRow) => formatDuration(record.duration ?? 0),
 };
 
 const PAGE_SIZES = [10, 25, 50, 100];
@@ -177,14 +179,14 @@ const QueryTable = ({ query, data }: QueryTableProps) => {
 					title: 'Q1 (25%)',
 					sortable: true,
 					render: (record: DataRow) =>
-						formatDuration(record.duration_lower_quartile),
+						formatDuration(record.duration_lower_quartile ?? 0),
 				},
 				{
 					accessor: 'duration_upper_quartile',
 					title: 'Q3 (75%)',
 					sortable: true,
 					render: (record: DataRow) =>
-						formatDuration(record.duration_upper_quartile),
+						formatDuration(record.duration_upper_quartile ?? 0),
 				},
 				{
 					accessor: 'duration_percentage',
@@ -412,6 +414,7 @@ export const StatsTable = ({ query, data }: StatsTableProps) => {
 					{ preventScrollReset: true },
 				);
 			}}
+			keepMounted={false}
 		>
 			<Tabs.List>
 				<div className={classes['list-wrapper']}>

--- a/dashboard/app/components/stats/formatter.ts
+++ b/dashboard/app/components/stats/formatter.ts
@@ -34,11 +34,19 @@ export const formatDuration: DurationFormatter = (durationMs = 0) => {
 		return `${hours}h${minutes}m${seconds}s`;
 	}
 
-	if (seconds < 1) {
-		return `0.${Math.floor(milliseconds / 100)}s`;
+	if (minutes === 0) {
+		if (seconds === 0) {
+			return '0s';
+		}
+
+		if (seconds < 1) {
+			return `0.${Math.floor(milliseconds / 100)}s`;
+		}
+
+		return `${seconds}s`;
 	}
 
-	return minutes === 0 ? `${seconds}s` : `${minutes}m${seconds}s`;
+	return `${minutes}m${seconds}s`;
 };
 
 // Format percentage value


### PR DESCRIPTION
On top of a large refactor to use more `useMemo` and `useCallback`'s to reduce rerenders. The main feature is that users can now quickly select filters by selecting the home page stats table directly instead.