### PR TITLE
feat: add language group locales 

### DIFF
--- a/core/api/oas_handlers_gen.go
+++ b/core/api/oas_handlers_gen.go
@@ -1422,6 +1422,10 @@ func (s *Server) handleGetWebsiteIDLanguageRequest(args [1]string, argsEscaped b
 			Body:             nil,
 			Params: middleware.Parameters{
 				{
+					Name: "locale",
+					In:   "query",
+				}: params.Locale,
+				{
 					Name: "_me_sess",
 					In:   "cookie",
 				}: params.MeSess,

--- a/core/db/db.go
+++ b/core/db/db.go
@@ -54,8 +54,8 @@ type AnalyticsClient interface {
 	// Locales
 	GetWebsiteCountries(ctx context.Context, filter *Filters) ([]*model.StatsCountries, error)
 	GetWebsiteCountriesSummary(ctx context.Context, filter *Filters) ([]*model.StatsCountriesSummary, error)
-	GetWebsiteLanguages(ctx context.Context, filter *Filters) ([]*model.StatsLanguages, error)
-	GetWebsiteLanguagesSummary(ctx context.Context, filter *Filters) ([]*model.StatsLanguagesSummary, error)
+	GetWebsiteLanguages(ctx context.Context, isLocale bool, filter *Filters) ([]*model.StatsLanguages, error)
+	GetWebsiteLanguagesSummary(ctx context.Context, isLocale bool, filter *Filters) ([]*model.StatsLanguagesSummary, error)
 	// Referrers
 	GetWebsiteReferrers(ctx context.Context, filter *Filters) ([]*model.StatsReferrers, error)
 	GetWebsiteReferrersSummary(ctx context.Context, filter *Filters) ([]*model.StatsReferrerSummary, error)

--- a/core/db/duckdb/__snapshots__/locale_test.snap
+++ b/core/db/duckdb/__snapshots__/locale_test.snap
@@ -224,6 +224,178 @@ RECORDS:
 
 ---
 
+[TestGetWebsiteLanguagesLocale/Base - 1]
+RECORDS:
+&{StatsLanguagesSummary:{Language:Japanese Visitors:248841 VisitorsPercentage:0.498} Bounces:62167 Duration:4996}
+&{StatsLanguagesSummary:{Language:British English Visitors:125499 VisitorsPercentage:0.2512} Bounces:31490 Duration:5001}
+&{StatsLanguagesSummary:{Language:American English Visitors:125317 VisitorsPercentage:0.2508} Bounces:31027 Duration:5017}
+
+---
+
+[TestGetWebsiteLanguagesLocale/Browser - 1]
+RECORDS:
+&{StatsLanguagesSummary:{Language:Japanese Visitors:82811 VisitorsPercentage:0.4986} Bounces:20824 Duration:4966}
+&{StatsLanguagesSummary:{Language:American English Visitors:41719 VisitorsPercentage:0.2512} Bounces:10350 Duration:4991}
+&{StatsLanguagesSummary:{Language:British English Visitors:41560 VisitorsPercentage:0.2502} Bounces:10466 Duration:4994}
+
+---
+
+[TestGetWebsiteLanguagesLocale/Country - 1]
+RECORDS:
+&{StatsLanguagesSummary:{Language:Japanese Visitors:27567 VisitorsPercentage:0.499} Bounces:6921 Duration:4980}
+&{StatsLanguagesSummary:{Language:American English Visitors:13901 VisitorsPercentage:0.2516} Bounces:3418 Duration:5008}
+&{StatsLanguagesSummary:{Language:British English Visitors:13775 VisitorsPercentage:0.2494} Bounces:3505 Duration:5004}
+
+---
+
+[TestGetWebsiteLanguagesLocale/Device - 1]
+RECORDS:
+&{StatsLanguagesSummary:{Language:Japanese Visitors:9175 VisitorsPercentage:0.4917} Bounces:2336 Duration:4992}
+&{StatsLanguagesSummary:{Language:American English Visitors:4829 VisitorsPercentage:0.2588} Bounces:1168 Duration:5041}
+&{StatsLanguagesSummary:{Language:British English Visitors:4657 VisitorsPercentage:0.2496} Bounces:1187 Duration:4946}
+
+---
+
+[TestGetWebsiteLanguagesLocale/Empty - 1]
+RECORDS:
+
+---
+
+[TestGetWebsiteLanguagesLocale/Language - 1]
+RECORDS:
+&{StatsLanguagesSummary:{Language:American English Visitors:4829 VisitorsPercentage:0.5091} Bounces:1168 Duration:5041}
+&{StatsLanguagesSummary:{Language:British English Visitors:4657 VisitorsPercentage:0.4909} Bounces:1187 Duration:4946}
+
+---
+
+[TestGetWebsiteLanguagesLocale/OS - 1]
+RECORDS:
+&{StatsLanguagesSummary:{Language:American English Visitors:1623 VisitorsPercentage:0.5209} Bounces:390 Duration:5050}
+&{StatsLanguagesSummary:{Language:British English Visitors:1493 VisitorsPercentage:0.4791} Bounces:393 Duration:4858}
+
+---
+
+[TestGetWebsiteLanguagesLocale/Pathname - 1]
+RECORDS:
+&{StatsLanguagesSummary:{Language:American English Visitors:570 VisitorsPercentage:0.5229} Bounces:136 Duration:5294}
+&{StatsLanguagesSummary:{Language:British English Visitors:520 VisitorsPercentage:0.4771} Bounces:132 Duration:4987}
+
+---
+
+[TestGetWebsiteLanguagesLocale/Referrer - 1]
+RECORDS:
+&{StatsLanguagesSummary:{Language:American English Visitors:194 VisitorsPercentage:0.5092} Bounces:51 Duration:4677}
+&{StatsLanguagesSummary:{Language:British English Visitors:187 VisitorsPercentage:0.4908} Bounces:45 Duration:4761}
+
+---
+
+[TestGetWebsiteLanguagesLocale/UTMCampaign - 1]
+RECORDS:
+&{StatsLanguagesSummary:{Language:American English Visitors:58 VisitorsPercentage:0.5} Bounces:18 Duration:3943}
+&{StatsLanguagesSummary:{Language:British English Visitors:58 VisitorsPercentage:0.5} Bounces:13 Duration:5896}
+
+---
+
+[TestGetWebsiteLanguagesLocale/UTMMedium - 1]
+RECORDS:
+&{StatsLanguagesSummary:{Language:American English Visitors:18 VisitorsPercentage:0.5143} Bounces:4 Duration:3038}
+&{StatsLanguagesSummary:{Language:British English Visitors:17 VisitorsPercentage:0.4857} Bounces:2 Duration:7189}
+
+---
+
+[TestGetWebsiteLanguagesLocale/UTMSource - 1]
+RECORDS:
+&{StatsLanguagesSummary:{Language:American English Visitors:10 VisitorsPercentage:0.5882} Bounces:2 Duration:2631}
+&{StatsLanguagesSummary:{Language:British English Visitors:7 VisitorsPercentage:0.4118} Bounces:1 Duration:6547}
+
+---
+
+[TestGetWebsiteLanguagesLocaleSummary/Base - 1]
+RECORDS:
+&{Language:Japanese Visitors:248841 VisitorsPercentage:0.498}
+&{Language:British English Visitors:125499 VisitorsPercentage:0.2512}
+&{Language:American English Visitors:125317 VisitorsPercentage:0.2508}
+
+---
+
+[TestGetWebsiteLanguagesLocaleSummary/Browser - 1]
+RECORDS:
+&{Language:Japanese Visitors:82811 VisitorsPercentage:0.4986}
+&{Language:American English Visitors:41719 VisitorsPercentage:0.2512}
+&{Language:British English Visitors:41560 VisitorsPercentage:0.2502}
+
+---
+
+[TestGetWebsiteLanguagesLocaleSummary/Country - 1]
+RECORDS:
+&{Language:Japanese Visitors:27567 VisitorsPercentage:0.499}
+&{Language:American English Visitors:13901 VisitorsPercentage:0.2516}
+&{Language:British English Visitors:13775 VisitorsPercentage:0.2494}
+
+---
+
+[TestGetWebsiteLanguagesLocaleSummary/Device - 1]
+RECORDS:
+&{Language:Japanese Visitors:9175 VisitorsPercentage:0.4917}
+&{Language:American English Visitors:4829 VisitorsPercentage:0.2588}
+&{Language:British English Visitors:4657 VisitorsPercentage:0.2496}
+
+---
+
+[TestGetWebsiteLanguagesLocaleSummary/Empty - 1]
+RECORDS:
+
+---
+
+[TestGetWebsiteLanguagesLocaleSummary/Language - 1]
+RECORDS:
+&{Language:American English Visitors:4829 VisitorsPercentage:0.5091}
+&{Language:British English Visitors:4657 VisitorsPercentage:0.4909}
+
+---
+
+[TestGetWebsiteLanguagesLocaleSummary/OS - 1]
+RECORDS:
+&{Language:American English Visitors:1623 VisitorsPercentage:0.5209}
+&{Language:British English Visitors:1493 VisitorsPercentage:0.4791}
+
+---
+
+[TestGetWebsiteLanguagesLocaleSummary/Pathname - 1]
+RECORDS:
+&{Language:American English Visitors:570 VisitorsPercentage:0.5229}
+&{Language:British English Visitors:520 VisitorsPercentage:0.4771}
+
+---
+
+[TestGetWebsiteLanguagesLocaleSummary/Referrer - 1]
+RECORDS:
+&{Language:American English Visitors:194 VisitorsPercentage:0.5092}
+&{Language:British English Visitors:187 VisitorsPercentage:0.4908}
+
+---
+
+[TestGetWebsiteLanguagesLocaleSummary/UTMCampaign - 1]
+RECORDS:
+&{Language:American English Visitors:58 VisitorsPercentage:0.5}
+&{Language:British English Visitors:58 VisitorsPercentage:0.5}
+
+---
+
+[TestGetWebsiteLanguagesLocaleSummary/UTMMedium - 1]
+RECORDS:
+&{Language:American English Visitors:18 VisitorsPercentage:0.5143}
+&{Language:British English Visitors:17 VisitorsPercentage:0.4857}
+
+---
+
+[TestGetWebsiteLanguagesLocaleSummary/UTMSource - 1]
+RECORDS:
+&{Language:American English Visitors:10 VisitorsPercentage:0.5882}
+&{Language:British English Visitors:7 VisitorsPercentage:0.4118}
+
+---
+
 [TestGetWebsiteLanguagesSummary/Base - 1]
 RECORDS:
 &{Language:English Visitors:250816 VisitorsPercentage:0.502}

--- a/core/db/duckdb/locale_test.go
+++ b/core/db/duckdb/locale_test.go
@@ -45,7 +45,23 @@ func TestGetWebsiteLanguagesSummary(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			summary, err := client.GetWebsiteLanguagesSummary(ctx, tc.Filters)
+			summary, err := client.GetWebsiteLanguagesSummary(ctx, false, tc.Filters)
+			require.NoError(err)
+
+			snap := NewSnapRecords(summary)
+			snaps.MatchSnapshot(t, snap.Snapshot())
+		})
+	}
+}
+
+func TestGetWebsiteLanguagesLocaleSummary(t *testing.T) {
+	_, require, ctx, client := UseDatabaseFixture(t, SIMPLE_FIXTURE)
+
+	testCases := getBaseTestCases(MEDIUM_HOSTNAME)
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			summary, err := client.GetWebsiteLanguagesSummary(ctx, true, tc.Filters)
 			require.NoError(err)
 
 			snap := NewSnapRecords(summary)
@@ -61,7 +77,23 @@ func TestGetWebsiteLanguages(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			languages, err := client.GetWebsiteLanguages(ctx, tc.Filters)
+			languages, err := client.GetWebsiteLanguages(ctx, false, tc.Filters)
+			require.NoError(err)
+
+			snap := NewSnapRecords(languages)
+			snaps.MatchSnapshot(t, snap.Snapshot())
+		})
+	}
+}
+
+func TestGetWebsiteLanguagesLocale(t *testing.T) {
+	_, require, ctx, client := UseDatabaseFixture(t, SIMPLE_FIXTURE)
+
+	testCases := getBaseTestCases(MEDIUM_HOSTNAME)
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			languages, err := client.GetWebsiteLanguages(ctx, true, tc.Filters)
 			require.NoError(err)
 
 			snap := NewSnapRecords(languages)

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -997,6 +997,12 @@ paths:
       description: Get a list of languages and their stats.
       operationId: get-website-id-language
       parameters:
+        - in: query
+          name: locale
+          description: Whether to return the language name or the language dialect/locale.
+          schema:
+            type: boolean
+            default: false
         - $ref: "#/components/parameters/SessionAuth"
         - $ref: "#/components/parameters/Hostname"
         - $ref: "#/components/parameters/Summary"
@@ -1917,12 +1923,14 @@ components:
     StatsLanguages:
       type: array
       title: StatsLanguages
+      description: List of languages and their stats.
       items:
         type: object
         properties:
           language:
             type: string
             description: Language name.
+            example: English
           visitors:
             type: integer
             description: Number of unique visitors for language.

--- a/core/services/stats.go
+++ b/core/services/stats.go
@@ -924,7 +924,7 @@ func (h *Handler) GetWebsiteIDLanguage(ctx context.Context, params api.GetWebsit
 	switch params.Summary.Value {
 	case true:
 		// Get summary
-		languages, err := h.analyticsDB.GetWebsiteLanguagesSummary(ctx, filters)
+		languages, err := h.analyticsDB.GetWebsiteLanguagesSummary(ctx, params.Locale.Value, filters)
 		if err != nil {
 			log.Error().
 				Err(err).
@@ -946,7 +946,7 @@ func (h *Handler) GetWebsiteIDLanguage(ctx context.Context, params api.GetWebsit
 		return &res, nil
 	case false:
 		// Get languages
-		languages, err := h.analyticsDB.GetWebsiteLanguages(ctx, filters)
+		languages, err := h.analyticsDB.GetWebsiteLanguages(ctx, params.Locale.Value, filters)
 		if err != nil {
 			log.Error().
 				Err(err).

--- a/dashboard/app/api/types.d.ts
+++ b/dashboard/app/api/types.d.ts
@@ -532,9 +532,15 @@ export interface components {
         /** @description Total time spent on page from referrer in milliseconds. */
         duration?: number;
       }[];
-    /** StatsLanguages */
+    /**
+     * StatsLanguages
+     * @description List of languages and their stats.
+     */
     StatsLanguages: {
-        /** @description Language name. */
+        /**
+         * @description Language name.
+         * @example English
+         */
         language: string;
         /** @description Number of unique visitors for language. */
         visitors: number;
@@ -1544,6 +1550,8 @@ export interface operations {
   "get-website-id-language": {
     parameters: {
       query?: {
+        /** @description Whether to return the language name or the language dialect/locale. */
+        locale?: boolean;
         summary?: components["parameters"]["Summary"];
         start?: components["parameters"]["PeriodStart"];
         end?: components["parameters"]["PeriodEnd"];

--- a/dashboard/app/components/stats/StatsItem.tsx
+++ b/dashboard/app/components/stats/StatsItem.tsx
@@ -36,7 +36,8 @@ const StatsItem = ({
 	percentage = 0,
 	tab,
 }: StatsItemProps) => {
-	const { addFilter } = useFilter();
+	const { addFilter, isFilterActiveEq } = useFilter();
+	const showLocales = isFilterActiveEq('language');
 	const { hovered, ref } = useHover<HTMLButtonElement>();
 
 	const formattedValue = useMemo(
@@ -46,7 +47,9 @@ const StatsItem = ({
 
 	const handleFilter = () => {
 		const filter = FILTER_MAP[tab] ?? 'path';
-		addFilter(filter, 'eq', label);
+		if (filter !== 'language' || !showLocales) {
+			addFilter(filter, 'eq', label);
+		}
 	};
 
 	return (
@@ -69,6 +72,7 @@ const StatsItem = ({
 							target="_blank"
 							rel="noreferrer noopener"
 							data-hidden={!isFQDN(label)}
+							onClick={(event) => event.stopPropagation()}
 						>
 							<IconExternal />
 						</UnstyledButton>

--- a/dashboard/app/components/stats/StatsTable.tsx
+++ b/dashboard/app/components/stats/StatsTable.tsx
@@ -176,10 +176,10 @@ const QueryTable = ({ query, data, isMobile }: QueryTableProps) => {
 	});
 
 	const { isFilterActiveEq } = useFilter();
-	const isLanguageFilterActive = isFilterActiveEq('language');
+	const showLocales = isFilterActiveEq('language');
 	const columns = useMemo(
-		() => getColumnsForQuery(query, isLanguageFilterActive),
-		[query, isLanguageFilterActive],
+		() => getColumnsForQuery(query, showLocales),
+		[query, showLocales],
 	);
 
 	const records = useMemo(() => {
@@ -215,11 +215,14 @@ const QueryTable = ({ query, data, isMobile }: QueryTableProps) => {
 	const handleFilter: DataRowClick = (row) => {
 		const { record } = row;
 		const filter = FILTER_MAP[query] ?? 'path';
-		const value =
-			query === 'time'
-				? record.path
-				: record[ACCESSOR_MAP[query]] || 'Direct/None';
-		addFilter(filter, 'eq', String(value));
+		// Do not add filter if the page is on language and locales are already shown.
+		if (filter !== 'language' || !showLocales) {
+			const value =
+				query === 'time'
+					? record.path
+					: record[ACCESSOR_MAP[query]] || 'Direct/None';
+			addFilter(filter, 'eq', String(value));
+		}
 	};
 
 	// Reset page when query changes.

--- a/dashboard/app/components/stats/StatsTable.tsx
+++ b/dashboard/app/components/stats/StatsTable.tsx
@@ -231,6 +231,14 @@ const QueryTable = ({ query, data, isMobile }: QueryTableProps) => {
 		setPageSize(10);
 	}, [query, data.length]);
 
+	// Reset sort status when query changes.
+	useDidUpdate(() => {
+		setSortStatus({
+			columnAccessor: 'visitors',
+			direction: 'desc',
+		});
+	}, [query]);
+
 	return (
 		<div className={classes.tableWrapper}>
 			<div className={classes.tableHeader}>

--- a/dashboard/app/components/stats/StatsTable.tsx
+++ b/dashboard/app/components/stats/StatsTable.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Group, Tabs, Text, UnstyledButton } from '@mantine/core';
-import { useMediaQuery } from '@mantine/hooks';
+import { useDidUpdate, useMediaQuery } from '@mantine/hooks';
 import { Link, useNavigate, useSearchParams } from '@remix-run/react';
 import {
 	DataTable,
@@ -225,11 +225,11 @@ const QueryTable = ({ query, data, isMobile }: QueryTableProps) => {
 		}
 	};
 
-	// Reset page when query changes.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Valid pattern.
-	useEffect(() => {
+	// Reset page when query or data length changes (from filters).
+	useDidUpdate(() => {
 		setPage(1);
-	}, [query]);
+		setPageSize(10);
+	}, [query, data.length]);
 
 	return (
 		<div className={classes.tableWrapper}>

--- a/dashboard/app/components/stats/types.ts
+++ b/dashboard/app/components/stats/types.ts
@@ -48,6 +48,7 @@ interface DataRow {
 	country?: string;
 	// Languages
 	language?: string;
+	locale?: string;
 }
 
 interface StatsValue {

--- a/dashboard/app/components/stats/types.ts
+++ b/dashboard/app/components/stats/types.ts
@@ -48,7 +48,6 @@ interface DataRow {
 	country?: string;
 	// Languages
 	language?: string;
-	locale?: string;
 }
 
 interface StatsValue {

--- a/dashboard/app/components/stats/utils.ts
+++ b/dashboard/app/components/stats/utils.ts
@@ -1,37 +1,7 @@
-import type { DataRow } from './types';
-
 const sortBy =
 	// biome-ignore lint/suspicious/noExplicitAny: Generic function.
 		<T extends Record<string, any>>(key: keyof T) =>
 		(a: T, b: T) =>
 			a[key] > b[key] ? 1 : b[key] > a[key] ? -1 : 0;
 
-const aggregateStatsByLanguage = (stats: DataRow[]): DataRow[] => {
-	// A record of aggregated stats for each language. e.g. "English", DataRow
-	const languageStats: Record<string, DataRow> = {};
-
-	for (const stat of stats) {
-		const language = stat.language || 'Unknown';
-
-		if (!languageStats[language]) {
-			languageStats[language] = { ...stat };
-		} else {
-			// Add the stats together
-			languageStats[language] = {
-				language,
-				// Calculate sums
-				visitors:
-					(languageStats[language].visitors || 0) + (stat.visitors || 0),
-				pageviews:
-					(languageStats[language].pageviews || 0) + (stat.pageviews || 0),
-				bounces: (languageStats[language].bounces || 0) + (stat.bounces || 0),
-				duration:
-					(languageStats[language].duration || 0) + (stat.duration || 0),
-			};
-		}
-	}
-
-	return Object.values(languageStats);
-};
-
-export { sortBy, aggregateStatsByLanguage };
+export { sortBy };

--- a/dashboard/app/components/stats/utils.ts
+++ b/dashboard/app/components/stats/utils.ts
@@ -1,0 +1,37 @@
+import type { DataRow } from './types';
+
+const sortBy =
+	// biome-ignore lint/suspicious/noExplicitAny: Generic function.
+		<T extends Record<string, any>>(key: keyof T) =>
+		(a: T, b: T) =>
+			a[key] > b[key] ? 1 : b[key] > a[key] ? -1 : 0;
+
+const aggregateStatsByLanguage = (stats: DataRow[]): DataRow[] => {
+	// A record of aggregated stats for each language. e.g. "English", DataRow
+	const languageStats: Record<string, DataRow> = {};
+
+	for (const stat of stats) {
+		const language = stat.language || 'Unknown';
+
+		if (!languageStats[language]) {
+			languageStats[language] = { ...stat };
+		} else {
+			// Add the stats together
+			languageStats[language] = {
+				language,
+				// Calculate sums
+				visitors:
+					(languageStats[language].visitors || 0) + (stat.visitors || 0),
+				pageviews:
+					(languageStats[language].pageviews || 0) + (stat.pageviews || 0),
+				bounces: (languageStats[language].bounces || 0) + (stat.bounces || 0),
+				duration:
+					(languageStats[language].duration || 0) + (stat.duration || 0),
+			};
+		}
+	}
+
+	return Object.values(languageStats);
+};
+
+export { sortBy, aggregateStatsByLanguage };

--- a/dashboard/app/hooks/use-filter.ts
+++ b/dashboard/app/hooks/use-filter.ts
@@ -36,10 +36,19 @@ const useFilter = () => {
 		[searchParams, setSearchParams],
 	);
 
+	const isFilterActiveEq = useCallback(
+		(filter: Filter) => {
+			const key = getKey(filter, 'eq');
+			return searchParams.has(key);
+		},
+		[searchParams],
+	);
+
 	return {
 		searchParams,
 		addFilter,
 		removeFilter,
+		isFilterActiveEq,
 	};
 };
 

--- a/dashboard/app/hooks/use-filter.ts
+++ b/dashboard/app/hooks/use-filter.ts
@@ -52,4 +52,4 @@ const useFilter = () => {
 	};
 };
 
-export { useFilter };
+export { useFilter, getKey };

--- a/dashboard/app/utils/stats.ts
+++ b/dashboard/app/utils/stats.ts
@@ -186,6 +186,8 @@ const fetchStats = async (
 					pathKey: params.hostname,
 					query: {
 						summary: isSummary,
+						// If an eq filter is present, we should return the locales instead of languages.
+						locale: searchParams.has('language[eq]'),
 						...filters,
 					},
 				})


### PR DESCRIPTION
Closes #11. This adds locales to the results if you filter a specific language.

![image](https://github.com/medama-io/medama/assets/38220115/63912e9d-e8f9-4302-887d-5b14537a9de3)

Also a couple fixes on expanded tables when switching queries and multiple filters, leading to inconsistent state.
