### PR TITLE
feat(dashboard): select referrer via external button

### DIFF
--- a/dashboard/app/components/icons/external.svg
+++ b/dashboard/app/components/icons/external.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>

--- a/dashboard/app/components/icons/external.tsx
+++ b/dashboard/app/components/icons/external.tsx
@@ -1,0 +1,20 @@
+export const IconExternal = () => {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		>
+			<title>Icon External</title>
+			<path d="M15 3h6v6" />
+			<path d="M10 14 21 3" />
+			<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+		</svg>
+	);
+};

--- a/dashboard/app/components/stats/StatsItem.module.css
+++ b/dashboard/app/components/stats/StatsItem.module.css
@@ -29,3 +29,16 @@
 .bar {
 	border: 1px solid var(--me-color-border-violet);
 }
+
+.external {
+	svg {
+		margin-bottom: -2px;
+		color: var(--me-color-text-muted);
+		width: 17px;
+		height: 17px;
+	}
+
+	&[data-hidden="true"] {
+		display: none;
+	}
+}

--- a/dashboard/app/components/stats/StatsItem.tsx
+++ b/dashboard/app/components/stats/StatsItem.tsx
@@ -1,7 +1,9 @@
 import { Group, Text, UnstyledButton } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import React, { useMemo } from 'react';
+import isFQDN from 'validator/lib/isFQDN';
 
+import { IconExternal } from '@/components/icons/external';
 import { useFilter } from '@/hooks/use-filter';
 
 import { formatCount, formatDuration } from './formatter';
@@ -55,9 +57,23 @@ const StatsItem = ({
 			ref={ref}
 		>
 			<Group justify="space-between" pb={6} wrap="nowrap">
-				<Text fz={14} truncate>
-					{label}
-				</Text>
+				<Group gap="xs">
+					<Text fz={14} truncate style={{ userSelect: 'text' }}>
+						{label}
+					</Text>
+					{tab === 'Referrers' && (
+						<UnstyledButton
+							className={classes.external}
+							component="a"
+							href={`https://${label}`}
+							target="_blank"
+							rel="noreferrer noopener"
+							data-hidden={!isFQDN(label)}
+						>
+							<IconExternal />
+						</UnstyledButton>
+					)}
+				</Group>
 				<Group align="center" gap="xs" wrap="nowrap">
 					<Text
 						component="span"


### PR DESCRIPTION
This adds a small icon next to the referrer on the homepage to quickly visit referrer domain.