### PR TITLE
fix(db): update queries to use unique user instead of unique page

### DIFF
--- a/core/db/duckdb/__snapshots__/locale_test.snap
+++ b/core/db/duckdb/__snapshots__/locale_test.snap
@@ -1,29 +1,29 @@
 
 [TestGetWebsiteCountries/Base - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:166773 VisitorsPercentage:0.3336} Bounces:41757 Duration:4986}
-&{StatsCountriesSummary:{Country:Japan Visitors:166589 VisitorsPercentage:0.3333} Bounces:41843 Duration:5007}
-&{StatsCountriesSummary:{Country:United States Visitors:166496 VisitorsPercentage:0.3331} Bounces:41654 Duration:5014}
+&{StatsCountriesSummary:{Country:United States Visitors:166892 VisitorsPercentage:0.334} Bounces:41323 Duration:5014}
+&{StatsCountriesSummary:{Country:Japan Visitors:166747 VisitorsPercentage:0.3337} Bounces:41697 Duration:5007}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:166018 VisitorsPercentage:0.3323} Bounces:41664 Duration:4986}
 
 ---
 
 [TestGetWebsiteCountries/Browser - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:Japan Visitors:55424 VisitorsPercentage:0.3335} Bounces:14169 Duration:4954}
-&{StatsCountriesSummary:{Country:United States Visitors:55378 VisitorsPercentage:0.3333} Bounces:13930 Duration:4992}
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:55368 VisitorsPercentage:0.3332} Bounces:13867 Duration:4992}
+&{StatsCountriesSummary:{Country:Japan Visitors:55533 VisitorsPercentage:0.3344} Bounces:14047 Duration:4954}
+&{StatsCountriesSummary:{Country:United States Visitors:55314 VisitorsPercentage:0.333} Bounces:13749 Duration:4992}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:55243 VisitorsPercentage:0.3326} Bounces:13844 Duration:4992}
 
 ---
 
 [TestGetWebsiteCountries/Country - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:55368 VisitorsPercentage:1} Bounces:13867 Duration:4992}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:55243 VisitorsPercentage:1} Bounces:13844 Duration:4992}
 
 ---
 
 [TestGetWebsiteCountries/Device - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:18593 VisitorsPercentage:1} Bounces:4662 Duration:4997}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:18661 VisitorsPercentage:1} Bounces:4691 Duration:4997}
 
 ---
 
@@ -34,71 +34,71 @@ RECORDS:
 
 [TestGetWebsiteCountries/Language - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:9378 VisitorsPercentage:1} Bounces:2339 Duration:5003}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:9486 VisitorsPercentage:1} Bounces:2355 Duration:5003}
 
 ---
 
 [TestGetWebsiteCountries/OS - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:3085 VisitorsPercentage:1} Bounces:786 Duration:4971}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:3116 VisitorsPercentage:1} Bounces:783 Duration:4971}
 
 ---
 
 [TestGetWebsiteCountries/Pathname - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:1073 VisitorsPercentage:1} Bounces:260 Duration:5098}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:1090 VisitorsPercentage:1} Bounces:268 Duration:5098}
 
 ---
 
 [TestGetWebsiteCountries/Referrer - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:359 VisitorsPercentage:1} Bounces:91 Duration:4728}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
 
 ---
 
 [TestGetWebsiteCountries/UTMCampaign - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:110 VisitorsPercentage:1} Bounces:25 Duration:4732}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
 
 ---
 
 [TestGetWebsiteCountries/UTMMedium - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:36 VisitorsPercentage:1} Bounces:5 Duration:6547}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
 
 ---
 
 [TestGetWebsiteCountries/UTMSource - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:16 VisitorsPercentage:1} Bounces:2 Duration:3389}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
 
 ---
 
 [TestGetWebsiteCountriesSummary/Base - 1]
 RECORDS:
-&{Country:United Kingdom Visitors:166773 VisitorsPercentage:0.3336}
-&{Country:Japan Visitors:166589 VisitorsPercentage:0.3333}
-&{Country:United States Visitors:166496 VisitorsPercentage:0.3331}
+&{Country:United States Visitors:166892 VisitorsPercentage:0.334}
+&{Country:Japan Visitors:166747 VisitorsPercentage:0.3337}
+&{Country:United Kingdom Visitors:166018 VisitorsPercentage:0.3323}
 
 ---
 
 [TestGetWebsiteCountriesSummary/Browser - 1]
 RECORDS:
-&{Country:Japan Visitors:55424 VisitorsPercentage:0.3335}
-&{Country:United States Visitors:55378 VisitorsPercentage:0.3333}
-&{Country:United Kingdom Visitors:55368 VisitorsPercentage:0.3332}
+&{Country:Japan Visitors:55533 VisitorsPercentage:0.3344}
+&{Country:United States Visitors:55314 VisitorsPercentage:0.333}
+&{Country:United Kingdom Visitors:55243 VisitorsPercentage:0.3326}
 
 ---
 
 [TestGetWebsiteCountriesSummary/Country - 1]
 RECORDS:
-&{Country:United Kingdom Visitors:55368 VisitorsPercentage:1}
+&{Country:United Kingdom Visitors:55243 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteCountriesSummary/Device - 1]
 RECORDS:
-&{Country:United Kingdom Visitors:18593 VisitorsPercentage:1}
+&{Country:United Kingdom Visitors:18661 VisitorsPercentage:1}
 
 ---
 
@@ -109,71 +109,71 @@ RECORDS:
 
 [TestGetWebsiteCountriesSummary/Language - 1]
 RECORDS:
-&{Country:United Kingdom Visitors:9378 VisitorsPercentage:1}
+&{Country:United Kingdom Visitors:9486 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteCountriesSummary/OS - 1]
 RECORDS:
-&{Country:United Kingdom Visitors:3085 VisitorsPercentage:1}
+&{Country:United Kingdom Visitors:3116 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteCountriesSummary/Pathname - 1]
 RECORDS:
-&{Country:United Kingdom Visitors:1073 VisitorsPercentage:1}
+&{Country:United Kingdom Visitors:1090 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteCountriesSummary/Referrer - 1]
 RECORDS:
-&{Country:United Kingdom Visitors:359 VisitorsPercentage:1}
+&{Country:United Kingdom Visitors:381 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteCountriesSummary/UTMCampaign - 1]
 RECORDS:
-&{Country:United Kingdom Visitors:110 VisitorsPercentage:1}
+&{Country:United Kingdom Visitors:116 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteCountriesSummary/UTMMedium - 1]
 RECORDS:
-&{Country:United Kingdom Visitors:36 VisitorsPercentage:1}
+&{Country:United Kingdom Visitors:35 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteCountriesSummary/UTMSource - 1]
 RECORDS:
-&{Country:United Kingdom Visitors:16 VisitorsPercentage:1}
+&{Country:United Kingdom Visitors:17 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteLanguages/Base - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:250059 VisitorsPercentage:0.5003} Bounces:62495 Duration:5010}
-&{StatsLanguagesSummary:{Language:Japanese Visitors:249799 VisitorsPercentage:0.4997} Bounces:62759 Duration:4996}
+&{StatsLanguagesSummary:{Language:English Visitors:250816 VisitorsPercentage:0.502} Bounces:62517 Duration:5010}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:248841 VisitorsPercentage:0.498} Bounces:62167 Duration:4996}
 
 ---
 
 [TestGetWebsiteLanguages/Browser - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:83086 VisitorsPercentage:0.5} Bounces:20909 Duration:4992}
-&{StatsLanguagesSummary:{Language:Japanese Visitors:83084 VisitorsPercentage:0.5} Bounces:21057 Duration:4966}
+&{StatsLanguagesSummary:{Language:English Visitors:83279 VisitorsPercentage:0.5014} Bounces:20816 Duration:4992}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:82811 VisitorsPercentage:0.4986} Bounces:20824 Duration:4966}
 
 ---
 
 [TestGetWebsiteLanguages/Country - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:27787 VisitorsPercentage:0.5019} Bounces:6902 Duration:5006}
-&{StatsLanguagesSummary:{Language:Japanese Visitors:27581 VisitorsPercentage:0.4981} Bounces:6965 Duration:4980}
+&{StatsLanguagesSummary:{Language:English Visitors:27676 VisitorsPercentage:0.501} Bounces:6923 Duration:5006}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:27567 VisitorsPercentage:0.499} Bounces:6921 Duration:4980}
 
 ---
 
 [TestGetWebsiteLanguages/Device - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:9378 VisitorsPercentage:0.5044} Bounces:2339 Duration:5003}
-&{StatsLanguagesSummary:{Language:Japanese Visitors:9215 VisitorsPercentage:0.4956} Bounces:2323 Duration:4992}
+&{StatsLanguagesSummary:{Language:English Visitors:9486 VisitorsPercentage:0.5083} Bounces:2355 Duration:5003}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:9175 VisitorsPercentage:0.4917} Bounces:2336 Duration:4992}
 
 ---
 
@@ -184,71 +184,71 @@ RECORDS:
 
 [TestGetWebsiteLanguages/Language - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:9378 VisitorsPercentage:1} Bounces:2339 Duration:5003}
+&{StatsLanguagesSummary:{Language:English Visitors:9486 VisitorsPercentage:1} Bounces:2355 Duration:5003}
 
 ---
 
 [TestGetWebsiteLanguages/OS - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:3085 VisitorsPercentage:1} Bounces:786 Duration:4971}
+&{StatsLanguagesSummary:{Language:English Visitors:3116 VisitorsPercentage:1} Bounces:783 Duration:4971}
 
 ---
 
 [TestGetWebsiteLanguages/Pathname - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:1073 VisitorsPercentage:1} Bounces:260 Duration:5098}
+&{StatsLanguagesSummary:{Language:English Visitors:1090 VisitorsPercentage:1} Bounces:268 Duration:5098}
 
 ---
 
 [TestGetWebsiteLanguages/Referrer - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:359 VisitorsPercentage:1} Bounces:91 Duration:4728}
+&{StatsLanguagesSummary:{Language:English Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
 
 ---
 
 [TestGetWebsiteLanguages/UTMCampaign - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:110 VisitorsPercentage:1} Bounces:25 Duration:4732}
+&{StatsLanguagesSummary:{Language:English Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
 
 ---
 
 [TestGetWebsiteLanguages/UTMMedium - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:36 VisitorsPercentage:1} Bounces:5 Duration:6547}
+&{StatsLanguagesSummary:{Language:English Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
 
 ---
 
 [TestGetWebsiteLanguages/UTMSource - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:16 VisitorsPercentage:1} Bounces:2 Duration:3389}
+&{StatsLanguagesSummary:{Language:English Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
 
 ---
 
 [TestGetWebsiteLanguagesSummary/Base - 1]
 RECORDS:
-&{Language:English Visitors:250059 VisitorsPercentage:0.5003}
-&{Language:Japanese Visitors:249799 VisitorsPercentage:0.4997}
+&{Language:English Visitors:250816 VisitorsPercentage:0.502}
+&{Language:Japanese Visitors:248841 VisitorsPercentage:0.498}
 
 ---
 
 [TestGetWebsiteLanguagesSummary/Browser - 1]
 RECORDS:
-&{Language:English Visitors:83086 VisitorsPercentage:0.5}
-&{Language:Japanese Visitors:83084 VisitorsPercentage:0.5}
+&{Language:English Visitors:83279 VisitorsPercentage:0.5014}
+&{Language:Japanese Visitors:82811 VisitorsPercentage:0.4986}
 
 ---
 
 [TestGetWebsiteLanguagesSummary/Country - 1]
 RECORDS:
-&{Language:English Visitors:27787 VisitorsPercentage:0.5019}
-&{Language:Japanese Visitors:27581 VisitorsPercentage:0.4981}
+&{Language:English Visitors:27676 VisitorsPercentage:0.501}
+&{Language:Japanese Visitors:27567 VisitorsPercentage:0.499}
 
 ---
 
 [TestGetWebsiteLanguagesSummary/Device - 1]
 RECORDS:
-&{Language:English Visitors:9378 VisitorsPercentage:0.5044}
-&{Language:Japanese Visitors:9215 VisitorsPercentage:0.4956}
+&{Language:English Visitors:9486 VisitorsPercentage:0.5083}
+&{Language:Japanese Visitors:9175 VisitorsPercentage:0.4917}
 
 ---
 
@@ -259,42 +259,42 @@ RECORDS:
 
 [TestGetWebsiteLanguagesSummary/Language - 1]
 RECORDS:
-&{Language:English Visitors:9378 VisitorsPercentage:1}
+&{Language:English Visitors:9486 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteLanguagesSummary/OS - 1]
 RECORDS:
-&{Language:English Visitors:3085 VisitorsPercentage:1}
+&{Language:English Visitors:3116 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteLanguagesSummary/Pathname - 1]
 RECORDS:
-&{Language:English Visitors:1073 VisitorsPercentage:1}
+&{Language:English Visitors:1090 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteLanguagesSummary/Referrer - 1]
 RECORDS:
-&{Language:English Visitors:359 VisitorsPercentage:1}
+&{Language:English Visitors:381 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteLanguagesSummary/UTMCampaign - 1]
 RECORDS:
-&{Language:English Visitors:110 VisitorsPercentage:1}
+&{Language:English Visitors:116 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteLanguagesSummary/UTMMedium - 1]
 RECORDS:
-&{Language:English Visitors:36 VisitorsPercentage:1}
+&{Language:English Visitors:35 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteLanguagesSummary/UTMSource - 1]
 RECORDS:
-&{Language:English Visitors:16 VisitorsPercentage:1}
+&{Language:English Visitors:17 VisitorsPercentage:1}
 
 ---

--- a/core/db/duckdb/__snapshots__/referrers_test.snap
+++ b/core/db/duckdb/__snapshots__/referrers_test.snap
@@ -1,33 +1,33 @@
 
 [TestGetWebsiteReferrers/Base - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:166879 VisitorsPercentage:0.3339} Bounces:41808 Duration:4985}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:166576 VisitorsPercentage:0.3332} Bounces:41843 Duration:5018}
-&{StatsReferrerSummary:{Referrer: Visitors:166403 VisitorsPercentage:0.3329} Bounces:41603 Duration:5005}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:167163 VisitorsPercentage:0.3346} Bounces:41666 Duration:5018}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:166318 VisitorsPercentage:0.3329} Bounces:41704 Duration:4985}
+&{StatsReferrerSummary:{Referrer: Visitors:166176 VisitorsPercentage:0.3326} Bounces:41314 Duration:5005}
 
 ---
 
 [TestGetWebsiteReferrers/Browser - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:55691 VisitorsPercentage:0.3351} Bounces:13906 Duration:4980}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:55337 VisitorsPercentage:0.333} Bounces:14104 Duration:4944}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:55142 VisitorsPercentage:0.3318} Bounces:13956 Duration:5016}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:55495 VisitorsPercentage:0.3341} Bounces:14006 Duration:4944}
+&{StatsReferrerSummary:{Referrer: Visitors:55307 VisitorsPercentage:0.333} Bounces:13742 Duration:4980}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:55288 VisitorsPercentage:0.3329} Bounces:13892 Duration:5016}
 
 ---
 
 [TestGetWebsiteReferrers/Country - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:18594 VisitorsPercentage:0.3358} Bounces:4567 Duration:5008}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:18408 VisitorsPercentage:0.3325} Bounces:4690 Duration:5025}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:18366 VisitorsPercentage:0.3317} Bounces:4610 Duration:4938}
+&{StatsReferrerSummary:{Referrer: Visitors:18505 VisitorsPercentage:0.335} Bounces:4576 Duration:5008}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:18444 VisitorsPercentage:0.3339} Bounces:4661 Duration:5025}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:18294 VisitorsPercentage:0.3312} Bounces:4607 Duration:4938}
 
 ---
 
 [TestGetWebsiteReferrers/Device - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:google.com Visitors:6219 VisitorsPercentage:0.3345} Bounces:1539 Duration:5099}
-&{StatsReferrerSummary:{Referrer: Visitors:6199 VisitorsPercentage:0.3334} Bounces:1554 Duration:4975}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:6175 VisitorsPercentage:0.3321} Bounces:1569 Duration:4901}
+&{StatsReferrerSummary:{Referrer: Visitors:6264 VisitorsPercentage:0.3357} Bounces:1547 Duration:4975}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:6262 VisitorsPercentage:0.3356} Bounces:1540 Duration:5099}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:6135 VisitorsPercentage:0.3288} Bounces:1604 Duration:4901}
 
 ---
 
@@ -38,49 +38,49 @@ RECORDS:
 
 [TestGetWebsiteReferrers/Language - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:3131 VisitorsPercentage:0.3339} Bounces:760 Duration:4998}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:3129 VisitorsPercentage:0.3337} Bounces:773 Duration:5096}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:3118 VisitorsPercentage:0.3325} Bounces:806 Duration:4909}
+&{StatsReferrerSummary:{Referrer: Visitors:3189 VisitorsPercentage:0.3362} Bounces:777 Duration:4998}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:3159 VisitorsPercentage:0.333} Bounces:759 Duration:5096}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:3138 VisitorsPercentage:0.3308} Bounces:819 Duration:4909}
 
 ---
 
 [TestGetWebsiteReferrers/OS - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:1048 VisitorsPercentage:0.3397} Bounces:274 Duration:4735}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:1026 VisitorsPercentage:0.3326} Bounces:267 Duration:4809}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:1011 VisitorsPercentage:0.3277} Bounces:245 Duration:5257}
+&{StatsReferrerSummary:{Referrer: Visitors:1055 VisitorsPercentage:0.3386} Bounces:264 Duration:4735}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:1036 VisitorsPercentage:0.3325} Bounces:272 Duration:4809}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:1025 VisitorsPercentage:0.3289} Bounces:247 Duration:5257}
 
 ---
 
 [TestGetWebsiteReferrers/Pathname - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:366 VisitorsPercentage:0.3411} Bounces:89 Duration:5411}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:359 VisitorsPercentage:0.3346} Bounces:91 Duration:4728}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:348 VisitorsPercentage:0.3243} Bounces:80 Duration:5308}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:0.3495} Bounces:96 Duration:4728}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:355 VisitorsPercentage:0.3257} Bounces:90 Duration:5308}
+&{StatsReferrerSummary:{Referrer: Visitors:354 VisitorsPercentage:0.3248} Bounces:82 Duration:5411}
 
 ---
 
 [TestGetWebsiteReferrers/Referrer - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:359 VisitorsPercentage:1} Bounces:91 Duration:4728}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
 
 ---
 
 [TestGetWebsiteReferrers/UTMCampaign - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:110 VisitorsPercentage:1} Bounces:25 Duration:4732}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
 
 ---
 
 [TestGetWebsiteReferrers/UTMMedium - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:36 VisitorsPercentage:1} Bounces:5 Duration:6547}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
 
 ---
 
 [TestGetWebsiteReferrers/UTMSource - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:16 VisitorsPercentage:1} Bounces:2 Duration:3389}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
 
 ---
 

--- a/core/db/duckdb/__snapshots__/types_test.snap
+++ b/core/db/duckdb/__snapshots__/types_test.snap
@@ -1,27 +1,27 @@
 
 [TestGetWebsiteBrowsers/Base - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Safari Visitors:167325 VisitorsPercentage:0.3347} Bounces:41823 Duration:5002}
-&{StatsBrowsersSummary:{Browser:Firefox Visitors:166363 VisitorsPercentage:0.3328} Bounces:41465 Duration:5027}
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:166170 VisitorsPercentage:0.3324} Bounces:41966 Duration:4980}
+&{StatsBrowsersSummary:{Browser:Safari Visitors:166918 VisitorsPercentage:0.3341} Bounces:41597 Duration:5002}
+&{StatsBrowsersSummary:{Browser:Firefox Visitors:166649 VisitorsPercentage:0.3335} Bounces:41447 Duration:5027}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:166090 VisitorsPercentage:0.3324} Bounces:41640 Duration:4980}
 
 ---
 
 [TestGetWebsiteBrowsers/Browser - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:166170 VisitorsPercentage:1} Bounces:41966 Duration:4980}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:166090 VisitorsPercentage:1} Bounces:41640 Duration:4980}
 
 ---
 
 [TestGetWebsiteBrowsers/Country - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:55368 VisitorsPercentage:1} Bounces:13867 Duration:4992}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:55243 VisitorsPercentage:1} Bounces:13844 Duration:4992}
 
 ---
 
 [TestGetWebsiteBrowsers/Device - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:18593 VisitorsPercentage:1} Bounces:4662 Duration:4997}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:18661 VisitorsPercentage:1} Bounces:4691 Duration:4997}
 
 ---
 
@@ -32,69 +32,69 @@ RECORDS:
 
 [TestGetWebsiteBrowsers/Language - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:9378 VisitorsPercentage:1} Bounces:2339 Duration:5003}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:9486 VisitorsPercentage:1} Bounces:2355 Duration:5003}
 
 ---
 
 [TestGetWebsiteBrowsers/OS - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:3085 VisitorsPercentage:1} Bounces:786 Duration:4971}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:3116 VisitorsPercentage:1} Bounces:783 Duration:4971}
 
 ---
 
 [TestGetWebsiteBrowsers/Pathname - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:1073 VisitorsPercentage:1} Bounces:260 Duration:5098}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:1090 VisitorsPercentage:1} Bounces:268 Duration:5098}
 
 ---
 
 [TestGetWebsiteBrowsers/Referrer - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:359 VisitorsPercentage:1} Bounces:91 Duration:4728}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
 
 ---
 
 [TestGetWebsiteBrowsers/UTMCampaign - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:110 VisitorsPercentage:1} Bounces:25 Duration:4732}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
 
 ---
 
 [TestGetWebsiteBrowsers/UTMMedium - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:36 VisitorsPercentage:1} Bounces:5 Duration:6547}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
 
 ---
 
 [TestGetWebsiteBrowsers/UTMSource - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:16 VisitorsPercentage:1} Bounces:2 Duration:3389}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
 
 ---
 
 [TestGetWebsiteBrowsersSummary/Base - 1]
 RECORDS:
-&{Browser:Safari Visitors:167325 VisitorsPercentage:0.3347}
-&{Browser:Firefox Visitors:166363 VisitorsPercentage:0.3328}
-&{Browser:Chrome Visitors:166170 VisitorsPercentage:0.3324}
+&{Browser:Safari Visitors:166918 VisitorsPercentage:0.3341}
+&{Browser:Firefox Visitors:166649 VisitorsPercentage:0.3335}
+&{Browser:Chrome Visitors:166090 VisitorsPercentage:0.3324}
 
 ---
 
 [TestGetWebsiteBrowsersSummary/Browser - 1]
 RECORDS:
-&{Browser:Chrome Visitors:166170 VisitorsPercentage:1}
+&{Browser:Chrome Visitors:166090 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteBrowsersSummary/Country - 1]
 RECORDS:
-&{Browser:Chrome Visitors:55368 VisitorsPercentage:1}
+&{Browser:Chrome Visitors:55243 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteBrowsersSummary/Device - 1]
 RECORDS:
-&{Browser:Chrome Visitors:18593 VisitorsPercentage:1}
+&{Browser:Chrome Visitors:18661 VisitorsPercentage:1}
 
 ---
 
@@ -105,73 +105,73 @@ RECORDS:
 
 [TestGetWebsiteBrowsersSummary/Language - 1]
 RECORDS:
-&{Browser:Chrome Visitors:9378 VisitorsPercentage:1}
+&{Browser:Chrome Visitors:9486 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteBrowsersSummary/OS - 1]
 RECORDS:
-&{Browser:Chrome Visitors:3085 VisitorsPercentage:1}
+&{Browser:Chrome Visitors:3116 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteBrowsersSummary/Pathname - 1]
 RECORDS:
-&{Browser:Chrome Visitors:1073 VisitorsPercentage:1}
+&{Browser:Chrome Visitors:1090 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteBrowsersSummary/Referrer - 1]
 RECORDS:
-&{Browser:Chrome Visitors:359 VisitorsPercentage:1}
+&{Browser:Chrome Visitors:381 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteBrowsersSummary/UTMCampaign - 1]
 RECORDS:
-&{Browser:Chrome Visitors:110 VisitorsPercentage:1}
+&{Browser:Chrome Visitors:116 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteBrowsersSummary/UTMMedium - 1]
 RECORDS:
-&{Browser:Chrome Visitors:36 VisitorsPercentage:1}
+&{Browser:Chrome Visitors:35 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteBrowsersSummary/UTMSource - 1]
 RECORDS:
-&{Browser:Chrome Visitors:16 VisitorsPercentage:1}
+&{Browser:Chrome Visitors:17 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteDevices/Base - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:167052 VisitorsPercentage:0.3342} Bounces:41829 Duration:5005}
-&{StatsDevicesSummary:{Device:Tablet Visitors:166644 VisitorsPercentage:0.3334} Bounces:41927 Duration:4995}
-&{StatsDevicesSummary:{Device:Mobile Visitors:166162 VisitorsPercentage:0.3324} Bounces:41498 Duration:5006}
+&{StatsDevicesSummary:{Device:Desktop Visitors:166959 VisitorsPercentage:0.3341} Bounces:41553 Duration:5005}
+&{StatsDevicesSummary:{Device:Tablet Visitors:166722 VisitorsPercentage:0.3337} Bounces:41786 Duration:4995}
+&{StatsDevicesSummary:{Device:Mobile Visitors:165976 VisitorsPercentage:0.3322} Bounces:41345 Duration:5006}
 
 ---
 
 [TestGetWebsiteDevices/Browser - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:55528 VisitorsPercentage:0.3342} Bounces:14051 Duration:4995}
-&{StatsDevicesSummary:{Device:Tablet Visitors:55451 VisitorsPercentage:0.3337} Bounces:14089 Duration:4940}
-&{StatsDevicesSummary:{Device:Mobile Visitors:55191 VisitorsPercentage:0.3321} Bounces:13826 Duration:4999}
+&{StatsDevicesSummary:{Device:Desktop Visitors:55422 VisitorsPercentage:0.3337} Bounces:13790 Duration:4995}
+&{StatsDevicesSummary:{Device:Mobile Visitors:55360 VisitorsPercentage:0.3333} Bounces:13886 Duration:4999}
+&{StatsDevicesSummary:{Device:Tablet Visitors:55308 VisitorsPercentage:0.333} Bounces:13964 Duration:4940}
 
 ---
 
 [TestGetWebsiteDevices/Country - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:18593 VisitorsPercentage:0.3358} Bounces:4662 Duration:4997}
-&{StatsDevicesSummary:{Device:Tablet Visitors:18530 VisitorsPercentage:0.3347} Bounces:4623 Duration:4983}
-&{StatsDevicesSummary:{Device:Mobile Visitors:18245 VisitorsPercentage:0.3295} Bounces:4582 Duration:4994}
+&{StatsDevicesSummary:{Device:Desktop Visitors:18661 VisitorsPercentage:0.3378} Bounces:4691 Duration:4997}
+&{StatsDevicesSummary:{Device:Mobile Visitors:18333 VisitorsPercentage:0.3319} Bounces:4603 Duration:4994}
+&{StatsDevicesSummary:{Device:Tablet Visitors:18249 VisitorsPercentage:0.3303} Bounces:4550 Duration:4983}
 
 ---
 
 [TestGetWebsiteDevices/Device - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:18593 VisitorsPercentage:1} Bounces:4662 Duration:4997}
+&{StatsDevicesSummary:{Device:Desktop Visitors:18661 VisitorsPercentage:1} Bounces:4691 Duration:4997}
 
 ---
 
@@ -182,73 +182,73 @@ RECORDS:
 
 [TestGetWebsiteDevices/Language - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:9378 VisitorsPercentage:1} Bounces:2339 Duration:5003}
+&{StatsDevicesSummary:{Device:Desktop Visitors:9486 VisitorsPercentage:1} Bounces:2355 Duration:5003}
 
 ---
 
 [TestGetWebsiteDevices/OS - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:3085 VisitorsPercentage:1} Bounces:786 Duration:4971}
+&{StatsDevicesSummary:{Device:Desktop Visitors:3116 VisitorsPercentage:1} Bounces:783 Duration:4971}
 
 ---
 
 [TestGetWebsiteDevices/Pathname - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:1073 VisitorsPercentage:1} Bounces:260 Duration:5098}
+&{StatsDevicesSummary:{Device:Desktop Visitors:1090 VisitorsPercentage:1} Bounces:268 Duration:5098}
 
 ---
 
 [TestGetWebsiteDevices/Referrer - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:359 VisitorsPercentage:1} Bounces:91 Duration:4728}
+&{StatsDevicesSummary:{Device:Desktop Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
 
 ---
 
 [TestGetWebsiteDevices/UTMCampaign - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:110 VisitorsPercentage:1} Bounces:25 Duration:4732}
+&{StatsDevicesSummary:{Device:Desktop Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
 
 ---
 
 [TestGetWebsiteDevices/UTMMedium - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:36 VisitorsPercentage:1} Bounces:5 Duration:6547}
+&{StatsDevicesSummary:{Device:Desktop Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
 
 ---
 
 [TestGetWebsiteDevices/UTMSource - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:16 VisitorsPercentage:1} Bounces:2 Duration:3389}
+&{StatsDevicesSummary:{Device:Desktop Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
 
 ---
 
 [TestGetWebsiteDevicesSummary/Base - 1]
 RECORDS:
-&{Device:Desktop Visitors:167052 VisitorsPercentage:0.3342}
-&{Device:Tablet Visitors:166644 VisitorsPercentage:0.3334}
-&{Device:Mobile Visitors:166162 VisitorsPercentage:0.3324}
+&{Device:Desktop Visitors:166959 VisitorsPercentage:0.3341}
+&{Device:Tablet Visitors:166722 VisitorsPercentage:0.3337}
+&{Device:Mobile Visitors:165976 VisitorsPercentage:0.3322}
 
 ---
 
 [TestGetWebsiteDevicesSummary/Browser - 1]
 RECORDS:
-&{Device:Desktop Visitors:55528 VisitorsPercentage:0.3342}
-&{Device:Tablet Visitors:55451 VisitorsPercentage:0.3337}
-&{Device:Mobile Visitors:55191 VisitorsPercentage:0.3321}
+&{Device:Desktop Visitors:55422 VisitorsPercentage:0.3337}
+&{Device:Mobile Visitors:55360 VisitorsPercentage:0.3333}
+&{Device:Tablet Visitors:55308 VisitorsPercentage:0.333}
 
 ---
 
 [TestGetWebsiteDevicesSummary/Country - 1]
 RECORDS:
-&{Device:Desktop Visitors:18593 VisitorsPercentage:0.3358}
-&{Device:Tablet Visitors:18530 VisitorsPercentage:0.3347}
-&{Device:Mobile Visitors:18245 VisitorsPercentage:0.3295}
+&{Device:Desktop Visitors:18661 VisitorsPercentage:0.3378}
+&{Device:Mobile Visitors:18333 VisitorsPercentage:0.3319}
+&{Device:Tablet Visitors:18249 VisitorsPercentage:0.3303}
 
 ---
 
 [TestGetWebsiteDevicesSummary/Device - 1]
 RECORDS:
-&{Device:Desktop Visitors:18593 VisitorsPercentage:1}
+&{Device:Desktop Visitors:18661 VisitorsPercentage:1}
 
 ---
 
@@ -259,75 +259,75 @@ RECORDS:
 
 [TestGetWebsiteDevicesSummary/Language - 1]
 RECORDS:
-&{Device:Desktop Visitors:9378 VisitorsPercentage:1}
+&{Device:Desktop Visitors:9486 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteDevicesSummary/OS - 1]
 RECORDS:
-&{Device:Desktop Visitors:3085 VisitorsPercentage:1}
+&{Device:Desktop Visitors:3116 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteDevicesSummary/Pathname - 1]
 RECORDS:
-&{Device:Desktop Visitors:1073 VisitorsPercentage:1}
+&{Device:Desktop Visitors:1090 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteDevicesSummary/Referrer - 1]
 RECORDS:
-&{Device:Desktop Visitors:359 VisitorsPercentage:1}
+&{Device:Desktop Visitors:381 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteDevicesSummary/UTMCampaign - 1]
 RECORDS:
-&{Device:Desktop Visitors:110 VisitorsPercentage:1}
+&{Device:Desktop Visitors:116 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteDevicesSummary/UTMMedium - 1]
 RECORDS:
-&{Device:Desktop Visitors:36 VisitorsPercentage:1}
+&{Device:Desktop Visitors:35 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteDevicesSummary/UTMSource - 1]
 RECORDS:
-&{Device:Desktop Visitors:16 VisitorsPercentage:1}
+&{Device:Desktop Visitors:17 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteOS/Base - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:167198 VisitorsPercentage:0.3345} Bounces:42038 Duration:5006}
-&{StatsOSSummary:{OS:Windows Visitors:166384 VisitorsPercentage:0.3329} Bounces:41647 Duration:5001}
-&{StatsOSSummary:{OS:Linux Visitors:166276 VisitorsPercentage:0.3326} Bounces:41569 Duration:5002}
+&{StatsOSSummary:{OS:iOS Visitors:166647 VisitorsPercentage:0.3335} Bounces:41649 Duration:5006}
+&{StatsOSSummary:{OS:Windows Visitors:166538 VisitorsPercentage:0.3333} Bounces:41565 Duration:5001}
+&{StatsOSSummary:{OS:Linux Visitors:166472 VisitorsPercentage:0.3332} Bounces:41470 Duration:5002}
 
 ---
 
 [TestGetWebsiteOS/Browser - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:55614 VisitorsPercentage:0.3347} Bounces:14086 Duration:4975}
-&{StatsOSSummary:{OS:Linux Visitors:55441 VisitorsPercentage:0.3336} Bounces:13911 Duration:4997}
-&{StatsOSSummary:{OS:Windows Visitors:55115 VisitorsPercentage:0.3317} Bounces:13969 Duration:4969}
+&{StatsOSSummary:{OS:Linux Visitors:55412 VisitorsPercentage:0.3336} Bounces:13814 Duration:4997}
+&{StatsOSSummary:{OS:Windows Visitors:55394 VisitorsPercentage:0.3335} Bounces:13832 Duration:4969}
+&{StatsOSSummary:{OS:iOS Visitors:55284 VisitorsPercentage:0.3329} Bounces:13994 Duration:4975}
 
 ---
 
 [TestGetWebsiteOS/Country - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:18557 VisitorsPercentage:0.3352} Bounces:4659 Duration:5002}
-&{StatsOSSummary:{OS:Linux Visitors:18456 VisitorsPercentage:0.3333} Bounces:4544 Duration:5046}
-&{StatsOSSummary:{OS:Windows Visitors:18355 VisitorsPercentage:0.3315} Bounces:4664 Duration:4930}
+&{StatsOSSummary:{OS:iOS Visitors:18554 VisitorsPercentage:0.3359} Bounces:4655 Duration:5002}
+&{StatsOSSummary:{OS:Linux Visitors:18365 VisitorsPercentage:0.3324} Bounces:4551 Duration:5046}
+&{StatsOSSummary:{OS:Windows Visitors:18324 VisitorsPercentage:0.3317} Bounces:4638 Duration:4930}
 
 ---
 
 [TestGetWebsiteOS/Device - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:6287 VisitorsPercentage:0.3381} Bounces:1609 Duration:4996}
-&{StatsOSSummary:{OS:Linux Visitors:6155 VisitorsPercentage:0.331} Bounces:1501 Duration:5021}
-&{StatsOSSummary:{OS:Windows Visitors:6151 VisitorsPercentage:0.3308} Bounces:1552 Duration:4978}
+&{StatsOSSummary:{OS:iOS Visitors:6314 VisitorsPercentage:0.3384} Bounces:1608 Duration:4996}
+&{StatsOSSummary:{OS:Linux Visitors:6175 VisitorsPercentage:0.3309} Bounces:1543 Duration:5021}
+&{StatsOSSummary:{OS:Windows Visitors:6172 VisitorsPercentage:0.3307} Bounces:1540 Duration:4978}
 
 ---
 
@@ -338,77 +338,77 @@ RECORDS:
 
 [TestGetWebsiteOS/Language - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:3178 VisitorsPercentage:0.3389} Bounces:820 Duration:5011}
-&{StatsOSSummary:{OS:Linux Visitors:3115 VisitorsPercentage:0.3322} Bounces:733 Duration:5040}
-&{StatsOSSummary:{OS:Windows Visitors:3085 VisitorsPercentage:0.329} Bounces:786 Duration:4971}
+&{StatsOSSummary:{OS:iOS Visitors:3246 VisitorsPercentage:0.3422} Bounces:829 Duration:5011}
+&{StatsOSSummary:{OS:Linux Visitors:3124 VisitorsPercentage:0.3293} Bounces:743 Duration:5040}
+&{StatsOSSummary:{OS:Windows Visitors:3116 VisitorsPercentage:0.3285} Bounces:783 Duration:4971}
 
 ---
 
 [TestGetWebsiteOS/OS - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:3085 VisitorsPercentage:1} Bounces:786 Duration:4971}
+&{StatsOSSummary:{OS:Windows Visitors:3116 VisitorsPercentage:1} Bounces:783 Duration:4971}
 
 ---
 
 [TestGetWebsiteOS/Pathname - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:1073 VisitorsPercentage:1} Bounces:260 Duration:5098}
+&{StatsOSSummary:{OS:Windows Visitors:1090 VisitorsPercentage:1} Bounces:268 Duration:5098}
 
 ---
 
 [TestGetWebsiteOS/Referrer - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:359 VisitorsPercentage:1} Bounces:91 Duration:4728}
+&{StatsOSSummary:{OS:Windows Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
 
 ---
 
 [TestGetWebsiteOS/UTMCampaign - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:110 VisitorsPercentage:1} Bounces:25 Duration:4732}
+&{StatsOSSummary:{OS:Windows Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
 
 ---
 
 [TestGetWebsiteOS/UTMMedium - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:36 VisitorsPercentage:1} Bounces:5 Duration:6547}
+&{StatsOSSummary:{OS:Windows Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
 
 ---
 
 [TestGetWebsiteOS/UTMSource - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:16 VisitorsPercentage:1} Bounces:2 Duration:3389}
+&{StatsOSSummary:{OS:Windows Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
 
 ---
 
 [TestGetWebsiteOSSummary/Base - 1]
 RECORDS:
-&{OS:iOS Visitors:167198 VisitorsPercentage:0.3345}
-&{OS:Windows Visitors:166384 VisitorsPercentage:0.3329}
-&{OS:Linux Visitors:166276 VisitorsPercentage:0.3326}
+&{OS:iOS Visitors:166647 VisitorsPercentage:0.3335}
+&{OS:Windows Visitors:166538 VisitorsPercentage:0.3333}
+&{OS:Linux Visitors:166472 VisitorsPercentage:0.3332}
 
 ---
 
 [TestGetWebsiteOSSummary/Browser - 1]
 RECORDS:
-&{OS:iOS Visitors:55614 VisitorsPercentage:0.3347}
-&{OS:Linux Visitors:55441 VisitorsPercentage:0.3336}
-&{OS:Windows Visitors:55115 VisitorsPercentage:0.3317}
+&{OS:Linux Visitors:55412 VisitorsPercentage:0.3336}
+&{OS:Windows Visitors:55394 VisitorsPercentage:0.3335}
+&{OS:iOS Visitors:55284 VisitorsPercentage:0.3329}
 
 ---
 
 [TestGetWebsiteOSSummary/Country - 1]
 RECORDS:
-&{OS:iOS Visitors:18557 VisitorsPercentage:0.3352}
-&{OS:Linux Visitors:18456 VisitorsPercentage:0.3333}
-&{OS:Windows Visitors:18355 VisitorsPercentage:0.3315}
+&{OS:iOS Visitors:18554 VisitorsPercentage:0.3359}
+&{OS:Linux Visitors:18365 VisitorsPercentage:0.3324}
+&{OS:Windows Visitors:18324 VisitorsPercentage:0.3317}
 
 ---
 
 [TestGetWebsiteOSSummary/Device - 1]
 RECORDS:
-&{OS:iOS Visitors:6287 VisitorsPercentage:0.3381}
-&{OS:Linux Visitors:6155 VisitorsPercentage:0.331}
-&{OS:Windows Visitors:6151 VisitorsPercentage:0.3308}
+&{OS:iOS Visitors:6314 VisitorsPercentage:0.3384}
+&{OS:Linux Visitors:6175 VisitorsPercentage:0.3309}
+&{OS:Windows Visitors:6172 VisitorsPercentage:0.3307}
 
 ---
 
@@ -419,44 +419,44 @@ RECORDS:
 
 [TestGetWebsiteOSSummary/Language - 1]
 RECORDS:
-&{OS:iOS Visitors:3178 VisitorsPercentage:0.3389}
-&{OS:Linux Visitors:3115 VisitorsPercentage:0.3322}
-&{OS:Windows Visitors:3085 VisitorsPercentage:0.329}
+&{OS:iOS Visitors:3246 VisitorsPercentage:0.3422}
+&{OS:Linux Visitors:3124 VisitorsPercentage:0.3293}
+&{OS:Windows Visitors:3116 VisitorsPercentage:0.3285}
 
 ---
 
 [TestGetWebsiteOSSummary/OS - 1]
 RECORDS:
-&{OS:Windows Visitors:3085 VisitorsPercentage:1}
+&{OS:Windows Visitors:3116 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteOSSummary/Pathname - 1]
 RECORDS:
-&{OS:Windows Visitors:1073 VisitorsPercentage:1}
+&{OS:Windows Visitors:1090 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteOSSummary/Referrer - 1]
 RECORDS:
-&{OS:Windows Visitors:359 VisitorsPercentage:1}
+&{OS:Windows Visitors:381 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteOSSummary/UTMCampaign - 1]
 RECORDS:
-&{OS:Windows Visitors:110 VisitorsPercentage:1}
+&{OS:Windows Visitors:116 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteOSSummary/UTMMedium - 1]
 RECORDS:
-&{OS:Windows Visitors:36 VisitorsPercentage:1}
+&{OS:Windows Visitors:35 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteOSSummary/UTMSource - 1]
 RECORDS:
-&{OS:Windows Visitors:16 VisitorsPercentage:1}
+&{OS:Windows Visitors:17 VisitorsPercentage:1}
 
 ---

--- a/core/db/duckdb/__snapshots__/utm_test.snap
+++ b/core/db/duckdb/__snapshots__/utm_test.snap
@@ -1,33 +1,33 @@
 
 [TestGetWebsiteUTMCampaigns/Base - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:166775 VisitorsPercentage:0.3336} Bounces:41899 Duration:5000}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:166762 VisitorsPercentage:0.3336} Bounces:41845 Duration:5002}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:166321 VisitorsPercentage:0.3327} Bounces:41510 Duration:5007}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:166923 VisitorsPercentage:0.3341} Bounces:41554 Duration:5000}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:166654 VisitorsPercentage:0.3335} Bounces:41720 Duration:5002}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:166080 VisitorsPercentage:0.3324} Bounces:41410 Duration:5007}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Browser - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:55460 VisitorsPercentage:0.3338} Bounces:13958 Duration:4970}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:55392 VisitorsPercentage:0.3333} Bounces:13965 Duration:4977}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:55318 VisitorsPercentage:0.3329} Bounces:14043 Duration:4992}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:55517 VisitorsPercentage:0.3343} Bounces:13819 Duration:4977}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:55310 VisitorsPercentage:0.333} Bounces:13910 Duration:4992}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:55263 VisitorsPercentage:0.3327} Bounces:13911 Duration:4970}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Country - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:18553 VisitorsPercentage:0.3351} Bounces:4710 Duration:5017}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:18425 VisitorsPercentage:0.3328} Bounces:4544 Duration:5002}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:18390 VisitorsPercentage:0.3321} Bounces:4613 Duration:4958}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:18468 VisitorsPercentage:0.3343} Bounces:4588 Duration:5002}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:18406 VisitorsPercentage:0.3332} Bounces:4657 Duration:5017}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:18369 VisitorsPercentage:0.3325} Bounces:4599 Duration:4958}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Device - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:6250 VisitorsPercentage:0.3361} Bounces:1567 Duration:4970}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:6219 VisitorsPercentage:0.3345} Bounces:1539 Duration:5040}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:6124 VisitorsPercentage:0.3294} Bounces:1556 Duration:4982}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:6260 VisitorsPercentage:0.3355} Bounces:1568 Duration:5040}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:6228 VisitorsPercentage:0.3337} Bounces:1579 Duration:4970}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:6173 VisitorsPercentage:0.3308} Bounces:1544 Duration:4982}
 
 ---
 
@@ -38,83 +38,83 @@ RECORDS:
 
 [TestGetWebsiteUTMCampaigns/Language - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:3148 VisitorsPercentage:0.3357} Bounces:793 Duration:4972}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:3143 VisitorsPercentage:0.3351} Bounces:756 Duration:5105}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:3087 VisitorsPercentage:0.3292} Bounces:790 Duration:4872}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:3215 VisitorsPercentage:0.3389} Bounces:812 Duration:4972}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:3150 VisitorsPercentage:0.3321} Bounces:758 Duration:5105}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:3121 VisitorsPercentage:0.329} Bounces:785 Duration:4872}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/OS - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:1047 VisitorsPercentage:0.3394} Bounces:250 Duration:5131}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:1039 VisitorsPercentage:0.3368} Bounces:265 Duration:4997}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:999 VisitorsPercentage:0.3238} Bounces:271 Duration:4736}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:1068 VisitorsPercentage:0.3427} Bounces:258 Duration:4997}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:1043 VisitorsPercentage:0.3347} Bounces:255 Duration:5131}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:1005 VisitorsPercentage:0.3225} Bounces:270 Duration:4736}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Pathname - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:375 VisitorsPercentage:0.3495} Bounces:86 Duration:5509}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:360 VisitorsPercentage:0.3355} Bounces:88 Duration:4948}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:338 VisitorsPercentage:0.315} Bounces:86 Duration:5038}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:369 VisitorsPercentage:0.3385} Bounces:92 Duration:4948}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:361 VisitorsPercentage:0.3312} Bounces:86 Duration:5038}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:360 VisitorsPercentage:0.3303} Bounces:90 Duration:5509}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Referrer - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:128 VisitorsPercentage:0.3565} Bounces:31 Duration:4761}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:121 VisitorsPercentage:0.337} Bounces:35 Duration:4700}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:110 VisitorsPercentage:0.3064} Bounces:25 Duration:4732}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:141 VisitorsPercentage:0.3701} Bounces:38 Duration:4761}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:124 VisitorsPercentage:0.3255} Bounces:27 Duration:4700}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:116 VisitorsPercentage:0.3045} Bounces:31 Duration:4732}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/UTMCampaign - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:110 VisitorsPercentage:1} Bounces:25 Duration:4732}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/UTMMedium - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:36 VisitorsPercentage:1} Bounces:5 Duration:6547}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/UTMSource - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:16 VisitorsPercentage:1} Bounces:2 Duration:3389}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
 
 ---
 
 [TestGetWebsiteUTMCampaignsSummary/Base - 1]
 RECORDS:
-&{Campaign: Visitors:166775 VisitorsPercentage:0.3336}
-&{Campaign:winter Visitors:166762 VisitorsPercentage:0.3336}
-&{Campaign:summer Visitors:166321 VisitorsPercentage:0.3327}
+&{Campaign: Visitors:166923 VisitorsPercentage:0.3341}
+&{Campaign:winter Visitors:166654 VisitorsPercentage:0.3335}
+&{Campaign:summer Visitors:166080 VisitorsPercentage:0.3324}
 
 ---
 
 [TestGetWebsiteUTMCampaignsSummary/Browser - 1]
 RECORDS:
-&{Campaign:summer Visitors:55460 VisitorsPercentage:0.3338}
-&{Campaign: Visitors:55392 VisitorsPercentage:0.3333}
-&{Campaign:winter Visitors:55318 VisitorsPercentage:0.3329}
+&{Campaign: Visitors:55517 VisitorsPercentage:0.3343}
+&{Campaign:winter Visitors:55310 VisitorsPercentage:0.333}
+&{Campaign:summer Visitors:55263 VisitorsPercentage:0.3327}
 
 ---
 
 [TestGetWebsiteUTMCampaignsSummary/Country - 1]
 RECORDS:
-&{Campaign:winter Visitors:18553 VisitorsPercentage:0.3351}
-&{Campaign:summer Visitors:18425 VisitorsPercentage:0.3328}
-&{Campaign: Visitors:18390 VisitorsPercentage:0.3321}
+&{Campaign:summer Visitors:18468 VisitorsPercentage:0.3343}
+&{Campaign:winter Visitors:18406 VisitorsPercentage:0.3332}
+&{Campaign: Visitors:18369 VisitorsPercentage:0.3325}
 
 ---
 
 [TestGetWebsiteUTMCampaignsSummary/Device - 1]
 RECORDS:
-&{Campaign:summer Visitors:6250 VisitorsPercentage:0.3361}
-&{Campaign:winter Visitors:6219 VisitorsPercentage:0.3345}
-&{Campaign: Visitors:6124 VisitorsPercentage:0.3294}
+&{Campaign:winter Visitors:6260 VisitorsPercentage:0.3355}
+&{Campaign:summer Visitors:6228 VisitorsPercentage:0.3337}
+&{Campaign: Visitors:6173 VisitorsPercentage:0.3308}
 
 ---
 
@@ -125,83 +125,83 @@ RECORDS:
 
 [TestGetWebsiteUTMCampaignsSummary/Language - 1]
 RECORDS:
-&{Campaign:summer Visitors:3148 VisitorsPercentage:0.3357}
-&{Campaign:winter Visitors:3143 VisitorsPercentage:0.3351}
-&{Campaign: Visitors:3087 VisitorsPercentage:0.3292}
+&{Campaign:summer Visitors:3215 VisitorsPercentage:0.3389}
+&{Campaign:winter Visitors:3150 VisitorsPercentage:0.3321}
+&{Campaign: Visitors:3121 VisitorsPercentage:0.329}
 
 ---
 
 [TestGetWebsiteUTMCampaignsSummary/OS - 1]
 RECORDS:
-&{Campaign:summer Visitors:1047 VisitorsPercentage:0.3394}
-&{Campaign:winter Visitors:1039 VisitorsPercentage:0.3368}
-&{Campaign: Visitors:999 VisitorsPercentage:0.3238}
+&{Campaign:winter Visitors:1068 VisitorsPercentage:0.3427}
+&{Campaign:summer Visitors:1043 VisitorsPercentage:0.3347}
+&{Campaign: Visitors:1005 VisitorsPercentage:0.3225}
 
 ---
 
 [TestGetWebsiteUTMCampaignsSummary/Pathname - 1]
 RECORDS:
-&{Campaign:summer Visitors:375 VisitorsPercentage:0.3495}
-&{Campaign:winter Visitors:360 VisitorsPercentage:0.3355}
-&{Campaign: Visitors:338 VisitorsPercentage:0.315}
+&{Campaign:winter Visitors:369 VisitorsPercentage:0.3385}
+&{Campaign: Visitors:361 VisitorsPercentage:0.3312}
+&{Campaign:summer Visitors:360 VisitorsPercentage:0.3303}
 
 ---
 
 [TestGetWebsiteUTMCampaignsSummary/Referrer - 1]
 RECORDS:
-&{Campaign:winter Visitors:128 VisitorsPercentage:0.3565}
-&{Campaign: Visitors:121 VisitorsPercentage:0.337}
-&{Campaign:summer Visitors:110 VisitorsPercentage:0.3064}
+&{Campaign:winter Visitors:141 VisitorsPercentage:0.3701}
+&{Campaign: Visitors:124 VisitorsPercentage:0.3255}
+&{Campaign:summer Visitors:116 VisitorsPercentage:0.3045}
 
 ---
 
 [TestGetWebsiteUTMCampaignsSummary/UTMCampaign - 1]
 RECORDS:
-&{Campaign:summer Visitors:110 VisitorsPercentage:1}
+&{Campaign:summer Visitors:116 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteUTMCampaignsSummary/UTMMedium - 1]
 RECORDS:
-&{Campaign:summer Visitors:36 VisitorsPercentage:1}
+&{Campaign:summer Visitors:35 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteUTMCampaignsSummary/UTMSource - 1]
 RECORDS:
-&{Campaign:summer Visitors:16 VisitorsPercentage:1}
+&{Campaign:summer Visitors:17 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteUTMMediums/Base - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:167184 VisitorsPercentage:0.3345} Bounces:41714 Duration:5008}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:166565 VisitorsPercentage:0.3332} Bounces:41657 Duration:5004}
-&{StatsUTMMediumsSummary:{Medium: Visitors:166109 VisitorsPercentage:0.3323} Bounces:41883 Duration:4995}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:167067 VisitorsPercentage:0.3344} Bounces:41702 Duration:5008}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:166355 VisitorsPercentage:0.3329} Bounces:41466 Duration:5004}
+&{StatsUTMMediumsSummary:{Medium: Visitors:166235 VisitorsPercentage:0.3327} Bounces:41516 Duration:4995}
 
 ---
 
 [TestGetWebsiteUTMMediums/Browser - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:55528 VisitorsPercentage:0.3342} Bounces:14048 Duration:4976}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:55479 VisitorsPercentage:0.3339} Bounces:13959 Duration:4992}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:55163 VisitorsPercentage:0.332} Bounces:13959 Duration:4973}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:55415 VisitorsPercentage:0.3336} Bounces:13833 Duration:4992}
+&{StatsUTMMediumsSummary:{Medium: Visitors:55402 VisitorsPercentage:0.3336} Bounces:13902 Duration:4976}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:55273 VisitorsPercentage:0.3328} Bounces:13905 Duration:4973}
 
 ---
 
 [TestGetWebsiteUTMMediums/Country - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:18618 VisitorsPercentage:0.3363} Bounces:4694 Duration:5006}
-&{StatsUTMMediumsSummary:{Medium: Visitors:18435 VisitorsPercentage:0.333} Bounces:4560 Duration:4995}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:18315 VisitorsPercentage:0.3308} Bounces:4613 Duration:4977}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:18538 VisitorsPercentage:0.3356} Bounces:4668 Duration:5006}
+&{StatsUTMMediumsSummary:{Medium: Visitors:18528 VisitorsPercentage:0.3354} Bounces:4607 Duration:4995}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:18177 VisitorsPercentage:0.329} Bounces:4569 Duration:4977}
 
 ---
 
 [TestGetWebsiteUTMMediums/Device - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:6288 VisitorsPercentage:0.3382} Bounces:1569 Duration:5036}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:6274 VisitorsPercentage:0.3374} Bounces:1615 Duration:4916}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:6031 VisitorsPercentage:0.3244} Bounces:1478 Duration:5028}
+&{StatsUTMMediumsSummary:{Medium: Visitors:6299 VisitorsPercentage:0.3375} Bounces:1579 Duration:5036}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:6293 VisitorsPercentage:0.3372} Bounces:1618 Duration:4916}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:6069 VisitorsPercentage:0.3252} Bounces:1494 Duration:5028}
 
 ---
 
@@ -212,85 +212,85 @@ RECORDS:
 
 [TestGetWebsiteUTMMediums/Language - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:3225 VisitorsPercentage:0.3439} Bounces:781 Duration:5126}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:3132 VisitorsPercentage:0.334} Bounces:796 Duration:4909}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:3021 VisitorsPercentage:0.3221} Bounces:762 Duration:4968}
+&{StatsUTMMediumsSummary:{Medium: Visitors:3216 VisitorsPercentage:0.339} Bounces:782 Duration:5126}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:3193 VisitorsPercentage:0.3366} Bounces:804 Duration:4909}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:3077 VisitorsPercentage:0.3244} Bounces:769 Duration:4968}
 
 ---
 
 [TestGetWebsiteUTMMediums/OS - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:1078 VisitorsPercentage:0.3494} Bounces:272 Duration:5072}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:1020 VisitorsPercentage:0.3306} Bounces:255 Duration:4848}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:987 VisitorsPercentage:0.3199} Bounces:259 Duration:4970}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:1052 VisitorsPercentage:0.3376} Bounces:275 Duration:4848}
+&{StatsUTMMediumsSummary:{Medium: Visitors:1043 VisitorsPercentage:0.3347} Bounces:249 Duration:5072}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:1021 VisitorsPercentage:0.3277} Bounces:259 Duration:4970}
 
 ---
 
 [TestGetWebsiteUTMMediums/Pathname - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:385 VisitorsPercentage:0.3588} Bounces:88 Duration:4950}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:356 VisitorsPercentage:0.3318} Bounces:86 Duration:4826}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:332 VisitorsPercentage:0.3094} Bounces:86 Duration:5556}
+&{StatsUTMMediumsSummary:{Medium: Visitors:384 VisitorsPercentage:0.3523} Bounces:94 Duration:4950}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:364 VisitorsPercentage:0.3339} Bounces:101 Duration:4826}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:342 VisitorsPercentage:0.3138} Bounces:73 Duration:5556}
 
 ---
 
 [TestGetWebsiteUTMMediums/Referrer - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:129 VisitorsPercentage:0.3593} Bounces:26 Duration:4812}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:121 VisitorsPercentage:0.337} Bounces:36 Duration:4180}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:109 VisitorsPercentage:0.3036} Bounces:29 Duration:5558}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:132 VisitorsPercentage:0.3465} Bounces:41 Duration:4180}
+&{StatsUTMMediumsSummary:{Medium: Visitors:131 VisitorsPercentage:0.3438} Bounces:34 Duration:4812}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:118 VisitorsPercentage:0.3097} Bounces:21 Duration:5558}
 
 ---
 
 [TestGetWebsiteUTMMediums/UTMCampaign - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:41 VisitorsPercentage:0.3727} Bounces:6 Duration:5240}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:36 VisitorsPercentage:0.3273} Bounces:5 Duration:6547}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:33 VisitorsPercentage:0.3} Bounces:14 Duration:4395}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:42 VisitorsPercentage:0.3621} Bounces:16 Duration:4395}
+&{StatsUTMMediumsSummary:{Medium: Visitors:39 VisitorsPercentage:0.3362} Bounces:9 Duration:5240}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:35 VisitorsPercentage:0.3017} Bounces:6 Duration:6547}
 
 ---
 
 [TestGetWebsiteUTMMediums/UTMMedium - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:36 VisitorsPercentage:1} Bounces:5 Duration:6547}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
 
 ---
 
 [TestGetWebsiteUTMMediums/UTMSource - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:16 VisitorsPercentage:1} Bounces:2 Duration:3389}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
 
 ---
 
 [TestGetWebsiteUTMMediumsSummary/Base - 1]
 RECORDS:
-&{Medium:cpc Visitors:167184 VisitorsPercentage:0.3345}
-&{Medium:organic Visitors:166565 VisitorsPercentage:0.3332}
-&{Medium: Visitors:166109 VisitorsPercentage:0.3323}
+&{Medium:cpc Visitors:167067 VisitorsPercentage:0.3344}
+&{Medium:organic Visitors:166355 VisitorsPercentage:0.3329}
+&{Medium: Visitors:166235 VisitorsPercentage:0.3327}
 
 ---
 
 [TestGetWebsiteUTMMediumsSummary/Browser - 1]
 RECORDS:
-&{Medium: Visitors:55528 VisitorsPercentage:0.3342}
-&{Medium:cpc Visitors:55479 VisitorsPercentage:0.3339}
-&{Medium:organic Visitors:55163 VisitorsPercentage:0.332}
+&{Medium:cpc Visitors:55415 VisitorsPercentage:0.3336}
+&{Medium: Visitors:55402 VisitorsPercentage:0.3336}
+&{Medium:organic Visitors:55273 VisitorsPercentage:0.3328}
 
 ---
 
 [TestGetWebsiteUTMMediumsSummary/Country - 1]
 RECORDS:
-&{Medium:cpc Visitors:18618 VisitorsPercentage:0.3363}
-&{Medium: Visitors:18435 VisitorsPercentage:0.333}
-&{Medium:organic Visitors:18315 VisitorsPercentage:0.3308}
+&{Medium:cpc Visitors:18538 VisitorsPercentage:0.3356}
+&{Medium: Visitors:18528 VisitorsPercentage:0.3354}
+&{Medium:organic Visitors:18177 VisitorsPercentage:0.329}
 
 ---
 
 [TestGetWebsiteUTMMediumsSummary/Device - 1]
 RECORDS:
-&{Medium: Visitors:6288 VisitorsPercentage:0.3382}
-&{Medium:cpc Visitors:6274 VisitorsPercentage:0.3374}
-&{Medium:organic Visitors:6031 VisitorsPercentage:0.3244}
+&{Medium: Visitors:6299 VisitorsPercentage:0.3375}
+&{Medium:cpc Visitors:6293 VisitorsPercentage:0.3372}
+&{Medium:organic Visitors:6069 VisitorsPercentage:0.3252}
 
 ---
 
@@ -301,85 +301,85 @@ RECORDS:
 
 [TestGetWebsiteUTMMediumsSummary/Language - 1]
 RECORDS:
-&{Medium: Visitors:3225 VisitorsPercentage:0.3439}
-&{Medium:cpc Visitors:3132 VisitorsPercentage:0.334}
-&{Medium:organic Visitors:3021 VisitorsPercentage:0.3221}
+&{Medium: Visitors:3216 VisitorsPercentage:0.339}
+&{Medium:cpc Visitors:3193 VisitorsPercentage:0.3366}
+&{Medium:organic Visitors:3077 VisitorsPercentage:0.3244}
 
 ---
 
 [TestGetWebsiteUTMMediumsSummary/OS - 1]
 RECORDS:
-&{Medium: Visitors:1078 VisitorsPercentage:0.3494}
-&{Medium:cpc Visitors:1020 VisitorsPercentage:0.3306}
-&{Medium:organic Visitors:987 VisitorsPercentage:0.3199}
+&{Medium:cpc Visitors:1052 VisitorsPercentage:0.3376}
+&{Medium: Visitors:1043 VisitorsPercentage:0.3347}
+&{Medium:organic Visitors:1021 VisitorsPercentage:0.3277}
 
 ---
 
 [TestGetWebsiteUTMMediumsSummary/Pathname - 1]
 RECORDS:
-&{Medium: Visitors:385 VisitorsPercentage:0.3588}
-&{Medium:cpc Visitors:356 VisitorsPercentage:0.3318}
-&{Medium:organic Visitors:332 VisitorsPercentage:0.3094}
+&{Medium: Visitors:384 VisitorsPercentage:0.3523}
+&{Medium:cpc Visitors:364 VisitorsPercentage:0.3339}
+&{Medium:organic Visitors:342 VisitorsPercentage:0.3138}
 
 ---
 
 [TestGetWebsiteUTMMediumsSummary/Referrer - 1]
 RECORDS:
-&{Medium: Visitors:129 VisitorsPercentage:0.3593}
-&{Medium:cpc Visitors:121 VisitorsPercentage:0.337}
-&{Medium:organic Visitors:109 VisitorsPercentage:0.3036}
+&{Medium:cpc Visitors:132 VisitorsPercentage:0.3465}
+&{Medium: Visitors:131 VisitorsPercentage:0.3438}
+&{Medium:organic Visitors:118 VisitorsPercentage:0.3097}
 
 ---
 
 [TestGetWebsiteUTMMediumsSummary/UTMCampaign - 1]
 RECORDS:
-&{Medium: Visitors:41 VisitorsPercentage:0.3727}
-&{Medium:organic Visitors:36 VisitorsPercentage:0.3273}
-&{Medium:cpc Visitors:33 VisitorsPercentage:0.3}
+&{Medium:cpc Visitors:42 VisitorsPercentage:0.3621}
+&{Medium: Visitors:39 VisitorsPercentage:0.3362}
+&{Medium:organic Visitors:35 VisitorsPercentage:0.3017}
 
 ---
 
 [TestGetWebsiteUTMMediumsSummary/UTMMedium - 1]
 RECORDS:
-&{Medium:organic Visitors:36 VisitorsPercentage:1}
+&{Medium:organic Visitors:35 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteUTMMediumsSummary/UTMSource - 1]
 RECORDS:
-&{Medium:organic Visitors:16 VisitorsPercentage:1}
+&{Medium:organic Visitors:17 VisitorsPercentage:1}
 
 ---
 
 [TestGetWebsiteUTMSources/Base - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:167073 VisitorsPercentage:0.3342} Bounces:41766 Duration:5006}
-&{StatsUTMSourcesSummary:{Source:bing Visitors:166544 VisitorsPercentage:0.3332} Bounces:41637 Duration:4990}
-&{StatsUTMSourcesSummary:{Source: Visitors:166241 VisitorsPercentage:0.3326} Bounces:41851 Duration:5013}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:166720 VisitorsPercentage:0.3337} Bounces:41302 Duration:5006}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:166575 VisitorsPercentage:0.3334} Bounces:41910 Duration:4990}
+&{StatsUTMSourcesSummary:{Source: Visitors:166362 VisitorsPercentage:0.333} Bounces:41472 Duration:5013}
 
 ---
 
 [TestGetWebsiteUTMSources/Browser - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:55615 VisitorsPercentage:0.3347} Bounces:13981 Duration:4978}
-&{StatsUTMSourcesSummary:{Source:bing Visitors:55304 VisitorsPercentage:0.3328} Bounces:13994 Duration:4976}
-&{StatsUTMSourcesSummary:{Source: Visitors:55251 VisitorsPercentage:0.3325} Bounces:13991 Duration:4989}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:55742 VisitorsPercentage:0.3356} Bounces:14094 Duration:4976}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:55251 VisitorsPercentage:0.3327} Bounces:13803 Duration:4978}
+&{StatsUTMSourcesSummary:{Source: Visitors:55097 VisitorsPercentage:0.3317} Bounces:13743 Duration:4989}
 
 ---
 
 [TestGetWebsiteUTMSources/Country - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:18525 VisitorsPercentage:0.3346} Bounces:4559 Duration:5014}
-&{StatsUTMSourcesSummary:{Source: Visitors:18437 VisitorsPercentage:0.333} Bounces:4695 Duration:4965}
-&{StatsUTMSourcesSummary:{Source:bing Visitors:18406 VisitorsPercentage:0.3324} Bounces:4613 Duration:4993}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:18552 VisitorsPercentage:0.3358} Bounces:4676 Duration:4993}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:18490 VisitorsPercentage:0.3347} Bounces:4614 Duration:5014}
+&{StatsUTMSourcesSummary:{Source: Visitors:18201 VisitorsPercentage:0.3295} Bounces:4554 Duration:4965}
 
 ---
 
 [TestGetWebsiteUTMSources/Device - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:6284 VisitorsPercentage:0.338} Bounces:1542 Duration:5031}
-&{StatsUTMSourcesSummary:{Source: Visitors:6190 VisitorsPercentage:0.3329} Bounces:1616 Duration:4915}
-&{StatsUTMSourcesSummary:{Source:bing Visitors:6119 VisitorsPercentage:0.3291} Bounces:1504 Duration:5044}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:6267 VisitorsPercentage:0.3358} Bounces:1566 Duration:5044}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:6213 VisitorsPercentage:0.3329} Bounces:1553 Duration:5031}
+&{StatsUTMSourcesSummary:{Source: Visitors:6181 VisitorsPercentage:0.3312} Bounces:1572 Duration:4915}
 
 ---
 
@@ -390,87 +390,87 @@ RECORDS:
 
 [TestGetWebsiteUTMSources/Language - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:3259 VisitorsPercentage:0.3475} Bounces:811 Duration:5028}
-&{StatsUTMSourcesSummary:{Source: Visitors:3090 VisitorsPercentage:0.3295} Bounces:818 Duration:4835}
-&{StatsUTMSourcesSummary:{Source:bing Visitors:3029 VisitorsPercentage:0.323} Bounces:710 Duration:5120}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:3206 VisitorsPercentage:0.338} Bounces:785 Duration:5120}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:3190 VisitorsPercentage:0.3363} Bounces:792 Duration:5028}
+&{StatsUTMSourcesSummary:{Source: Visitors:3090 VisitorsPercentage:0.3257} Bounces:778 Duration:4835}
 
 ---
 
 [TestGetWebsiteUTMSources/OS - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:1060 VisitorsPercentage:0.3436} Bounces:281 Duration:4861}
-&{StatsUTMSourcesSummary:{Source: Visitors:1040 VisitorsPercentage:0.3371} Bounces:271 Duration:4954}
-&{StatsUTMSourcesSummary:{Source:bing Visitors:985 VisitorsPercentage:0.3193} Bounces:234 Duration:5071}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:1064 VisitorsPercentage:0.3415} Bounces:261 Duration:5071}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:1034 VisitorsPercentage:0.3318} Bounces:268 Duration:4861}
+&{StatsUTMSourcesSummary:{Source: Visitors:1018 VisitorsPercentage:0.3267} Bounces:254 Duration:4954}
 
 ---
 
 [TestGetWebsiteUTMSources/Pathname - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:366 VisitorsPercentage:0.3411} Bounces:102 Duration:4985}
-&{StatsUTMSourcesSummary:{Source: Visitors:357 VisitorsPercentage:0.3327} Bounces:86 Duration:5028}
-&{StatsUTMSourcesSummary:{Source:bing Visitors:350 VisitorsPercentage:0.3262} Bounces:72 Duration:5441}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:381 VisitorsPercentage:0.3495} Bounces:88 Duration:5441}
+&{StatsUTMSourcesSummary:{Source: Visitors:365 VisitorsPercentage:0.3349} Bounces:96 Duration:5028}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:344 VisitorsPercentage:0.3156} Bounces:84 Duration:4985}
 
 ---
 
 [TestGetWebsiteUTMSources/Referrer - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source: Visitors:121 VisitorsPercentage:0.337} Bounces:30 Duration:4723}
-&{StatsUTMSourcesSummary:{Source:bing Visitors:120 VisitorsPercentage:0.3343} Bounces:26 Duration:4694}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:118 VisitorsPercentage:0.3287} Bounces:35 Duration:4732}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:140 VisitorsPercentage:0.3675} Bounces:32 Duration:4694}
+&{StatsUTMSourcesSummary:{Source: Visitors:126 VisitorsPercentage:0.3307} Bounces:38 Duration:4723}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:115 VisitorsPercentage:0.3018} Bounces:26 Duration:4732}
 
 ---
 
 [TestGetWebsiteUTMSources/UTMCampaign - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:43 VisitorsPercentage:0.3909} Bounces:9 Duration:3851}
-&{StatsUTMSourcesSummary:{Source: Visitors:36 VisitorsPercentage:0.3273} Bounces:10 Duration:3696}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:31 VisitorsPercentage:0.2818} Bounces:6 Duration:6888}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:49 VisitorsPercentage:0.4224} Bounces:12 Duration:3851}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:35 VisitorsPercentage:0.3017} Bounces:5 Duration:6888}
+&{StatsUTMSourcesSummary:{Source: Visitors:32 VisitorsPercentage:0.2759} Bounces:14 Duration:3696}
 
 ---
 
 [TestGetWebsiteUTMSources/UTMMedium - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:16 VisitorsPercentage:0.4444} Bounces:2 Duration:3389}
-&{StatsUTMSourcesSummary:{Source: Visitors:12 VisitorsPercentage:0.3333} Bounces:3 Duration:3102}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:8 VisitorsPercentage:0.2222} Bounces:0 Duration:9728}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:17 VisitorsPercentage:0.4857} Bounces:3 Duration:3389}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:10 VisitorsPercentage:0.2857} Bounces:0 Duration:9728}
+&{StatsUTMSourcesSummary:{Source: Visitors:8 VisitorsPercentage:0.2286} Bounces:3 Duration:3102}
 
 ---
 
 [TestGetWebsiteUTMSources/UTMSource - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:16 VisitorsPercentage:1} Bounces:2 Duration:3389}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
 
 ---
 
 [TestGetWebsiteUTMSourcesSummary/Base - 1]
 RECORDS:
-&{Source:twitter Visitors:167073 VisitorsPercentage:0.3342}
-&{Source:bing Visitors:166544 VisitorsPercentage:0.3332}
-&{Source: Visitors:166241 VisitorsPercentage:0.3326}
+&{Source:twitter Visitors:166720 VisitorsPercentage:0.3337}
+&{Source:bing Visitors:166575 VisitorsPercentage:0.3334}
+&{Source: Visitors:166362 VisitorsPercentage:0.333}
 
 ---
 
 [TestGetWebsiteUTMSourcesSummary/Browser - 1]
 RECORDS:
-&{Source:twitter Visitors:55615 VisitorsPercentage:0.3347}
-&{Source:bing Visitors:55304 VisitorsPercentage:0.3328}
-&{Source: Visitors:55251 VisitorsPercentage:0.3325}
+&{Source:bing Visitors:55742 VisitorsPercentage:0.3356}
+&{Source:twitter Visitors:55251 VisitorsPercentage:0.3327}
+&{Source: Visitors:55097 VisitorsPercentage:0.3317}
 
 ---
 
 [TestGetWebsiteUTMSourcesSummary/Country - 1]
 RECORDS:
-&{Source:twitter Visitors:18525 VisitorsPercentage:0.3346}
-&{Source: Visitors:18437 VisitorsPercentage:0.333}
-&{Source:bing Visitors:18406 VisitorsPercentage:0.3324}
+&{Source:bing Visitors:18552 VisitorsPercentage:0.3358}
+&{Source:twitter Visitors:18490 VisitorsPercentage:0.3347}
+&{Source: Visitors:18201 VisitorsPercentage:0.3295}
 
 ---
 
 [TestGetWebsiteUTMSourcesSummary/Device - 1]
 RECORDS:
-&{Source:twitter Visitors:6284 VisitorsPercentage:0.338}
-&{Source: Visitors:6190 VisitorsPercentage:0.3329}
-&{Source:bing Visitors:6119 VisitorsPercentage:0.3291}
+&{Source:bing Visitors:6267 VisitorsPercentage:0.3358}
+&{Source:twitter Visitors:6213 VisitorsPercentage:0.3329}
+&{Source: Visitors:6181 VisitorsPercentage:0.3312}
 
 ---
 
@@ -481,54 +481,54 @@ RECORDS:
 
 [TestGetWebsiteUTMSourcesSummary/Language - 1]
 RECORDS:
-&{Source:twitter Visitors:3259 VisitorsPercentage:0.3475}
-&{Source: Visitors:3090 VisitorsPercentage:0.3295}
-&{Source:bing Visitors:3029 VisitorsPercentage:0.323}
+&{Source:bing Visitors:3206 VisitorsPercentage:0.338}
+&{Source:twitter Visitors:3190 VisitorsPercentage:0.3363}
+&{Source: Visitors:3090 VisitorsPercentage:0.3257}
 
 ---
 
 [TestGetWebsiteUTMSourcesSummary/OS - 1]
 RECORDS:
-&{Source:twitter Visitors:1060 VisitorsPercentage:0.3436}
-&{Source: Visitors:1040 VisitorsPercentage:0.3371}
-&{Source:bing Visitors:985 VisitorsPercentage:0.3193}
+&{Source:bing Visitors:1064 VisitorsPercentage:0.3415}
+&{Source:twitter Visitors:1034 VisitorsPercentage:0.3318}
+&{Source: Visitors:1018 VisitorsPercentage:0.3267}
 
 ---
 
 [TestGetWebsiteUTMSourcesSummary/Pathname - 1]
 RECORDS:
-&{Source:twitter Visitors:366 VisitorsPercentage:0.3411}
-&{Source: Visitors:357 VisitorsPercentage:0.3327}
-&{Source:bing Visitors:350 VisitorsPercentage:0.3262}
+&{Source:bing Visitors:381 VisitorsPercentage:0.3495}
+&{Source: Visitors:365 VisitorsPercentage:0.3349}
+&{Source:twitter Visitors:344 VisitorsPercentage:0.3156}
 
 ---
 
 [TestGetWebsiteUTMSourcesSummary/Referrer - 1]
 RECORDS:
-&{Source: Visitors:121 VisitorsPercentage:0.337}
-&{Source:bing Visitors:120 VisitorsPercentage:0.3343}
-&{Source:twitter Visitors:118 VisitorsPercentage:0.3287}
+&{Source:bing Visitors:140 VisitorsPercentage:0.3675}
+&{Source: Visitors:126 VisitorsPercentage:0.3307}
+&{Source:twitter Visitors:115 VisitorsPercentage:0.3018}
 
 ---
 
 [TestGetWebsiteUTMSourcesSummary/UTMCampaign - 1]
 RECORDS:
-&{Source:bing Visitors:43 VisitorsPercentage:0.3909}
-&{Source: Visitors:36 VisitorsPercentage:0.3273}
-&{Source:twitter Visitors:31 VisitorsPercentage:0.2818}
+&{Source:bing Visitors:49 VisitorsPercentage:0.4224}
+&{Source:twitter Visitors:35 VisitorsPercentage:0.3017}
+&{Source: Visitors:32 VisitorsPercentage:0.2759}
 
 ---
 
 [TestGetWebsiteUTMSourcesSummary/UTMMedium - 1]
 RECORDS:
-&{Source:bing Visitors:16 VisitorsPercentage:0.4444}
-&{Source: Visitors:12 VisitorsPercentage:0.3333}
-&{Source:twitter Visitors:8 VisitorsPercentage:0.2222}
+&{Source:bing Visitors:17 VisitorsPercentage:0.4857}
+&{Source:twitter Visitors:10 VisitorsPercentage:0.2857}
+&{Source: Visitors:8 VisitorsPercentage:0.2286}
 
 ---
 
 [TestGetWebsiteUTMSourcesSummary/UTMSource - 1]
 RECORDS:
-&{Source:bing Visitors:16 VisitorsPercentage:1}
+&{Source:bing Visitors:17 VisitorsPercentage:1}
 
 ---

--- a/core/db/duckdb/locale.go
+++ b/core/db/duckdb/locale.go
@@ -23,7 +23,7 @@ func (c *Client) GetWebsiteCountriesSummary(ctx context.Context, filter *db.Filt
 	// VisitorsPercentage is the percentage the country contributes to the total unique visits.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -31,7 +31,7 @@ func (c *Client) GetWebsiteCountriesSummary(ctx context.Context, filter *db.Filt
 		)
 		SELECT
 			country,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage
 		FROM views
 		WHERE `)
@@ -71,7 +71,7 @@ func (c *Client) GetWebsiteCountries(ctx context.Context, filter *db.Filters) ([
 	// VisitorsPercentage is the percentage the country contributes to the total unique visits.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -79,9 +79,9 @@ func (c *Client) GetWebsiteCountries(ctx context.Context, filter *db.Filters) ([
 		)
 		SELECT
 			country,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage,
-			COUNT(*) FILTER (WHERE is_unique_page = true AND duration_ms < 5000) AS bounces,
+			COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces,
 			CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration
 		FROM views
 		WHERE `)
@@ -121,7 +121,7 @@ func (c *Client) GetWebsiteLanguagesSummary(ctx context.Context, filter *db.Filt
 	// VisitorsPercentage is the percentage the language contributes to the total unique visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -129,7 +129,7 @@ func (c *Client) GetWebsiteLanguagesSummary(ctx context.Context, filter *db.Filt
 		)
 		SELECT
 			language_base AS language,
-			COUNT(*) FILTER (is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage
 		FROM views
 		WHERE `)
@@ -169,7 +169,7 @@ func (c *Client) GetWebsiteLanguages(ctx context.Context, filter *db.Filters) ([
 	// VisitorsPercentage is the percentage the language contributes to the total unique visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -177,9 +177,9 @@ func (c *Client) GetWebsiteLanguages(ctx context.Context, filter *db.Filters) ([
 		)
 		SELECT
 			language_base AS language,
-			COUNT(*) FILTER (is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage,
-			COUNT(*) FILTER (WHERE is_unique_page = true AND duration_ms < 5000) AS bounces,
+			COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces,
 			CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration
 		FROM views
 		WHERE `)

--- a/core/db/duckdb/referrers.go
+++ b/core/db/duckdb/referrers.go
@@ -75,7 +75,7 @@ func (c *Client) GetWebsiteReferrers(ctx context.Context, filter *db.Filters) ([
 	// Duration is the median duration the user spent on the page in milliseconds.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -83,9 +83,9 @@ func (c *Client) GetWebsiteReferrers(ctx context.Context, filter *db.Filters) ([
 		)
 		SELECT
 			referrer_host AS referrer,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage,
-			COUNT(*) FILTER (WHERE is_unique_page = true AND duration_ms < 5000) AS bounces,
+			COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces,
 			CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration
 		FROM views
 		WHERE `)

--- a/core/db/duckdb/types.go
+++ b/core/db/duckdb/types.go
@@ -23,7 +23,7 @@ func (c *Client) GetWebsiteBrowsersSummary(ctx context.Context, filter *db.Filte
 	// VisitorsPercentage is the percentage the browser contributes to the total visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -31,7 +31,7 @@ func (c *Client) GetWebsiteBrowsersSummary(ctx context.Context, filter *db.Filte
 		)
 		SELECT
 			ua_browser AS browser,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage
 		FROM views
 		WHERE `)
@@ -74,7 +74,7 @@ func (c *Client) GetWebsiteBrowsers(ctx context.Context, filter *db.Filters) ([]
 	// Duration is the median duration of the page.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -82,9 +82,9 @@ func (c *Client) GetWebsiteBrowsers(ctx context.Context, filter *db.Filters) ([]
 		)
 		SELECT
 			ua_browser AS browser,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage,
-			COUNT(*) FILTER (WHERE is_unique_page = true AND duration_ms < 5000) AS bounces,
+			COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces,
 			CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration
 		FROM views
 		WHERE `)
@@ -123,7 +123,7 @@ func (c *Client) GetWebsiteOSSummary(ctx context.Context, filter *db.Filters) ([
 	// VisitorsPercentage is the percentage the operating contributes to the total visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -131,7 +131,7 @@ func (c *Client) GetWebsiteOSSummary(ctx context.Context, filter *db.Filters) ([
 		)
 		SELECT
 			ua_os AS os,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage
 		FROM views
 		WHERE `)
@@ -171,7 +171,7 @@ func (c *Client) GetWebsiteOS(ctx context.Context, filter *db.Filters) ([]*model
 	// VisitorsPercentage is the percentage the operating contributes to the total visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -179,9 +179,9 @@ func (c *Client) GetWebsiteOS(ctx context.Context, filter *db.Filters) ([]*model
 		)
 		SELECT
 			ua_os AS os,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage,
-			COUNT(*) FILTER (WHERE is_unique_page = true AND duration_ms < 5000) AS bounces,
+			COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces,
 			CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration
 		FROM views
 		WHERE `)
@@ -220,7 +220,7 @@ func (c *Client) GetWebsiteDevicesSummary(ctx context.Context, filter *db.Filter
 	// VisitorsPercentage is the percentage the device contributes to the total visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -228,7 +228,7 @@ func (c *Client) GetWebsiteDevicesSummary(ctx context.Context, filter *db.Filter
 		)
 		SELECT
 			ua_device_type AS device,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage
 		FROM views
 		WHERE `)
@@ -268,7 +268,7 @@ func (c *Client) GetWebsiteDevices(ctx context.Context, filter *db.Filters) ([]*
 	// VisitorsPercentage is the percentage the device contributes to the total visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -276,9 +276,9 @@ func (c *Client) GetWebsiteDevices(ctx context.Context, filter *db.Filters) ([]*
 		)
 		SELECT
 			ua_device_type AS device,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage,
-			COUNT(*) FILTER (WHERE is_unique_page = true AND duration_ms < 5000) AS bounces,
+			COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces,
 			CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration
 		FROM views
 		WHERE `)

--- a/core/db/duckdb/utm.go
+++ b/core/db/duckdb/utm.go
@@ -22,7 +22,7 @@ func (c *Client) GetWebsiteUTMSourcesSummary(ctx context.Context, filter *db.Fil
 	// VisitorsPercentage is the percentage the utm source contributes to the total unique visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -30,7 +30,7 @@ func (c *Client) GetWebsiteUTMSourcesSummary(ctx context.Context, filter *db.Fil
 		)
 		SELECT
 			utm_source AS source,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage
 		FROM views
 		WHERE `)
@@ -70,7 +70,7 @@ func (c *Client) GetWebsiteUTMSources(ctx context.Context, filter *db.Filters) (
 	// VisitorsPercentage is the percentage the utm source contributes to the total unique visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -78,9 +78,9 @@ func (c *Client) GetWebsiteUTMSources(ctx context.Context, filter *db.Filters) (
 		)
 		SELECT
 			utm_source AS source,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage,
-			COUNT(*) FILTER (WHERE is_unique_page = true AND duration_ms < 5000) AS bounces,
+			COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces,
 			CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration
 		FROM views
 		WHERE `)
@@ -119,7 +119,7 @@ func (c *Client) GetWebsiteUTMMediumsSummary(ctx context.Context, filter *db.Fil
 	// VisitorsPercentage is the percentage the utm medium contributes to the total unique visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -127,7 +127,7 @@ func (c *Client) GetWebsiteUTMMediumsSummary(ctx context.Context, filter *db.Fil
 		)
 		SELECT
 			utm_medium AS medium,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage
 		FROM views
 		WHERE `)
@@ -167,7 +167,7 @@ func (c *Client) GetWebsiteUTMMediums(ctx context.Context, filter *db.Filters) (
 	// VisitorsPercentage is the percentage the utm medium contributes to the total unique visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -175,9 +175,9 @@ func (c *Client) GetWebsiteUTMMediums(ctx context.Context, filter *db.Filters) (
 		)
 		SELECT
 			utm_medium AS medium,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage,
-			COUNT(*) FILTER (WHERE is_unique_page = true AND duration_ms < 5000) AS bounces,
+			COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces,
 			CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration
 		FROM views
 		WHERE `)
@@ -216,7 +216,7 @@ func (c *Client) GetWebsiteUTMCampaignsSummary(ctx context.Context, filter *db.F
 	// VisitorsPercentage is the percentage the utm campaign contributes to the total unique visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -224,7 +224,7 @@ func (c *Client) GetWebsiteUTMCampaignsSummary(ctx context.Context, filter *db.F
 		)
 		SELECT
 			utm_campaign AS campaign,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage
 		FROM views
 		WHERE `)
@@ -264,7 +264,7 @@ func (c *Client) GetWebsiteUTMCampaigns(ctx context.Context, filter *db.Filters)
 	// VisitorsPercentage is the percentage the utm campaign contributes to the total unique visitors.
 	query.WriteString(`--sql
 		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_page = true) AS total_visitors
+			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
 			FROM views
 			WHERE `)
 	query.WriteString(filter.WhereString())
@@ -272,9 +272,9 @@ func (c *Client) GetWebsiteUTMCampaigns(ctx context.Context, filter *db.Filters)
 		)
 		SELECT
 			utm_campaign AS campaign,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
+			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
 			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage,
-			COUNT(*) FILTER (WHERE is_unique_page = true AND duration_ms < 5000) AS bounces,
+			COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces,
 			CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration
 		FROM views
 		WHERE `)


### PR DESCRIPTION
This updates some queries to measure per unique visitor, instead of per unique visitor per page as it seemed incorrect for Browsers, OS, Devices to return a page count instead of a unique visitor count.