### PR TITLE
fix: update time queries to be more consistent

### DIFF
--- a/core/api/oas_json_gen.go
+++ b/core/api/oas_json_gen.go
@@ -4037,6 +4037,12 @@ func (s *StatsTimeItem) encodeFields(e *jx.Encoder) {
 		e.Str(s.Path)
 	}
 	{
+		if s.Visitors.Set {
+			e.FieldStart("visitors")
+			s.Visitors.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("duration")
 		e.Int(s.Duration)
 	}
@@ -4056,21 +4062,15 @@ func (s *StatsTimeItem) encodeFields(e *jx.Encoder) {
 		e.FieldStart("duration_percentage")
 		e.Float32(s.DurationPercentage)
 	}
-	{
-		if s.Visitors.Set {
-			e.FieldStart("visitors")
-			s.Visitors.Encode(e)
-		}
-	}
 }
 
 var jsonFieldsNameOfStatsTimeItem = [6]string{
 	0: "path",
-	1: "duration",
-	2: "duration_upper_quartile",
-	3: "duration_lower_quartile",
-	4: "duration_percentage",
-	5: "visitors",
+	1: "visitors",
+	2: "duration",
+	3: "duration_upper_quartile",
+	4: "duration_lower_quartile",
+	5: "duration_percentage",
 }
 
 // Decode decodes StatsTimeItem from json.
@@ -4094,8 +4094,18 @@ func (s *StatsTimeItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"path\"")
 			}
+		case "visitors":
+			if err := func() error {
+				s.Visitors.Reset()
+				if err := s.Visitors.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"visitors\"")
+			}
 		case "duration":
-			requiredBitSet[0] |= 1 << 1
+			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
 				v, err := d.Int()
 				s.Duration = int(v)
@@ -4127,7 +4137,7 @@ func (s *StatsTimeItem) Decode(d *jx.Decoder) error {
 				return errors.Wrap(err, "decode field \"duration_lower_quartile\"")
 			}
 		case "duration_percentage":
-			requiredBitSet[0] |= 1 << 4
+			requiredBitSet[0] |= 1 << 5
 			if err := func() error {
 				v, err := d.Float32()
 				s.DurationPercentage = float32(v)
@@ -4137,16 +4147,6 @@ func (s *StatsTimeItem) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"duration_percentage\"")
-			}
-		case "visitors":
-			if err := func() error {
-				s.Visitors.Reset()
-				if err := s.Visitors.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"visitors\"")
 			}
 		default:
 			return d.Skip()
@@ -4158,7 +4158,7 @@ func (s *StatsTimeItem) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00010011,
+		0b00100101,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/core/api/oas_json_gen.go
+++ b/core/api/oas_json_gen.go
@@ -4062,22 +4062,15 @@ func (s *StatsTimeItem) encodeFields(e *jx.Encoder) {
 			s.Visitors.Encode(e)
 		}
 	}
-	{
-		if s.Bounces.Set {
-			e.FieldStart("bounces")
-			s.Bounces.Encode(e)
-		}
-	}
 }
 
-var jsonFieldsNameOfStatsTimeItem = [7]string{
+var jsonFieldsNameOfStatsTimeItem = [6]string{
 	0: "path",
 	1: "duration",
 	2: "duration_upper_quartile",
 	3: "duration_lower_quartile",
 	4: "duration_percentage",
 	5: "visitors",
-	6: "bounces",
 }
 
 // Decode decodes StatsTimeItem from json.
@@ -4154,16 +4147,6 @@ func (s *StatsTimeItem) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"visitors\"")
-			}
-		case "bounces":
-			if err := func() error {
-				s.Bounces.Reset()
-				if err := s.Bounces.Decode(d); err != nil {
-					return err
-				}
-				return nil
-			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
 			}
 		default:
 			return d.Skip()

--- a/core/api/oas_schemas_gen.go
+++ b/core/api/oas_schemas_gen.go
@@ -1950,6 +1950,8 @@ func (*StatsTime) getWebsiteIDTimeRes() {}
 type StatsTimeItem struct {
 	// Pathname of the page.
 	Path string `json:"path"`
+	// Number of unique visitors for given page.
+	Visitors OptInt `json:"visitors"`
 	// Median time spent on page in milliseconds.
 	Duration int `json:"duration"`
 	// Total time spent on page in milliseconds for the upper quartile (75%).
@@ -1958,13 +1960,16 @@ type StatsTimeItem struct {
 	DurationLowerQuartile OptInt `json:"duration_lower_quartile"`
 	// Percentage of time contributing to the total time spent on the website.
 	DurationPercentage float32 `json:"duration_percentage"`
-	// Number of unique visitors for given page.
-	Visitors OptInt `json:"visitors"`
 }
 
 // GetPath returns the value of Path.
 func (s *StatsTimeItem) GetPath() string {
 	return s.Path
+}
+
+// GetVisitors returns the value of Visitors.
+func (s *StatsTimeItem) GetVisitors() OptInt {
+	return s.Visitors
 }
 
 // GetDuration returns the value of Duration.
@@ -1987,14 +1992,14 @@ func (s *StatsTimeItem) GetDurationPercentage() float32 {
 	return s.DurationPercentage
 }
 
-// GetVisitors returns the value of Visitors.
-func (s *StatsTimeItem) GetVisitors() OptInt {
-	return s.Visitors
-}
-
 // SetPath sets the value of Path.
 func (s *StatsTimeItem) SetPath(val string) {
 	s.Path = val
+}
+
+// SetVisitors sets the value of Visitors.
+func (s *StatsTimeItem) SetVisitors(val OptInt) {
+	s.Visitors = val
 }
 
 // SetDuration sets the value of Duration.
@@ -2015,11 +2020,6 @@ func (s *StatsTimeItem) SetDurationLowerQuartile(val OptInt) {
 // SetDurationPercentage sets the value of DurationPercentage.
 func (s *StatsTimeItem) SetDurationPercentage(val float32) {
 	s.DurationPercentage = val
-}
-
-// SetVisitors sets the value of Visitors.
-func (s *StatsTimeItem) SetVisitors(val OptInt) {
-	s.Visitors = val
 }
 
 type StatsUTMCampaigns []StatsUTMCampaignsItem

--- a/core/api/oas_schemas_gen.go
+++ b/core/api/oas_schemas_gen.go
@@ -1960,8 +1960,6 @@ type StatsTimeItem struct {
 	DurationPercentage float32 `json:"duration_percentage"`
 	// Number of unique visitors for given page.
 	Visitors OptInt `json:"visitors"`
-	// Number of bounces.
-	Bounces OptInt `json:"bounces"`
 }
 
 // GetPath returns the value of Path.
@@ -1994,11 +1992,6 @@ func (s *StatsTimeItem) GetVisitors() OptInt {
 	return s.Visitors
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsTimeItem) GetBounces() OptInt {
-	return s.Bounces
-}
-
 // SetPath sets the value of Path.
 func (s *StatsTimeItem) SetPath(val string) {
 	s.Path = val
@@ -2027,11 +2020,6 @@ func (s *StatsTimeItem) SetDurationPercentage(val float32) {
 // SetVisitors sets the value of Visitors.
 func (s *StatsTimeItem) SetVisitors(val OptInt) {
 	s.Visitors = val
-}
-
-// SetBounces sets the value of Bounces.
-func (s *StatsTimeItem) SetBounces(val OptInt) {
-	s.Bounces = val
 }
 
 type StatsUTMCampaigns []StatsUTMCampaignsItem

--- a/core/db/duckdb/__snapshots__/time_test.snap
+++ b/core/db/duckdb/__snapshots__/time_test.snap
@@ -1,33 +1,33 @@
 
 [TestGetWebsiteTime/Base - 1]
 RECORDS:
-&{StatsTimeSummary:{Pathname:/about Duration:5002 DurationPercentage:33.33} DurationUpperQuartile:7496 DurationLowerQuartile:2493 Pageviews:0 Visitors:166895 Bounces:41828}
-&{StatsTimeSummary:{Pathname:/ Duration:5008 DurationPercentage:33.37} DurationUpperQuartile:7492 DurationLowerQuartile:2490 Pageviews:0 Visitors:166610 Bounces:41647}
-&{StatsTimeSummary:{Pathname:/contact Duration:4998 DurationPercentage:33.3} DurationUpperQuartile:7498 DurationLowerQuartile:2509 Pageviews:0 Visitors:166353 Bounces:41779}
+&{StatsTimeSummary:{Pathname:/about Duration:5002 DurationPercentage:0.3326} DurationUpperQuartile:7496 DurationLowerQuartile:2493 Pageviews:0 Visitors:166895}
+&{StatsTimeSummary:{Pathname:/ Duration:5008 DurationPercentage:0.3336} DurationUpperQuartile:7492 DurationLowerQuartile:2490 Pageviews:0 Visitors:166610}
+&{StatsTimeSummary:{Pathname:/contact Duration:4998 DurationPercentage:0.3337} DurationUpperQuartile:7498 DurationLowerQuartile:2509 Pageviews:0 Visitors:166353}
 
 ---
 
 [TestGetWebsiteTime/Browser - 1]
 RECORDS:
-&{StatsTimeSummary:{Pathname:/about Duration:5000 DurationPercentage:33.47} DurationUpperQuartile:7489 DurationLowerQuartile:2473 Pageviews:0 Visitors:55789 Bounces:13969}
-&{StatsTimeSummary:{Pathname:/ Duration:4983 DurationPercentage:33.36} DurationUpperQuartile:7476 DurationLowerQuartile:2458 Pageviews:0 Visitors:55260 Bounces:13995}
-&{StatsTimeSummary:{Pathname:/contact Duration:4956 DurationPercentage:33.17} DurationUpperQuartile:7465 DurationLowerQuartile:2500 Pageviews:0 Visitors:55121 Bounces:14002}
+&{StatsTimeSummary:{Pathname:/about Duration:5000 DurationPercentage:0.3336} DurationUpperQuartile:7489 DurationLowerQuartile:2473 Pageviews:0 Visitors:55789}
+&{StatsTimeSummary:{Pathname:/ Duration:4983 DurationPercentage:0.3327} DurationUpperQuartile:7476 DurationLowerQuartile:2458 Pageviews:0 Visitors:55260}
+&{StatsTimeSummary:{Pathname:/contact Duration:4956 DurationPercentage:0.3337} DurationUpperQuartile:7465 DurationLowerQuartile:2500 Pageviews:0 Visitors:55121}
 
 ---
 
 [TestGetWebsiteTime/Country - 1]
 RECORDS:
-&{StatsTimeSummary:{Pathname:/ Duration:5041 DurationPercentage:33.67} DurationUpperQuartile:7486 DurationLowerQuartile:2511 Pageviews:0 Visitors:18558 Bounces:4632}
-&{StatsTimeSummary:{Pathname:/about Duration:4975 DurationPercentage:33.22} DurationUpperQuartile:7459 DurationLowerQuartile:2446 Pageviews:0 Visitors:18499 Bounces:4608}
-&{StatsTimeSummary:{Pathname:/contact Duration:4958 DurationPercentage:33.11} DurationUpperQuartile:7461 DurationLowerQuartile:2544 Pageviews:0 Visitors:18311 Bounces:4627}
+&{StatsTimeSummary:{Pathname:/ Duration:5041 DurationPercentage:0.3346} DurationUpperQuartile:7486 DurationLowerQuartile:2511 Pageviews:0 Visitors:18558}
+&{StatsTimeSummary:{Pathname:/about Duration:4975 DurationPercentage:0.33} DurationUpperQuartile:7459 DurationLowerQuartile:2446 Pageviews:0 Visitors:18499}
+&{StatsTimeSummary:{Pathname:/contact Duration:4958 DurationPercentage:0.3354} DurationUpperQuartile:7461 DurationLowerQuartile:2544 Pageviews:0 Visitors:18311}
 
 ---
 
 [TestGetWebsiteTime/Device - 1]
 RECORDS:
-&{StatsTimeSummary:{Pathname:/ Duration:5107 DurationPercentage:34.09} DurationUpperQuartile:7535 DurationLowerQuartile:2559 Pageviews:0 Visitors:6305 Bounces:1534}
-&{StatsTimeSummary:{Pathname:/about Duration:4981 DurationPercentage:33.25} DurationUpperQuartile:7422 DurationLowerQuartile:2374 Pageviews:0 Visitors:6164 Bounces:1534}
-&{StatsTimeSummary:{Pathname:/contact Duration:4894 DurationPercentage:32.67} DurationUpperQuartile:7460 DurationLowerQuartile:2545 Pageviews:0 Visitors:6124 Bounces:1594}
+&{StatsTimeSummary:{Pathname:/ Duration:5107 DurationPercentage:0.3384} DurationUpperQuartile:7535 DurationLowerQuartile:2559 Pageviews:0 Visitors:6305}
+&{StatsTimeSummary:{Pathname:/about Duration:4981 DurationPercentage:0.3274} DurationUpperQuartile:7422 DurationLowerQuartile:2374 Pageviews:0 Visitors:6164}
+&{StatsTimeSummary:{Pathname:/contact Duration:4894 DurationPercentage:0.3342} DurationUpperQuartile:7460 DurationLowerQuartile:2545 Pageviews:0 Visitors:6124}
 
 ---
 
@@ -38,79 +38,79 @@ RECORDS:
 
 [TestGetWebsiteTime/Language - 1]
 RECORDS:
-&{StatsTimeSummary:{Pathname:/ Duration:5145 DurationPercentage:34.4} DurationUpperQuartile:7523 DurationLowerQuartile:2607 Pageviews:0 Visitors:3230 Bounces:764}
-&{StatsTimeSummary:{Pathname:/about Duration:4936 DurationPercentage:33.01} DurationUpperQuartile:7388 DurationLowerQuartile:2390 Pageviews:0 Visitors:3075 Bounces:786}
-&{StatsTimeSummary:{Pathname:/contact Duration:4874 DurationPercentage:32.59} DurationUpperQuartile:7434 DurationLowerQuartile:2672 Pageviews:0 Visitors:3073 Bounces:789}
+&{StatsTimeSummary:{Pathname:/ Duration:5145 DurationPercentage:0.3397} DurationUpperQuartile:7523 DurationLowerQuartile:2607 Pageviews:0 Visitors:3230}
+&{StatsTimeSummary:{Pathname:/about Duration:4936 DurationPercentage:0.3288} DurationUpperQuartile:7388 DurationLowerQuartile:2390 Pageviews:0 Visitors:3075}
+&{StatsTimeSummary:{Pathname:/contact Duration:4874 DurationPercentage:0.3315} DurationUpperQuartile:7434 DurationLowerQuartile:2672 Pageviews:0 Visitors:3073}
 
 ---
 
 [TestGetWebsiteTime/OS - 1]
 RECORDS:
-&{StatsTimeSummary:{Pathname:/ Duration:5098 DurationPercentage:34.29} DurationUpperQuartile:7503 DurationLowerQuartile:2572 Pageviews:0 Visitors:1073 Bounces:260}
-&{StatsTimeSummary:{Pathname:/about Duration:4845 DurationPercentage:32.59} DurationUpperQuartile:7325 DurationLowerQuartile:2388 Pageviews:0 Visitors:1068 Bounces:283}
-&{StatsTimeSummary:{Pathname:/contact Duration:4924 DurationPercentage:33.12} DurationUpperQuartile:7435 DurationLowerQuartile:2797 Pageviews:0 Visitors:944 Bounces:243}
+&{StatsTimeSummary:{Pathname:/ Duration:5098 DurationPercentage:0.349} DurationUpperQuartile:7503 DurationLowerQuartile:2572 Pageviews:0 Visitors:1073}
+&{StatsTimeSummary:{Pathname:/about Duration:4845 DurationPercentage:0.3289} DurationUpperQuartile:7325 DurationLowerQuartile:2388 Pageviews:0 Visitors:1068}
+&{StatsTimeSummary:{Pathname:/contact Duration:4924 DurationPercentage:0.3221} DurationUpperQuartile:7435 DurationLowerQuartile:2797 Pageviews:0 Visitors:944}
 
 ---
 
 [TestGetWebsiteTime/Pathname - 1]
 RECORDS:
-&{StatsTimeSummary:{Pathname:/ Duration:5098 DurationPercentage:100} DurationUpperQuartile:7503 DurationLowerQuartile:2572 Pageviews:0 Visitors:1073 Bounces:260}
+&{StatsTimeSummary:{Pathname:/ Duration:5098 DurationPercentage:1} DurationUpperQuartile:7503 DurationLowerQuartile:2572 Pageviews:0 Visitors:1073}
 
 ---
 
 [TestGetWebsiteTime/Referrer - 1]
 RECORDS:
-&{StatsTimeSummary:{Pathname:/ Duration:4728 DurationPercentage:100} DurationUpperQuartile:7404 DurationLowerQuartile:2293 Pageviews:0 Visitors:359 Bounces:91}
+&{StatsTimeSummary:{Pathname:/ Duration:4728 DurationPercentage:1} DurationUpperQuartile:7404 DurationLowerQuartile:2293 Pageviews:0 Visitors:359}
 
 ---
 
 [TestGetWebsiteTime/UTMCampaign - 1]
 RECORDS:
-&{StatsTimeSummary:{Pathname:/ Duration:4732 DurationPercentage:100} DurationUpperQuartile:7502 DurationLowerQuartile:2291 Pageviews:0 Visitors:110 Bounces:25}
+&{StatsTimeSummary:{Pathname:/ Duration:4732 DurationPercentage:1} DurationUpperQuartile:7502 DurationLowerQuartile:2291 Pageviews:0 Visitors:110}
 
 ---
 
 [TestGetWebsiteTime/UTMMedium - 1]
 RECORDS:
-&{StatsTimeSummary:{Pathname:/ Duration:6547 DurationPercentage:100} DurationUpperQuartile:8733 DurationLowerQuartile:2558 Pageviews:0 Visitors:36 Bounces:5}
+&{StatsTimeSummary:{Pathname:/ Duration:6547 DurationPercentage:1} DurationUpperQuartile:8733 DurationLowerQuartile:2558 Pageviews:0 Visitors:36}
 
 ---
 
 [TestGetWebsiteTime/UTMSource - 1]
 RECORDS:
-&{StatsTimeSummary:{Pathname:/ Duration:3389 DurationPercentage:100} DurationUpperQuartile:6698 DurationLowerQuartile:2220 Pageviews:0 Visitors:16 Bounces:2}
+&{StatsTimeSummary:{Pathname:/ Duration:3389 DurationPercentage:1} DurationUpperQuartile:6698 DurationLowerQuartile:2220 Pageviews:0 Visitors:16}
 
 ---
 
 [TestGetWebsiteTimeSummary/Base - 1]
 RECORDS:
-&{Pathname:/about Duration:5002 DurationPercentage:0.3333}
-&{Pathname:/ Duration:5008 DurationPercentage:0.3337}
-&{Pathname:/contact Duration:4998 DurationPercentage:0.333}
+&{Pathname:/contact Duration:4998 DurationPercentage:0.3337}
+&{Pathname:/ Duration:5008 DurationPercentage:0.3336}
+&{Pathname:/about Duration:5002 DurationPercentage:0.3326}
 
 ---
 
 [TestGetWebsiteTimeSummary/Browser - 1]
 RECORDS:
-&{Pathname:/about Duration:5000 DurationPercentage:0.3347}
-&{Pathname:/ Duration:4983 DurationPercentage:0.3336}
-&{Pathname:/contact Duration:4956 DurationPercentage:0.3317}
+&{Pathname:/contact Duration:4956 DurationPercentage:0.3337}
+&{Pathname:/about Duration:5000 DurationPercentage:0.3336}
+&{Pathname:/ Duration:4983 DurationPercentage:0.3327}
 
 ---
 
 [TestGetWebsiteTimeSummary/Country - 1]
 RECORDS:
-&{Pathname:/ Duration:5041 DurationPercentage:0.3367}
-&{Pathname:/about Duration:4975 DurationPercentage:0.3322}
-&{Pathname:/contact Duration:4958 DurationPercentage:0.3311}
+&{Pathname:/contact Duration:4958 DurationPercentage:0.3354}
+&{Pathname:/ Duration:5041 DurationPercentage:0.3346}
+&{Pathname:/about Duration:4975 DurationPercentage:0.33}
 
 ---
 
 [TestGetWebsiteTimeSummary/Device - 1]
 RECORDS:
-&{Pathname:/ Duration:5107 DurationPercentage:0.3409}
-&{Pathname:/about Duration:4981 DurationPercentage:0.3325}
-&{Pathname:/contact Duration:4894 DurationPercentage:0.3267}
+&{Pathname:/ Duration:5107 DurationPercentage:0.3384}
+&{Pathname:/contact Duration:4894 DurationPercentage:0.3342}
+&{Pathname:/about Duration:4981 DurationPercentage:0.3274}
 
 ---
 
@@ -121,17 +121,17 @@ RECORDS:
 
 [TestGetWebsiteTimeSummary/Language - 1]
 RECORDS:
-&{Pathname:/ Duration:5145 DurationPercentage:0.344}
-&{Pathname:/about Duration:4936 DurationPercentage:0.3301}
-&{Pathname:/contact Duration:4874 DurationPercentage:0.3259}
+&{Pathname:/ Duration:5145 DurationPercentage:0.3397}
+&{Pathname:/contact Duration:4874 DurationPercentage:0.3315}
+&{Pathname:/about Duration:4936 DurationPercentage:0.3288}
 
 ---
 
 [TestGetWebsiteTimeSummary/OS - 1]
 RECORDS:
-&{Pathname:/ Duration:5098 DurationPercentage:0.3429}
-&{Pathname:/about Duration:4845 DurationPercentage:0.3259}
-&{Pathname:/contact Duration:4924 DurationPercentage:0.3312}
+&{Pathname:/ Duration:5098 DurationPercentage:0.349}
+&{Pathname:/about Duration:4845 DurationPercentage:0.3289}
+&{Pathname:/contact Duration:4924 DurationPercentage:0.3221}
 
 ---
 

--- a/core/db/duckdb/time.go
+++ b/core/db/duckdb/time.go
@@ -38,9 +38,9 @@ func (c *Client) GetWebsiteTimeSummary(ctx context.Context, filter *db.Filters) 
 		SELECT
 			pathname,
 			duration,
-			ifnull(ROUND(total_duration / (SELECT SUM(total_duration) FROM durations) * 100.0, 4), 0) AS duration_percentage
+			ifnull(ROUND(total_duration / (SELECT SUM(total_duration) FROM durations), 4), 0) AS duration_percentage
 		FROM durations
-		ORDER BY visitors DESC, duration DESC, pathname ASC`)
+		ORDER BY duration_percentage DESC, duration DESC, visitors DESC, pathname ASC`)
 
 	rows, err := c.NamedQueryContext(ctx, query.String(), filter.Args(nil))
 	if err != nil {
@@ -99,7 +99,7 @@ func (c *Client) GetWebsiteTime(ctx context.Context, filter *db.Filters) ([]*mod
 			duration,
 			duration_upper_quartile,
 			duration_lower_quartile,
-			ifnull(ROUND(total_duration / (SELECT SUM(total_duration) FROM durations) * 100.0, 4), 0) AS duration_percentage,
+			ifnull(ROUND(total_duration / (SELECT SUM(total_duration) FROM durations), 4), 0) AS duration_percentage,
 			visitors
 		FROM durations
 		ORDER BY visitors DESC, duration DESC, pathname ASC`)

--- a/core/db/duckdb/time.go
+++ b/core/db/duckdb/time.go
@@ -26,18 +26,19 @@ func (c *Client) GetWebsiteTimeSummary(ctx context.Context, filter *db.Filters) 
 		SELECT
 			pathname,
 			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
-			CAST(ifnull(quantile_cont(duration_ms, 0.5), 0) AS INTEGER) AS duration
+			CAST(ifnull(quantile_cont(duration_ms, 0.5), 0) AS INTEGER) AS duration,
+			SUM(duration_ms) AS total_duration
 		FROM views
 		WHERE `)
 	query.WriteString(filter.WhereString())
-	query.WriteString(` GROUP BY pathname HAVING duration > 0`)
+	query.WriteString(` GROUP BY pathname HAVING duration > 0 AND visitors >= 3`)
 	query.WriteString(filter.PaginationString())
 	query.WriteString(`)`)
 	query.WriteString(`--sql
 		SELECT
 			pathname,
 			duration,
-			ifnull(ROUND(duration / (SELECT SUM(duration) FROM durations), 4), 0) AS duration_percentage
+			ifnull(ROUND(total_duration / (SELECT SUM(total_duration) FROM durations) * 100.0, 4), 0) AS duration_percentage
 		FROM durations
 		ORDER BY visitors DESC, duration DESC, pathname ASC`)
 
@@ -77,8 +78,6 @@ func (c *Client) GetWebsiteTime(ctx context.Context, filter *db.Filters) ([]*mod
 	// DurationPercentage is the percentage the pathname contributes to the total duration.
 	//
 	// Visitors is the total number of unique visitors for the page.
-	//
-	// Bounces is the total number of bounces for the page.
 	query.WriteString(`--sql
 		WITH durations AS MATERIALIZED (
 		SELECT
@@ -87,11 +86,11 @@ func (c *Client) GetWebsiteTime(ctx context.Context, filter *db.Filters) ([]*mod
 			CAST(ifnull(quantile_cont(duration_ms, 0.75), 0) AS INTEGER) AS duration_upper_quartile,
 			CAST(ifnull(quantile_cont(duration_ms, 0.25), 0) AS INTEGER) AS duration_lower_quartile,
 			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
-			COUNT(*) FILTER (WHERE is_unique_page = true AND duration_ms < 5000) AS bounces
+			SUM(duration_ms) AS total_duration
 		FROM views
 		WHERE `)
 	query.WriteString(filter.WhereString())
-	query.WriteString(` GROUP BY pathname HAVING duration > 0`)
+	query.WriteString(` GROUP BY pathname HAVING duration > 0 AND duration_lower_quartile > 0 AND visitors >= 3`)
 	query.WriteString(filter.PaginationString())
 	query.WriteString(`)`)
 	query.WriteString(`--sql
@@ -100,9 +99,8 @@ func (c *Client) GetWebsiteTime(ctx context.Context, filter *db.Filters) ([]*mod
 			duration,
 			duration_upper_quartile,
 			duration_lower_quartile,
-			ifnull(ROUND(duration * 100.0 / (SELECT SUM(duration) FROM durations), 2), 0) AS duration_percentage,
-			visitors,
-			bounces
+			ifnull(ROUND(total_duration / (SELECT SUM(total_duration) FROM durations) * 100.0, 4), 0) AS duration_percentage,
+			visitors
 		FROM durations
 		ORDER BY visitors DESC, duration DESC, pathname ASC`)
 

--- a/core/model/stats.go
+++ b/core/model/stats.go
@@ -57,7 +57,6 @@ type StatsTime struct {
 	DurationLowerQuartile int `db:"duration_lower_quartile"`
 	Pageviews             int `db:"pageviews"`
 	Visitors              int `db:"visitors"`
-	Bounces               int `db:"bounces"`
 }
 
 type StatsReferrerSummary struct {

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -1567,6 +1567,9 @@ components:
           path:
             type: string
             description: Pathname of the page.
+          visitors:
+            type: integer
+            description: Number of unique visitors for given page.
           duration:
             type: integer
             description: Median time spent on page in milliseconds.
@@ -1580,12 +1583,6 @@ components:
             type: number
             description: Percentage of time contributing to the total time spent on the website.
             format: float
-          visitors:
-            type: integer
-            description: Number of unique visitors for given page.
-          bounces:
-            type: integer
-            description: Number of bounces.
         required:
           - path
           - duration

--- a/core/services/stats.go
+++ b/core/services/stats.go
@@ -277,7 +277,6 @@ func (h *Handler) GetWebsiteIDTime(ctx context.Context, params api.GetWebsiteIDT
 				DurationPercentage:    page.DurationPercentage,
 				DurationUpperQuartile: api.NewOptInt(page.DurationUpperQuartile),
 				DurationLowerQuartile: api.NewOptInt(page.DurationLowerQuartile),
-				Bounces:               api.NewOptInt(page.Bounces),
 				Visitors:              api.NewOptInt(page.Visitors),
 			})
 		}

--- a/dashboard/app/api/types.d.ts
+++ b/dashboard/app/api/types.d.ts
@@ -342,6 +342,8 @@ export interface components {
     StatsTime: {
         /** @description Pathname of the page. */
         path: string;
+        /** @description Number of unique visitors for given page. */
+        visitors?: number;
         /** @description Median time spent on page in milliseconds. */
         duration: number;
         /** @description Total time spent on page in milliseconds for the upper quartile (75%). */
@@ -353,8 +355,6 @@ export interface components {
          * @description Percentage of time contributing to the total time spent on the website.
          */
         duration_percentage: number;
-        /** @description Number of unique visitors for given page. */
-        visitors?: number;
       }[];
     /** StatsReferrers */
     StatsReferrers: {

--- a/dashboard/app/api/types.d.ts
+++ b/dashboard/app/api/types.d.ts
@@ -355,8 +355,6 @@ export interface components {
         duration_percentage: number;
         /** @description Number of unique visitors for given page. */
         visitors?: number;
-        /** @description Number of bounces. */
-        bounces?: number;
       }[];
     /** StatsReferrers */
     StatsReferrers: {

--- a/dashboard/app/components/stats/StatsDisplay.module.css
+++ b/dashboard/app/components/stats/StatsDisplay.module.css
@@ -29,29 +29,6 @@
 	}
 }
 
-.stat-item {
-	height: 50px;
-	margin: 6px 8px;
-	padding: 7px 16px;
-	width: calc(100% - 16px);
-
-	border-radius: 8px;
-
-	cursor: pointer;
-
-	&:last-child {
-		margin-bottom: 0;
-	}
-
-	&:hover {
-		background-color: var(--me-color-bg-grey);
-	}
-}
-
-.bar {
-	border: 1px solid var(--me-color-border-violet);
-}
-
 .more {
 	width: 100%;
 	padding: 8px 16px;

--- a/dashboard/app/components/stats/StatsHeader.tsx
+++ b/dashboard/app/components/stats/StatsHeader.tsx
@@ -51,15 +51,11 @@ const formatTooltipLabel = (
 		return 'No change since yesterday.';
 
 	let changeValue: string | number = Math.abs(stat.current - stat.previous);
-
-	const isPercentage = stat.chart === 'bounces';
-	const isDuration = stat.chart === 'duration';
-
-	if (isPercentage) {
+	if (stat.chart === 'bounces') {
 		changeValue = formatPercentage(changeValue);
 	}
 
-	if (isDuration) {
+	if (stat.chart === 'duration') {
 		changeValue = formatDuration(Number(changeValue));
 	}
 

--- a/dashboard/app/components/stats/StatsItem.module.css
+++ b/dashboard/app/components/stats/StatsItem.module.css
@@ -1,0 +1,31 @@
+.item {
+	height: 50px;
+	margin: 6px 8px;
+	padding: 7px 16px;
+	width: calc(100% - 16px);
+
+	border-radius: 8px;
+
+	cursor: pointer;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+
+	&:hover {
+		background-color: var(--me-color-bg-grey);
+	}
+
+	span {
+		opacity: 0;
+		transition: 0.07s;
+
+		&[data-active="true"] {
+			opacity: 1;
+		}
+	}
+}
+
+.bar {
+	border: 1px solid var(--me-color-border-violet);
+}

--- a/dashboard/app/components/stats/StatsItem.tsx
+++ b/dashboard/app/components/stats/StatsItem.tsx
@@ -1,9 +1,11 @@
 import { Group, Text, UnstyledButton } from '@mantine/core';
 import { useSearchParams } from '@remix-run/react';
+import { useHover } from '@mantine/hooks';
 
 import React, { useMemo } from 'react';
 import { formatCount, formatDuration } from './formatter';
-import classes from './StatsDisplay.module.css';
+
+import classes from './StatsItem.module.css';
 
 interface StatsItemProps {
 	label: string;
@@ -31,6 +33,7 @@ const StatsItem = ({
 	tab,
 }: StatsItemProps) => {
 	const [searchParams, setSearchParams] = useSearchParams();
+	const { hovered, ref } = useHover<HTMLButtonElement>();
 
 	const formattedValue = useMemo(
 		() => (tab === 'Time' ? formatDuration(count) : formatCount(count)),
@@ -46,17 +49,29 @@ const StatsItem = ({
 
 	return (
 		<UnstyledButton
-			className={classes['stat-item']}
+			className={classes.item}
 			onClick={handleFilter}
 			aria-label={`Filter by ${label}`}
+			ref={ref}
 		>
 			<Group justify="space-between" pb={6}>
 				<Text fz={14} truncate>
 					{label}
 				</Text>
-				<Text fw={600} fz={14}>
-					{formattedValue}
-				</Text>
+				<Group align="center" gap="xs">
+					<Text
+						component="span"
+						fz={12}
+						c="gray"
+						mr={4}
+						data-active={hovered ? 'true' : undefined}
+					>
+						{(percentage * 100).toFixed(1)}%
+					</Text>
+					<Text fw={600} fz={14}>
+						{formattedValue}
+					</Text>
+				</Group>
 			</Group>
 			<div
 				className={classes.bar}

--- a/dashboard/app/components/stats/StatsTable.tsx
+++ b/dashboard/app/components/stats/StatsTable.tsx
@@ -70,7 +70,10 @@ type PresetDataKeys =
 	| 'pageviews'
 	| 'pageviews_percentage'
 	| 'bounce_rate'
-	| 'duration';
+	| 'duration'
+	| 'duration_lower_quartile'
+	| 'duration_upper_quartile'
+	| 'duration_percentage';
 
 const PRESET_COLUMNS: Record<PresetDataKeys, DataTableColumn<DataRow>> = {
 	path: { accessor: 'path', title: 'Path', width: '100%' },
@@ -102,6 +105,25 @@ const PRESET_COLUMNS: Record<PresetDataKeys, DataTableColumn<DataRow>> = {
 		title: 'Duration',
 		sortable: true,
 		render: (record) => formatDuration(record.duration ?? 0),
+	},
+	duration_lower_quartile: {
+		accessor: 'duration_lower_quartile',
+		title: 'Q1 (25%)',
+		sortable: true,
+		render: (record) => formatDuration(record.duration_lower_quartile ?? 0),
+	},
+	duration_upper_quartile: {
+		accessor: 'duration_upper_quartile',
+		title: 'Q3 (75%)',
+		sortable: true,
+		render: (record) => formatDuration(record.duration_upper_quartile ?? 0),
+	},
+	duration_percentage: {
+		accessor: 'duration_percentage',
+		title: 'Duration %',
+		sortable: true,
+		render: (record) =>
+			formatPercentage((record.duration_percentage ?? 0) / 100),
 	},
 };
 
@@ -268,46 +290,25 @@ const TablePagination = ({
 };
 
 const getColumnsForQuery = (query: QueryType): DataTableColumn<DataRow>[] => {
-	const commonColumns = [
-		PRESET_COLUMNS.visitors,
-		PRESET_COLUMNS.visitors_percentage,
-		PRESET_COLUMNS.bounce_rate,
-		PRESET_COLUMNS.duration,
-	];
-
 	switch (query) {
 		case 'pages':
 			return [
 				PRESET_COLUMNS.path,
-				...commonColumns,
+				PRESET_COLUMNS.visitors,
+				PRESET_COLUMNS.visitors_percentage,
 				PRESET_COLUMNS.pageviews,
 				PRESET_COLUMNS.pageviews_percentage,
+				PRESET_COLUMNS.bounce_rate,
+				PRESET_COLUMNS.duration,
 			];
 		case 'time':
 			return [
 				PRESET_COLUMNS.path,
-				...commonColumns,
-				{
-					accessor: 'duration_lower_quartile',
-					title: 'Q1 (25%)',
-					sortable: true,
-					render: (record) =>
-						formatDuration(record.duration_lower_quartile ?? 0),
-				},
-				{
-					accessor: 'duration_upper_quartile',
-					title: 'Q3 (75%)',
-					sortable: true,
-					render: (record) =>
-						formatDuration(record.duration_upper_quartile ?? 0),
-				},
-				{
-					accessor: 'duration_percentage',
-					title: 'Duration %',
-					sortable: true,
-					render: (record) =>
-						formatPercentage((record.duration_percentage ?? 0) / 100),
-				},
+				PRESET_COLUMNS.visitors,
+				PRESET_COLUMNS.duration,
+				PRESET_COLUMNS.duration_lower_quartile,
+				PRESET_COLUMNS.duration_upper_quartile,
+				PRESET_COLUMNS.duration_percentage,
 			];
 		case 'referrers':
 		case 'sources':
@@ -315,25 +316,32 @@ const getColumnsForQuery = (query: QueryType): DataTableColumn<DataRow>[] => {
 		case 'campaigns':
 			return [
 				{
+					// Referrer, Source, Medium, Campaign
 					accessor: ACCESSOR_MAP[query],
 					title: LABEL_MAP[query].slice(0, -1),
 					width: '100%',
 					render: (record) => record[ACCESSOR_MAP[query]] || 'Direct/None',
 				},
-				...commonColumns,
+				PRESET_COLUMNS.visitors,
+				PRESET_COLUMNS.visitors_percentage,
+				PRESET_COLUMNS.bounce_rate,
+				PRESET_COLUMNS.duration,
 			];
 		case 'browsers':
-
 		case 'devices':
 		case 'languages':
 			return [
 				{
+					// Browser, Device, Language
 					accessor: ACCESSOR_MAP[query],
 					title: LABEL_MAP[query].slice(0, -1),
 					width: '100%',
 					render: (record) => record[ACCESSOR_MAP[query]] || 'Unknown',
 				},
-				...commonColumns,
+				PRESET_COLUMNS.visitors,
+				PRESET_COLUMNS.visitors_percentage,
+				PRESET_COLUMNS.bounce_rate,
+				PRESET_COLUMNS.duration,
 			];
 		case 'os':
 			return [
@@ -343,7 +351,10 @@ const getColumnsForQuery = (query: QueryType): DataTableColumn<DataRow>[] => {
 					width: '100%',
 					render: (record) => record.os || 'Unknown',
 				},
-				...commonColumns,
+				PRESET_COLUMNS.visitors,
+				PRESET_COLUMNS.visitors_percentage,
+				PRESET_COLUMNS.bounce_rate,
+				PRESET_COLUMNS.duration,
 			];
 		case 'countries':
 			return [
@@ -353,7 +364,10 @@ const getColumnsForQuery = (query: QueryType): DataTableColumn<DataRow>[] => {
 					width: '100%',
 					render: (record) => record.country || 'Unknown',
 				},
-				...commonColumns,
+				PRESET_COLUMNS.visitors,
+				PRESET_COLUMNS.visitors_percentage,
+				PRESET_COLUMNS.bounce_rate,
+				PRESET_COLUMNS.duration,
 			];
 		default:
 			throw new Error(`Invalid query: ${query}`);

--- a/dashboard/app/components/stats/StatsTable.tsx
+++ b/dashboard/app/components/stats/StatsTable.tsx
@@ -122,8 +122,7 @@ const PRESET_COLUMNS: Record<PresetDataKeys, DataTableColumn<DataRow>> = {
 		accessor: 'duration_percentage',
 		title: 'Duration %',
 		sortable: true,
-		render: (record) =>
-			formatPercentage((record.duration_percentage ?? 0) / 100),
+		render: (record) => formatPercentage(record.duration_percentage ?? 0),
 	},
 };
 

--- a/dashboard/app/components/stats/formatter.ts
+++ b/dashboard/app/components/stats/formatter.ts
@@ -18,29 +18,19 @@ const percentFormatter: Formatter = Intl.NumberFormat(languages, {
 
 // Convert duration in milliseconds to a human readable format
 export const formatDuration: Formatter = (durationMs = 0) => {
-	if (durationMs === 0) {
-		return '0s';
-	}
+	let milliseconds = durationMs;
+	if (milliseconds === 0 || milliseconds < 50) return 'N/A';
 
-	const totalSeconds = Math.floor(durationMs / 1000);
-	const hours = Math.floor(totalSeconds / 3600);
-	const minutes = Math.floor((totalSeconds % 3600) / 60);
-	const seconds = totalSeconds % 60;
-	const milliseconds = durationMs % 1000;
+	const hours = Math.floor(milliseconds / 3600000);
+	milliseconds %= 3600000;
+	const minutes = Math.floor(milliseconds / 60000);
+	milliseconds %= 60000;
+	const seconds = Math.round(milliseconds / 1000);
 
-	if (hours > 0) {
-		return `${hours}h${minutes}m${seconds}s`;
-	}
-
-	if (minutes === 0) {
-		if (milliseconds < 1000) {
-			return `0.${Math.floor(milliseconds / 100)}s`;
-		}
-
-		return `${seconds}s`;
-	}
-
-	return `${minutes}m${seconds}s`;
+	if (hours > 0) return `${hours}h${minutes}m${seconds}s`;
+	if (minutes > 0) return `${minutes}m${seconds}s`;
+	if (seconds > 0) return `${seconds}s`;
+	return `0.${Math.round(milliseconds / 100)}s`;
 };
 
 // Format percentage value

--- a/dashboard/app/utils/stats.ts
+++ b/dashboard/app/utils/stats.ts
@@ -39,7 +39,7 @@ interface FetchStatsOptions {
 	dataset?: Datasets;
 	limit?: number;
 	isSummary?: boolean;
-	chartStat: string;
+	chartStat?: string;
 }
 
 const isDatasetItem = (value: string): value is DatasetItem =>


### PR DESCRIPTION
Fixes a few incorrect values from existing queries related to time and also polishes the dashboard to handle time inputs more consistently. 

Additionally, the percentage of the bar on the stats homepage now shows on hover!