### PR TITLE
fix(core): omit trailing slash from pathname

### DIFF
--- a/core/services/event.go
+++ b/core/services/event.go
@@ -88,6 +88,11 @@ func (h *Handler) PostEventHit(ctx context.Context, req api.EventHit, params api
 	case api.EventLoadEventHit:
 		hostname := req.EventLoad.U.Hostname()
 		pathname := req.EventLoad.U.Path
+		// Remove trailing slash if it exists
+		if pathname != "/" {
+			pathname = strings.TrimSuffix(pathname, "/")
+		}
+
 		log = log.With().Str("hostname", hostname).Logger()
 
 		// Verify hostname exists


### PR DESCRIPTION
URLs with trailing slashes were considered different from ones without, skewing stats in certain cases.