### PR TITLE
refactor(core): use custom duckdb query builder

### DIFF
--- a/core/db/duckdb/common.go
+++ b/core/db/duckdb/common.go
@@ -1,0 +1,25 @@
+package duckdb
+
+import qb "github.com/medama-io/medama/db/duckdb/query"
+
+// These are common query builder clauses.
+const (
+	// VisitorsStmt is the number of unique visitors for the query.
+	VisitorsStmt = "COUNT(*) FILTER (is_unique_user = true) AS visitors"
+	// VisitorsPercentageStmt is the percentage the country contributes to the total unique visits.
+	// This expects a CTE named total with a total_visitors column to be present.
+	VisitorsPercentageStmt = "ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage"
+	// BouncesStmt is the number of bounces for the query.
+	BouncesStmt = "COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces"
+	// DurationStmt is the median duration of the visits.
+	DurationStmt = "CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration"
+)
+
+// TotalVisitorsCTE declares a materialized CTE to calculate the total number of unique visitors.
+func TotalVisitorsCTE(whereClause string) *qb.QueryBuilder {
+	return qb.New().WithMaterialized("total", qb.New().
+		Select("COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors").
+		From("views").
+		Where(whereClause),
+	)
+}

--- a/core/db/duckdb/common.go
+++ b/core/db/duckdb/common.go
@@ -9,6 +9,8 @@ const (
 	// VisitorsPercentageStmt is the percentage the country contributes to the total unique visits.
 	// This expects a CTE named total with a total_visitors column to be present.
 	VisitorsPercentageStmt = "ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage"
+	// PageviewsStmt is the number of pageviews for the query.
+	PageviewsStmt = "COUNT(*) AS pageviews"
 	// BouncesStmt is the number of bounces for the query.
 	BouncesStmt = "COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces"
 	// DurationStmt is the median duration of the visits.

--- a/core/db/duckdb/general.go
+++ b/core/db/duckdb/general.go
@@ -7,34 +7,31 @@ import (
 	"strconv"
 
 	"github.com/go-faster/errors"
+	qb "github.com/medama-io/medama/db/duckdb/query"
 	"github.com/medama-io/medama/model"
 )
 
 func (c *Client) GetSettingsUsage(ctx context.Context) (*model.GetSettingsUsage, error) {
-	queryThreads := `--sql
-		SELECT
-			value AS threads
-		FROM
-			duckdb_settings()
-		WHERE name = 'threads';`
+	queryThreads := qb.New().
+		Select("value AS threads").
+		From("duckdb_settings()").
+		Where("name = 'threads'")
 
-	queryMemory := `--sql
-		SELECT
-			value AS memory_limit
-		FROM
-			duckdb_settings()
-		WHERE name = 'memory_limit';`
+	queryMemory := qb.New().
+		Select("value AS memory_limit").
+		From("duckdb_settings()").
+		Where("name = 'memory_limit'")
 
 	var usage model.GetSettingsUsage
 
 	// Get the number of threads.
-	err := c.GetContext(ctx, &usage, queryThreads)
+	err := c.GetContext(ctx, &usage, queryThreads.Build())
 	if err != nil {
 		return nil, errors.Wrap(err, "db")
 	}
 
 	// Get the memory limit.
-	err = c.GetContext(ctx, &usage, queryMemory)
+	err = c.GetContext(ctx, &usage, queryMemory.Build())
 	if err != nil {
 		return nil, errors.Wrap(err, "db")
 	}

--- a/core/db/duckdb/query/qb.go
+++ b/core/db/duckdb/query/qb.go
@@ -12,9 +12,11 @@ type CTE struct {
 type QueryBuilder struct {
 	cteClauses       []CTE
 	selectClauses    []string
-	fromClause       string
+	fromClause       []string
+	leftJoinClause   string
 	whereClause      string
 	groupByClause    []string
+	havingClause     []string
 	orderByClause    []string
 	paginationClause string
 }
@@ -33,8 +35,13 @@ func (qb *QueryBuilder) Select(columns ...string) *QueryBuilder {
 	return qb
 }
 
-func (qb *QueryBuilder) From(table string) *QueryBuilder {
-	qb.fromClause = table
+func (qb *QueryBuilder) From(tables ...string) *QueryBuilder {
+	qb.fromClause = append(qb.fromClause, tables...)
+	return qb
+}
+
+func (qb *QueryBuilder) LeftJoin(query string) *QueryBuilder {
+	qb.leftJoinClause = query
 	return qb
 }
 
@@ -45,6 +52,11 @@ func (qb *QueryBuilder) Where(query string) *QueryBuilder {
 
 func (qb *QueryBuilder) GroupBy(columns ...string) *QueryBuilder {
 	qb.groupByClause = append(qb.groupByClause, columns...)
+	return qb
+}
+
+func (qb *QueryBuilder) Having(query string) *QueryBuilder {
+	qb.havingClause = append(qb.havingClause, query)
 	return qb
 }
 
@@ -79,7 +91,12 @@ func (qb *QueryBuilder) Build() string {
 	query.WriteString(strings.Join(qb.selectClauses, ", "))
 
 	query.WriteString(" FROM ")
-	query.WriteString(qb.fromClause)
+	query.WriteString(strings.Join(qb.fromClause, ", "))
+
+	if qb.leftJoinClause != "" {
+		query.WriteString(" LEFT JOIN ")
+		query.WriteString(qb.leftJoinClause)
+	}
 
 	if len(qb.whereClause) > 0 {
 		query.WriteString(" WHERE ")
@@ -89,6 +106,11 @@ func (qb *QueryBuilder) Build() string {
 	if len(qb.groupByClause) > 0 {
 		query.WriteString(" GROUP BY ")
 		query.WriteString(strings.Join(qb.groupByClause, ", "))
+	}
+
+	if len(qb.havingClause) > 0 {
+		query.WriteString(" HAVING ")
+		query.WriteString(strings.Join(qb.havingClause, ", "))
 	}
 
 	if len(qb.orderByClause) > 0 {

--- a/core/db/duckdb/query/qb.go
+++ b/core/db/duckdb/query/qb.go
@@ -1,0 +1,104 @@
+package qb
+
+import (
+	"strings"
+)
+
+type CTE struct {
+	Name     string
+	Subquery *QueryBuilder
+}
+
+type QueryBuilder struct {
+	cteClauses       []CTE
+	selectClauses    []string
+	fromClause       string
+	whereClause      string
+	groupByClause    []string
+	orderByClause    []string
+	paginationClause string
+}
+
+func New() *QueryBuilder {
+	return &QueryBuilder{}
+}
+
+func (qb *QueryBuilder) WithMaterialized(name string, subquery *QueryBuilder) *QueryBuilder {
+	qb.cteClauses = append(qb.cteClauses, CTE{Name: name, Subquery: subquery})
+	return qb
+}
+
+func (qb *QueryBuilder) Select(columns ...string) *QueryBuilder {
+	qb.selectClauses = append(qb.selectClauses, columns...)
+	return qb
+}
+
+func (qb *QueryBuilder) From(table string) *QueryBuilder {
+	qb.fromClause = table
+	return qb
+}
+
+func (qb *QueryBuilder) Where(query string) *QueryBuilder {
+	qb.whereClause = query
+	return qb
+}
+
+func (qb *QueryBuilder) GroupBy(columns ...string) *QueryBuilder {
+	qb.groupByClause = append(qb.groupByClause, columns...)
+	return qb
+}
+
+func (qb *QueryBuilder) OrderBy(columns ...string) *QueryBuilder {
+	qb.orderByClause = append(qb.orderByClause, columns...)
+	return qb
+}
+
+func (qb *QueryBuilder) Pagination(query string) *QueryBuilder {
+	qb.paginationClause = query
+	return qb
+}
+
+func (qb *QueryBuilder) Build() string {
+	var query strings.Builder
+
+	for idx, cte := range qb.cteClauses {
+		// First CTE starts with WITH, while subsequent CTEs start with a comma
+		if idx == 0 {
+			query.WriteString("WITH ")
+		} else {
+			query.WriteString(", ")
+		}
+
+		query.WriteString(cte.Name)
+		query.WriteString(" AS MATERIALIZED (")
+		query.WriteString(cte.Subquery.Build())
+		query.WriteString(")")
+	}
+
+	query.WriteString("SELECT ")
+	query.WriteString(strings.Join(qb.selectClauses, ", "))
+
+	query.WriteString(" FROM ")
+	query.WriteString(qb.fromClause)
+
+	if len(qb.whereClause) > 0 {
+		query.WriteString(" WHERE ")
+		query.WriteString(qb.whereClause)
+	}
+
+	if len(qb.groupByClause) > 0 {
+		query.WriteString(" GROUP BY ")
+		query.WriteString(strings.Join(qb.groupByClause, ", "))
+	}
+
+	if len(qb.orderByClause) > 0 {
+		query.WriteString(" ORDER BY ")
+		query.WriteString(strings.Join(qb.orderByClause, ", "))
+	}
+
+	if qb.paginationClause != "" {
+		query.WriteString(qb.paginationClause)
+	}
+
+	return query.String()
+}

--- a/core/db/duckdb/time.go
+++ b/core/db/duckdb/time.go
@@ -31,9 +31,7 @@ func (c *Client) GetWebsiteTimeSummary(ctx context.Context, filter *db.Filters) 
 		FROM views
 		WHERE `)
 	query.WriteString(filter.WhereString())
-	query.WriteString(` GROUP BY pathname HAVING duration > 0 AND visitors >= 3`)
-	query.WriteString(filter.PaginationString())
-	query.WriteString(`)`)
+	query.WriteString(` GROUP BY pathname HAVING duration > 0 AND visitors >= 3)`)
 	query.WriteString(`--sql
 		SELECT
 			pathname,
@@ -41,6 +39,7 @@ func (c *Client) GetWebsiteTimeSummary(ctx context.Context, filter *db.Filters) 
 			ifnull(ROUND(total_duration / (SELECT SUM(total_duration) FROM durations), 4), 0) AS duration_percentage
 		FROM durations
 		ORDER BY duration_percentage DESC, duration DESC, visitors DESC, pathname ASC`)
+	query.WriteString(filter.PaginationString())
 
 	rows, err := c.NamedQueryContext(ctx, query.String(), filter.Args(nil))
 	if err != nil {
@@ -90,9 +89,7 @@ func (c *Client) GetWebsiteTime(ctx context.Context, filter *db.Filters) ([]*mod
 		FROM views
 		WHERE `)
 	query.WriteString(filter.WhereString())
-	query.WriteString(` GROUP BY pathname HAVING duration > 0 AND duration_lower_quartile > 0 AND visitors >= 3`)
-	query.WriteString(filter.PaginationString())
-	query.WriteString(`)`)
+	query.WriteString(` GROUP BY pathname HAVING duration > 0 AND duration_lower_quartile > 0 AND visitors >= 3)`)
 	query.WriteString(`--sql
 		SELECT
 			pathname,
@@ -103,6 +100,7 @@ func (c *Client) GetWebsiteTime(ctx context.Context, filter *db.Filters) ([]*mod
 			visitors
 		FROM durations
 		ORDER BY visitors DESC, duration DESC, pathname ASC`)
+	query.WriteString(filter.PaginationString())
 
 	rows, err := c.NamedQueryContext(ctx, query.String(), filter.Args(nil))
 	if err != nil {

--- a/core/db/duckdb/time.go
+++ b/core/db/duckdb/time.go
@@ -2,17 +2,20 @@ package duckdb
 
 import (
 	"context"
-	"strings"
 
 	"github.com/go-faster/errors"
 	"github.com/medama-io/medama/db"
+	qb "github.com/medama-io/medama/db/duckdb/query"
 	"github.com/medama-io/medama/model"
+)
+
+const (
+	durationPercentageStmt = "ifnull(ROUND(total_duration / (SELECT SUM(total_duration) FROM durations), 4), 0) AS duration_percentage"
 )
 
 // GetWebsiteTimeSummary returns a summary of the time for the given hostname.
 func (c *Client) GetWebsiteTimeSummary(ctx context.Context, filter *db.Filters) ([]*model.StatsTimeSummary, error) {
 	var times []*model.StatsTimeSummary
-	var query strings.Builder
 
 	// Array of time summaries
 	//
@@ -21,27 +24,28 @@ func (c *Client) GetWebsiteTimeSummary(ctx context.Context, filter *db.Filters) 
 	// Duration is the average duration the user spent on the page in milliseconds.
 	//
 	// DurationPercentage is the percentage the pathname contributes to the total duration.
-	query.WriteString(`--sql
-		WITH durations AS MATERIALIZED (
-		SELECT
-			pathname,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
-			CAST(ifnull(quantile_cont(duration_ms, 0.5), 0) AS INTEGER) AS duration,
-			SUM(duration_ms) AS total_duration
-		FROM views
-		WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(` GROUP BY pathname HAVING duration > 0 AND visitors >= 3)`)
-	query.WriteString(`--sql
-		SELECT
-			pathname,
-			duration,
-			ifnull(ROUND(total_duration / (SELECT SUM(total_duration) FROM durations), 4), 0) AS duration_percentage
-		FROM durations
-		ORDER BY duration_percentage DESC, duration DESC, visitors DESC, pathname ASC`)
-	query.WriteString(filter.PaginationString())
+	query := qb.New().WithMaterialized("durations", qb.New().
+		Select(
+			"pathname",
+			"COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors",
+			"CAST(ifnull(quantile_cont(duration_ms, 0.5), 0) AS INTEGER) AS duration",
+			"SUM(duration_ms) AS total_duration",
+		).
+		From("views").
+		Where(filter.WhereString()).
+		GroupBy("pathname").
+		Having("duration > 0 AND visitors >= 3"),
+	).
+		Select(
+			"pathname",
+			"duration",
+			durationPercentageStmt,
+		).
+		From("durations").
+		OrderBy("duration_percentage DESC", "duration DESC", "visitors DESC", "pathname ASC").
+		Pagination(filter.PaginationString())
 
-	rows, err := c.NamedQueryContext(ctx, query.String(), filter.Args(nil))
+	rows, err := c.NamedQueryContext(ctx, query.Build(), filter.Args(nil))
 	if err != nil {
 		return nil, errors.Wrap(err, "db")
 	}
@@ -62,7 +66,6 @@ func (c *Client) GetWebsiteTimeSummary(ctx context.Context, filter *db.Filters) 
 // GetWebsiteTime returns the time for the given hostname.
 func (c *Client) GetWebsiteTime(ctx context.Context, filter *db.Filters) ([]*model.StatsTime, error) {
 	var times []*model.StatsTime
-	var query strings.Builder
 
 	// Array of time summaries
 	//
@@ -77,32 +80,33 @@ func (c *Client) GetWebsiteTime(ctx context.Context, filter *db.Filters) ([]*mod
 	// DurationPercentage is the percentage the pathname contributes to the total duration.
 	//
 	// Visitors is the total number of unique visitors for the page.
-	query.WriteString(`--sql
-		WITH durations AS MATERIALIZED (
-		SELECT
-			pathname,
-			CAST(ifnull(quantile_cont(duration_ms, 0.5), 0) AS INTEGER) AS duration,
-			CAST(ifnull(quantile_cont(duration_ms, 0.75), 0) AS INTEGER) AS duration_upper_quartile,
-			CAST(ifnull(quantile_cont(duration_ms, 0.25), 0) AS INTEGER) AS duration_lower_quartile,
-			COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors,
-			SUM(duration_ms) AS total_duration
-		FROM views
-		WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(` GROUP BY pathname HAVING duration > 0 AND duration_lower_quartile > 0 AND visitors >= 3)`)
-	query.WriteString(`--sql
-		SELECT
-			pathname,
-			duration,
-			duration_upper_quartile,
-			duration_lower_quartile,
-			ifnull(ROUND(total_duration / (SELECT SUM(total_duration) FROM durations), 4), 0) AS duration_percentage,
-			visitors
-		FROM durations
-		ORDER BY visitors DESC, duration DESC, pathname ASC`)
-	query.WriteString(filter.PaginationString())
+	query := qb.New().WithMaterialized("durations", qb.New().
+		Select(
+			"pathname",
+			"CAST(ifnull(quantile_cont(duration_ms, 0.5), 0) AS INTEGER) AS duration",
+			"CAST(ifnull(quantile_cont(duration_ms, 0.75), 0) AS INTEGER) AS duration_upper_quartile",
+			"CAST(ifnull(quantile_cont(duration_ms, 0.25), 0) AS INTEGER) AS duration_lower_quartile",
+			"COUNT(*) FILTER (WHERE is_unique_page = true) AS visitors",
+			"SUM(duration_ms) AS total_duration",
+		).
+		From("views").
+		Where(filter.WhereString()).
+		GroupBy("pathname").
+		Having("duration > 0 AND duration_lower_quartile > 0 AND visitors >= 3"),
+	).
+		Select(
+			"pathname",
+			"duration",
+			"duration_upper_quartile",
+			"duration_lower_quartile",
+			durationPercentageStmt,
+			"visitors",
+		).
+		From("durations").
+		OrderBy("visitors DESC", "duration DESC", "pathname ASC").
+		Pagination(filter.PaginationString())
 
-	rows, err := c.NamedQueryContext(ctx, query.String(), filter.Args(nil))
+	rows, err := c.NamedQueryContext(ctx, query.Build(), filter.Args(nil))
 	if err != nil {
 		return nil, errors.Wrap(err, "db")
 	}

--- a/core/db/duckdb/types.go
+++ b/core/db/duckdb/types.go
@@ -2,7 +2,6 @@ package duckdb
 
 import (
 	"context"
-	"strings"
 
 	"github.com/go-faster/errors"
 	"github.com/medama-io/medama/db"
@@ -12,7 +11,6 @@ import (
 // GetWebsiteBrowser returns the browsers for the given hostname.
 func (c *Client) GetWebsiteBrowsersSummary(ctx context.Context, filter *db.Filters) ([]*model.StatsBrowsersSummary, error) {
 	var browsers []*model.StatsBrowsersSummary
-	var query strings.Builder
 
 	// Array of browsers
 	//
@@ -21,25 +19,19 @@ func (c *Client) GetWebsiteBrowsersSummary(ctx context.Context, filter *db.Filte
 	// Visitors is the number of unique visitors for the browser.
 	//
 	// VisitorsPercentage is the percentage the browser contributes to the total visitors.
-	query.WriteString(`--sql
-		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
-			FROM views
-			WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(`--sql
-		)
-		SELECT
-			ua_browser AS browser,
-			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
-			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage
-		FROM views
-		WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(` GROUP BY browser ORDER BY visitors DESC, browser ASC`)
-	query.WriteString(filter.PaginationString())
+	query := TotalVisitorsCTE(filter.WhereString()).
+		Select(
+			"ua_browser AS browser",
+			VisitorsStmt,
+			VisitorsPercentageStmt,
+		).
+		From("views").
+		Where(filter.WhereString()).
+		GroupBy("browser").
+		OrderBy("visitors DESC", "browser ASC").
+		Pagination(filter.PaginationString())
 
-	rows, err := c.NamedQueryContext(ctx, query.String(), filter.Args(nil))
+	rows, err := c.NamedQueryContext(ctx, query.Build(), filter.Args(nil))
 	if err != nil {
 		return nil, errors.Wrap(err, "db")
 	}
@@ -59,7 +51,6 @@ func (c *Client) GetWebsiteBrowsersSummary(ctx context.Context, filter *db.Filte
 
 func (c *Client) GetWebsiteBrowsers(ctx context.Context, filter *db.Filters) ([]*model.StatsBrowsers, error) {
 	var browsers []*model.StatsBrowsers
-	var query strings.Builder
 
 	// Array of browsers
 	//
@@ -72,27 +63,21 @@ func (c *Client) GetWebsiteBrowsers(ctx context.Context, filter *db.Filters) ([]
 	// Bounces is the number of unique visitors that match the pathname and have a duration of less than 5 seconds.
 	//
 	// Duration is the median duration of the page.
-	query.WriteString(`--sql
-		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
-			FROM views
-			WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(`--sql
-		)
-		SELECT
-			ua_browser AS browser,
-			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
-			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage,
-			COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces,
-			CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration
-		FROM views
-		WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(` GROUP BY browser ORDER BY visitors DESC, browser ASC`)
-	query.WriteString(filter.PaginationString())
+	query := TotalVisitorsCTE(filter.WhereString()).
+		Select(
+			"ua_browser AS browser",
+			VisitorsStmt,
+			VisitorsPercentageStmt,
+			BouncesStmt,
+			DurationStmt,
+		).
+		From("views").
+		Where(filter.WhereString()).
+		GroupBy("browser").
+		OrderBy("visitors DESC", "browser ASC").
+		Pagination(filter.PaginationString())
 
-	rows, err := c.NamedQueryContext(ctx, query.String(), filter.Args(nil))
+	rows, err := c.NamedQueryContext(ctx, query.Build(), filter.Args(nil))
 	if err != nil {
 		return nil, errors.Wrap(err, "db")
 	}
@@ -112,7 +97,6 @@ func (c *Client) GetWebsiteBrowsers(ctx context.Context, filter *db.Filters) ([]
 
 func (c *Client) GetWebsiteOSSummary(ctx context.Context, filter *db.Filters) ([]*model.StatsOSSummary, error) {
 	var os []*model.StatsOSSummary
-	var query strings.Builder
 
 	// Array of operating systems
 	//
@@ -121,25 +105,19 @@ func (c *Client) GetWebsiteOSSummary(ctx context.Context, filter *db.Filters) ([
 	// Visitors is the number of unique visitors for the operating system.
 	//
 	// VisitorsPercentage is the percentage the operating contributes to the total visitors.
-	query.WriteString(`--sql
-		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
-			FROM views
-			WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(`--sql
-		)
-		SELECT
-			ua_os AS os,
-			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
-			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage
-		FROM views
-		WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(` GROUP BY os ORDER BY visitors DESC, os ASC`)
-	query.WriteString(filter.PaginationString())
+	query := TotalVisitorsCTE(filter.WhereString()).
+		Select(
+			"ua_os AS os",
+			VisitorsStmt,
+			VisitorsPercentageStmt,
+		).
+		From("views").
+		Where(filter.WhereString()).
+		GroupBy("os").
+		OrderBy("visitors DESC", "os ASC").
+		Pagination(filter.PaginationString())
 
-	rows, err := c.NamedQueryContext(ctx, query.String(), filter.Args(nil))
+	rows, err := c.NamedQueryContext(ctx, query.Build(), filter.Args(nil))
 	if err != nil {
 		return nil, errors.Wrap(err, "db")
 	}
@@ -160,7 +138,6 @@ func (c *Client) GetWebsiteOSSummary(ctx context.Context, filter *db.Filters) ([
 // GetWebsiteOS returns the operating systems for the given hostname.
 func (c *Client) GetWebsiteOS(ctx context.Context, filter *db.Filters) ([]*model.StatsOS, error) {
 	var os []*model.StatsOS
-	var query strings.Builder
 
 	// Array of operating systems
 	//
@@ -169,27 +146,21 @@ func (c *Client) GetWebsiteOS(ctx context.Context, filter *db.Filters) ([]*model
 	// Visitors is the number of unique visitors for the operating system.
 	//
 	// VisitorsPercentage is the percentage the operating contributes to the total visitors.
-	query.WriteString(`--sql
-		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
-			FROM views
-			WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(`--sql
-		)
-		SELECT
-			ua_os AS os,
-			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
-			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage,
-			COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces,
-			CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration
-		FROM views
-		WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(` GROUP BY os ORDER BY visitors DESC, os ASC`)
-	query.WriteString(filter.PaginationString())
+	query := TotalVisitorsCTE(filter.WhereString()).
+		Select(
+			"ua_os AS os",
+			VisitorsStmt,
+			VisitorsPercentageStmt,
+			BouncesStmt,
+			DurationStmt,
+		).
+		From("views").
+		Where(filter.WhereString()).
+		GroupBy("os").
+		OrderBy("visitors DESC", "os ASC").
+		Pagination(filter.PaginationString())
 
-	rows, err := c.NamedQueryContext(ctx, query.String(), filter.Args(nil))
+	rows, err := c.NamedQueryContext(ctx, query.Build(), filter.Args(nil))
 	if err != nil {
 		return nil, errors.Wrap(err, "db")
 	}
@@ -209,7 +180,6 @@ func (c *Client) GetWebsiteOS(ctx context.Context, filter *db.Filters) ([]*model
 
 func (c *Client) GetWebsiteDevicesSummary(ctx context.Context, filter *db.Filters) ([]*model.StatsDevicesSummary, error) {
 	var devices []*model.StatsDevicesSummary
-	var query strings.Builder
 
 	// Array of devices
 	//
@@ -218,25 +188,19 @@ func (c *Client) GetWebsiteDevicesSummary(ctx context.Context, filter *db.Filter
 	// Visitors is the number of unique visitors for the device.
 	//
 	// VisitorsPercentage is the percentage the device contributes to the total visitors.
-	query.WriteString(`--sql
-		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
-			FROM views
-			WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(`--sql
-		)
-		SELECT
-			ua_device_type AS device,
-			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
-			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage
-		FROM views
-		WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(` GROUP BY device ORDER BY visitors DESC, device ASC`)
-	query.WriteString(filter.PaginationString())
+	query := TotalVisitorsCTE(filter.WhereString()).
+		Select(
+			"ua_device_type AS device",
+			VisitorsStmt,
+			VisitorsPercentageStmt,
+		).
+		From("views").
+		Where(filter.WhereString()).
+		GroupBy("device").
+		OrderBy("visitors DESC", "device ASC").
+		Pagination(filter.PaginationString())
 
-	rows, err := c.NamedQueryContext(ctx, query.String(), filter.Args(nil))
+	rows, err := c.NamedQueryContext(ctx, query.Build(), filter.Args(nil))
 	if err != nil {
 		return nil, errors.Wrap(err, "db")
 	}
@@ -257,7 +221,6 @@ func (c *Client) GetWebsiteDevicesSummary(ctx context.Context, filter *db.Filter
 // GetWebsiteDevices returns the devices for the given hostname.
 func (c *Client) GetWebsiteDevices(ctx context.Context, filter *db.Filters) ([]*model.StatsDevices, error) {
 	var devices []*model.StatsDevices
-	var query strings.Builder
 
 	// Array of devices
 	//
@@ -266,27 +229,21 @@ func (c *Client) GetWebsiteDevices(ctx context.Context, filter *db.Filters) ([]*
 	// Visitors is the number of unique visitors for the device.
 	//
 	// VisitorsPercentage is the percentage the device contributes to the total visitors.
-	query.WriteString(`--sql
-		WITH total AS MATERIALIZED (
-			SELECT COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors
-			FROM views
-			WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(`--sql
-		)
-		SELECT
-			ua_device_type AS device,
-			COUNT(*) FILTER (WHERE is_unique_user = true) AS visitors,
-			ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage,
-			COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces,
-			CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration
-		FROM views
-		WHERE `)
-	query.WriteString(filter.WhereString())
-	query.WriteString(` GROUP BY device ORDER BY visitors DESC, device ASC`)
-	query.WriteString(filter.PaginationString())
+	query := TotalVisitorsCTE(filter.WhereString()).
+		Select(
+			"ua_device_type AS device",
+			VisitorsStmt,
+			VisitorsPercentageStmt,
+			BouncesStmt,
+			DurationStmt,
+		).
+		From("views").
+		Where(filter.WhereString()).
+		GroupBy("device").
+		OrderBy("visitors DESC", "device ASC").
+		Pagination(filter.PaginationString())
 
-	rows, err := c.NamedQueryContext(ctx, query.String(), filter.Args(nil))
+	rows, err := c.NamedQueryContext(ctx, query.Build(), filter.Args(nil))
 	if err != nil {
 		return nil, errors.Wrap(err, "db")
 	}


### PR DESCRIPTION
This refactors the DuckDB queries to use a custom query builder for simpler and safer query modifications in the future. This also inadvertently resolved a bug related to time queries on the summary page being a little different from the expanded view, due to a misplaced `LIMIT` statement.