### PR TITLE
fix(dashboard): incorrect formatting to some tooltip values

### DIFF
--- a/dashboard/app/components/stats/StatsHeader.tsx
+++ b/dashboard/app/components/stats/StatsHeader.tsx
@@ -50,15 +50,18 @@ const formatTooltipLabel = (
 	if (stat.previous === undefined || status === 'zero')
 		return 'No change since yesterday.';
 
+	let changeValue: string | number = Math.abs(stat.current - stat.previous);
+
 	const isPercentage = stat.chart === 'bounces';
 	const isDuration = stat.chart === 'duration';
 
-	// Rely on Intl.NumberFormat to format the values according to the user's locale
-	const changeValue = isPercentage
-		? `${Math.abs(stat.current - stat.previous).toFixed(2)}%`
-		: isDuration
-			? formatDuration(Math.abs(stat.current - stat.previous))
-			: Math.abs(stat.current - stat.previous);
+	if (isPercentage) {
+		changeValue = formatPercentage(changeValue);
+	}
+
+	if (isDuration) {
+		changeValue = formatDuration(Number(changeValue));
+	}
 
 	return status === 'positive'
 		? `Increased by ${changeValue} since yesterday.`

--- a/dashboard/app/components/stats/formatter.ts
+++ b/dashboard/app/components/stats/formatter.ts
@@ -19,7 +19,7 @@ const percentFormatter: Formatter = Intl.NumberFormat(languages, {
 // Convert duration in milliseconds to a human readable format
 export const formatDuration: Formatter = (durationMs = 0) => {
 	if (durationMs === 0) {
-		return 'N/A';
+		return '0s';
 	}
 
 	const totalSeconds = Math.floor(durationMs / 1000);
@@ -33,11 +33,7 @@ export const formatDuration: Formatter = (durationMs = 0) => {
 	}
 
 	if (minutes === 0) {
-		if (seconds === 0) {
-			return '0s';
-		}
-
-		if (seconds < 1) {
+		if (milliseconds < 1000) {
 			return `0.${Math.floor(milliseconds / 100)}s`;
 		}
 


### PR DESCRIPTION
The percentage differences for some chart tooltips were completely incorrect. We only need to show differences in the tooltips, so we don't need anything complicated.