### PR TITLE
fix(core): use more accurate bounce rate query 

### DIFF
--- a/core/api/oas_json_gen.go
+++ b/core/api/oas_json_gen.go
@@ -2571,9 +2571,9 @@ func (s *StatsBrowsersItem) encodeFields(e *jx.Encoder) {
 		e.Float32(s.VisitorsPercentage)
 	}
 	{
-		if s.Bounces.Set {
-			e.FieldStart("bounces")
-			s.Bounces.Encode(e)
+		if s.BouncePercentage.Set {
+			e.FieldStart("bounce_percentage")
+			s.BouncePercentage.Encode(e)
 		}
 	}
 	{
@@ -2588,7 +2588,7 @@ var jsonFieldsNameOfStatsBrowsersItem = [5]string{
 	0: "browser",
 	1: "visitors",
 	2: "visitors_percentage",
-	3: "bounces",
+	3: "bounce_percentage",
 	4: "duration",
 }
 
@@ -2637,15 +2637,15 @@ func (s *StatsBrowsersItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"visitors_percentage\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			if err := func() error {
-				s.Bounces.Reset()
-				if err := s.Bounces.Decode(d); err != nil {
+				s.BouncePercentage.Reset()
+				if err := s.BouncePercentage.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			if err := func() error {
@@ -2785,9 +2785,9 @@ func (s *StatsCountriesItem) encodeFields(e *jx.Encoder) {
 		e.Float32(s.VisitorsPercentage)
 	}
 	{
-		if s.Bounces.Set {
-			e.FieldStart("bounces")
-			s.Bounces.Encode(e)
+		if s.BouncePercentage.Set {
+			e.FieldStart("bounce_percentage")
+			s.BouncePercentage.Encode(e)
 		}
 	}
 	{
@@ -2802,7 +2802,7 @@ var jsonFieldsNameOfStatsCountriesItem = [5]string{
 	0: "country",
 	1: "visitors",
 	2: "visitors_percentage",
-	3: "bounces",
+	3: "bounce_percentage",
 	4: "duration",
 }
 
@@ -2851,15 +2851,15 @@ func (s *StatsCountriesItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"visitors_percentage\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			if err := func() error {
-				s.Bounces.Reset()
-				if err := s.Bounces.Decode(d); err != nil {
+				s.BouncePercentage.Reset()
+				if err := s.BouncePercentage.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			if err := func() error {
@@ -2999,9 +2999,9 @@ func (s *StatsDevicesItem) encodeFields(e *jx.Encoder) {
 		e.Float32(s.VisitorsPercentage)
 	}
 	{
-		if s.Bounces.Set {
-			e.FieldStart("bounces")
-			s.Bounces.Encode(e)
+		if s.BouncePercentage.Set {
+			e.FieldStart("bounce_percentage")
+			s.BouncePercentage.Encode(e)
 		}
 	}
 	{
@@ -3016,7 +3016,7 @@ var jsonFieldsNameOfStatsDevicesItem = [5]string{
 	0: "device",
 	1: "visitors",
 	2: "visitors_percentage",
-	3: "bounces",
+	3: "bounce_percentage",
 	4: "duration",
 }
 
@@ -3065,15 +3065,15 @@ func (s *StatsDevicesItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"visitors_percentage\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			if err := func() error {
-				s.Bounces.Reset()
-				if err := s.Bounces.Decode(d); err != nil {
+				s.BouncePercentage.Reset()
+				if err := s.BouncePercentage.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			if err := func() error {
@@ -3213,9 +3213,9 @@ func (s *StatsLanguagesItem) encodeFields(e *jx.Encoder) {
 		e.Float32(s.VisitorsPercentage)
 	}
 	{
-		if s.Bounces.Set {
-			e.FieldStart("bounces")
-			s.Bounces.Encode(e)
+		if s.BouncePercentage.Set {
+			e.FieldStart("bounce_percentage")
+			s.BouncePercentage.Encode(e)
 		}
 	}
 	{
@@ -3230,7 +3230,7 @@ var jsonFieldsNameOfStatsLanguagesItem = [5]string{
 	0: "language",
 	1: "visitors",
 	2: "visitors_percentage",
-	3: "bounces",
+	3: "bounce_percentage",
 	4: "duration",
 }
 
@@ -3279,15 +3279,15 @@ func (s *StatsLanguagesItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"visitors_percentage\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			if err := func() error {
-				s.Bounces.Reset()
-				if err := s.Bounces.Decode(d); err != nil {
+				s.BouncePercentage.Reset()
+				if err := s.BouncePercentage.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			if err := func() error {
@@ -3427,9 +3427,9 @@ func (s *StatsOSItem) encodeFields(e *jx.Encoder) {
 		e.Float32(s.VisitorsPercentage)
 	}
 	{
-		if s.Bounces.Set {
-			e.FieldStart("bounces")
-			s.Bounces.Encode(e)
+		if s.BouncePercentage.Set {
+			e.FieldStart("bounce_percentage")
+			s.BouncePercentage.Encode(e)
 		}
 	}
 	{
@@ -3444,7 +3444,7 @@ var jsonFieldsNameOfStatsOSItem = [5]string{
 	0: "os",
 	1: "visitors",
 	2: "visitors_percentage",
-	3: "bounces",
+	3: "bounce_percentage",
 	4: "duration",
 }
 
@@ -3493,15 +3493,15 @@ func (s *StatsOSItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"visitors_percentage\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			if err := func() error {
-				s.Bounces.Reset()
-				if err := s.Bounces.Decode(d); err != nil {
+				s.BouncePercentage.Reset()
+				if err := s.BouncePercentage.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			if err := func() error {
@@ -3653,9 +3653,9 @@ func (s *StatsPagesItem) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
-		if s.Bounces.Set {
-			e.FieldStart("bounces")
-			s.Bounces.Encode(e)
+		if s.BouncePercentage.Set {
+			e.FieldStart("bounce_percentage")
+			s.BouncePercentage.Encode(e)
 		}
 	}
 	{
@@ -3672,7 +3672,7 @@ var jsonFieldsNameOfStatsPagesItem = [7]string{
 	2: "visitors_percentage",
 	3: "pageviews",
 	4: "pageviews_percentage",
-	5: "bounces",
+	5: "bounce_percentage",
 	6: "duration",
 }
 
@@ -3741,15 +3741,15 @@ func (s *StatsPagesItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"pageviews_percentage\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			if err := func() error {
-				s.Bounces.Reset()
-				if err := s.Bounces.Decode(d); err != nil {
+				s.BouncePercentage.Reset()
+				if err := s.BouncePercentage.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			if err := func() error {
@@ -3889,9 +3889,9 @@ func (s *StatsReferrersItem) encodeFields(e *jx.Encoder) {
 		e.Float32(s.VisitorsPercentage)
 	}
 	{
-		if s.Bounces.Set {
-			e.FieldStart("bounces")
-			s.Bounces.Encode(e)
+		if s.BouncePercentage.Set {
+			e.FieldStart("bounce_percentage")
+			s.BouncePercentage.Encode(e)
 		}
 	}
 	{
@@ -3906,7 +3906,7 @@ var jsonFieldsNameOfStatsReferrersItem = [5]string{
 	0: "referrer",
 	1: "visitors",
 	2: "visitors_percentage",
-	3: "bounces",
+	3: "bounce_percentage",
 	4: "duration",
 }
 
@@ -3955,15 +3955,15 @@ func (s *StatsReferrersItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"visitors_percentage\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			if err := func() error {
-				s.Bounces.Reset()
-				if err := s.Bounces.Decode(d); err != nil {
+				s.BouncePercentage.Reset()
+				if err := s.BouncePercentage.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			if err := func() error {
@@ -4188,8 +4188,8 @@ func (s *StatsSummaryCurrent) encodeFields(e *jx.Encoder) {
 		e.Int(s.Pageviews)
 	}
 	{
-		e.FieldStart("bounces")
-		e.Int(s.Bounces)
+		e.FieldStart("bounce_percentage")
+		e.Float32(s.BouncePercentage)
 	}
 	{
 		e.FieldStart("duration")
@@ -4200,7 +4200,7 @@ func (s *StatsSummaryCurrent) encodeFields(e *jx.Encoder) {
 var jsonFieldsNameOfStatsSummaryCurrent = [4]string{
 	0: "visitors",
 	1: "pageviews",
-	2: "bounces",
+	2: "bounce_percentage",
 	3: "duration",
 }
 
@@ -4237,17 +4237,17 @@ func (s *StatsSummaryCurrent) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"pageviews\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
-				v, err := d.Int()
-				s.Bounces = int(v)
+				v, err := d.Float32()
+				s.BouncePercentage = float32(v)
 				if err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			requiredBitSet[0] |= 1 << 3
@@ -4343,9 +4343,9 @@ func (s *StatsSummaryIntervalItem) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
-		if s.Bounces.Set {
-			e.FieldStart("bounces")
-			s.Bounces.Encode(e)
+		if s.BouncePercentage.Set {
+			e.FieldStart("bounce_percentage")
+			s.BouncePercentage.Encode(e)
 		}
 	}
 	{
@@ -4360,7 +4360,7 @@ var jsonFieldsNameOfStatsSummaryIntervalItem = [5]string{
 	0: "date",
 	1: "visitors",
 	2: "pageviews",
-	3: "bounces",
+	3: "bounce_percentage",
 	4: "duration",
 }
 
@@ -4405,15 +4405,15 @@ func (s *StatsSummaryIntervalItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"pageviews\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			if err := func() error {
-				s.Bounces.Reset()
-				if err := s.Bounces.Decode(d); err != nil {
+				s.BouncePercentage.Reset()
+				if err := s.BouncePercentage.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			if err := func() error {
@@ -4499,8 +4499,8 @@ func (s *StatsSummaryPrevious) encodeFields(e *jx.Encoder) {
 		e.Int(s.Pageviews)
 	}
 	{
-		e.FieldStart("bounces")
-		e.Int(s.Bounces)
+		e.FieldStart("bounce_percentage")
+		e.Float32(s.BouncePercentage)
 	}
 	{
 		e.FieldStart("duration")
@@ -4511,7 +4511,7 @@ func (s *StatsSummaryPrevious) encodeFields(e *jx.Encoder) {
 var jsonFieldsNameOfStatsSummaryPrevious = [4]string{
 	0: "visitors",
 	1: "pageviews",
-	2: "bounces",
+	2: "bounce_percentage",
 	3: "duration",
 }
 
@@ -4548,17 +4548,17 @@ func (s *StatsSummaryPrevious) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"pageviews\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			requiredBitSet[0] |= 1 << 2
 			if err := func() error {
-				v, err := d.Int()
-				s.Bounces = int(v)
+				v, err := d.Float32()
+				s.BouncePercentage = float32(v)
 				if err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			requiredBitSet[0] |= 1 << 3
@@ -4931,9 +4931,9 @@ func (s *StatsUTMCampaignsItem) encodeFields(e *jx.Encoder) {
 		e.Float32(s.VisitorsPercentage)
 	}
 	{
-		if s.Bounces.Set {
-			e.FieldStart("bounces")
-			s.Bounces.Encode(e)
+		if s.BouncePercentage.Set {
+			e.FieldStart("bounce_percentage")
+			s.BouncePercentage.Encode(e)
 		}
 	}
 	{
@@ -4948,7 +4948,7 @@ var jsonFieldsNameOfStatsUTMCampaignsItem = [5]string{
 	0: "campaign",
 	1: "visitors",
 	2: "visitors_percentage",
-	3: "bounces",
+	3: "bounce_percentage",
 	4: "duration",
 }
 
@@ -4997,15 +4997,15 @@ func (s *StatsUTMCampaignsItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"visitors_percentage\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			if err := func() error {
-				s.Bounces.Reset()
-				if err := s.Bounces.Decode(d); err != nil {
+				s.BouncePercentage.Reset()
+				if err := s.BouncePercentage.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			if err := func() error {
@@ -5145,9 +5145,9 @@ func (s *StatsUTMMediumsItem) encodeFields(e *jx.Encoder) {
 		e.Float32(s.VisitorsPercentage)
 	}
 	{
-		if s.Bounces.Set {
-			e.FieldStart("bounces")
-			s.Bounces.Encode(e)
+		if s.BouncePercentage.Set {
+			e.FieldStart("bounce_percentage")
+			s.BouncePercentage.Encode(e)
 		}
 	}
 	{
@@ -5162,7 +5162,7 @@ var jsonFieldsNameOfStatsUTMMediumsItem = [5]string{
 	0: "medium",
 	1: "visitors",
 	2: "visitors_percentage",
-	3: "bounces",
+	3: "bounce_percentage",
 	4: "duration",
 }
 
@@ -5211,15 +5211,15 @@ func (s *StatsUTMMediumsItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"visitors_percentage\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			if err := func() error {
-				s.Bounces.Reset()
-				if err := s.Bounces.Decode(d); err != nil {
+				s.BouncePercentage.Reset()
+				if err := s.BouncePercentage.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			if err := func() error {
@@ -5359,9 +5359,9 @@ func (s *StatsUTMSourcesItem) encodeFields(e *jx.Encoder) {
 		e.Float32(s.VisitorsPercentage)
 	}
 	{
-		if s.Bounces.Set {
-			e.FieldStart("bounces")
-			s.Bounces.Encode(e)
+		if s.BouncePercentage.Set {
+			e.FieldStart("bounce_percentage")
+			s.BouncePercentage.Encode(e)
 		}
 	}
 	{
@@ -5376,7 +5376,7 @@ var jsonFieldsNameOfStatsUTMSourcesItem = [5]string{
 	0: "source",
 	1: "visitors",
 	2: "visitors_percentage",
-	3: "bounces",
+	3: "bounce_percentage",
 	4: "duration",
 }
 
@@ -5425,15 +5425,15 @@ func (s *StatsUTMSourcesItem) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"visitors_percentage\"")
 			}
-		case "bounces":
+		case "bounce_percentage":
 			if err := func() error {
-				s.Bounces.Reset()
-				if err := s.Bounces.Decode(d); err != nil {
+				s.BouncePercentage.Reset()
+				if err := s.BouncePercentage.Decode(d); err != nil {
 					return err
 				}
 				return nil
 			}(); err != nil {
-				return errors.Wrap(err, "decode field \"bounces\"")
+				return errors.Wrap(err, "decode field \"bounce_percentage\"")
 			}
 		case "duration":
 			if err := func() error {

--- a/core/api/oas_response_encoders_gen.go
+++ b/core/api/oas_response_encoders_gen.go
@@ -1214,6 +1214,14 @@ func encodeGetWebsiteIDSourcesResponse(response GetWebsiteIDSourcesRes, w http.R
 func encodeGetWebsiteIDSummaryResponse(response GetWebsiteIDSummaryRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
 	case *StatsSummary:
+		if err := func() error {
+			if err := response.Validate(); err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrap(err, "validate")
+		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(200)
 

--- a/core/api/oas_schemas_gen.go
+++ b/core/api/oas_schemas_gen.go
@@ -1468,9 +1468,9 @@ type StatsBrowsersItem struct {
 	Visitors int `json:"visitors"`
 	// Percentage of unique visitors from browser.
 	VisitorsPercentage float32 `json:"visitors_percentage"`
-	// Number of bounces from referrer.
-	Bounces OptInt `json:"bounces"`
-	// Total time spent on page from referrer in milliseconds.
+	// Bounce rate percentage from browser.
+	BouncePercentage OptFloat32 `json:"bounce_percentage"`
+	// Total time spent on page from browser in milliseconds.
 	Duration OptInt `json:"duration"`
 }
 
@@ -1489,9 +1489,9 @@ func (s *StatsBrowsersItem) GetVisitorsPercentage() float32 {
 	return s.VisitorsPercentage
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsBrowsersItem) GetBounces() OptInt {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsBrowsersItem) GetBouncePercentage() OptFloat32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -1514,9 +1514,9 @@ func (s *StatsBrowsersItem) SetVisitorsPercentage(val float32) {
 	s.VisitorsPercentage = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsBrowsersItem) SetBounces(val OptInt) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsBrowsersItem) SetBouncePercentage(val OptFloat32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.
@@ -1535,9 +1535,9 @@ type StatsCountriesItem struct {
 	Visitors int `json:"visitors"`
 	// Percentage of unique visitors from country.
 	VisitorsPercentage float32 `json:"visitors_percentage"`
-	// Number of bounces from referrer.
-	Bounces OptInt `json:"bounces"`
-	// Total time spent on page from referrer in milliseconds.
+	// Bounce rate percentage from country.
+	BouncePercentage OptFloat32 `json:"bounce_percentage"`
+	// Total time spent on page from country in milliseconds.
 	Duration OptInt `json:"duration"`
 }
 
@@ -1556,9 +1556,9 @@ func (s *StatsCountriesItem) GetVisitorsPercentage() float32 {
 	return s.VisitorsPercentage
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsCountriesItem) GetBounces() OptInt {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsCountriesItem) GetBouncePercentage() OptFloat32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -1581,9 +1581,9 @@ func (s *StatsCountriesItem) SetVisitorsPercentage(val float32) {
 	s.VisitorsPercentage = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsCountriesItem) SetBounces(val OptInt) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsCountriesItem) SetBouncePercentage(val OptFloat32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.
@@ -1602,9 +1602,9 @@ type StatsDevicesItem struct {
 	Visitors int `json:"visitors"`
 	// Percentage of unique visitors from device.
 	VisitorsPercentage float32 `json:"visitors_percentage"`
-	// Number of bounces from referrer.
-	Bounces OptInt `json:"bounces"`
-	// Total time spent on page from referrer in milliseconds.
+	// Bounce rate percentage from device.
+	BouncePercentage OptFloat32 `json:"bounce_percentage"`
+	// Total time spent on page from device in milliseconds.
 	Duration OptInt `json:"duration"`
 }
 
@@ -1623,9 +1623,9 @@ func (s *StatsDevicesItem) GetVisitorsPercentage() float32 {
 	return s.VisitorsPercentage
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsDevicesItem) GetBounces() OptInt {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsDevicesItem) GetBouncePercentage() OptFloat32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -1648,9 +1648,9 @@ func (s *StatsDevicesItem) SetVisitorsPercentage(val float32) {
 	s.VisitorsPercentage = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsDevicesItem) SetBounces(val OptInt) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsDevicesItem) SetBouncePercentage(val OptFloat32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.
@@ -1669,9 +1669,9 @@ type StatsLanguagesItem struct {
 	Visitors int `json:"visitors"`
 	// Percentage of unique visitors for language.
 	VisitorsPercentage float32 `json:"visitors_percentage"`
-	// Number of bounces from referrer.
-	Bounces OptInt `json:"bounces"`
-	// Total time spent on page from referrer in milliseconds.
+	// Bounce rate percentage for language.
+	BouncePercentage OptFloat32 `json:"bounce_percentage"`
+	// Total time spent on page from language in milliseconds.
 	Duration OptInt `json:"duration"`
 }
 
@@ -1690,9 +1690,9 @@ func (s *StatsLanguagesItem) GetVisitorsPercentage() float32 {
 	return s.VisitorsPercentage
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsLanguagesItem) GetBounces() OptInt {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsLanguagesItem) GetBouncePercentage() OptFloat32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -1715,9 +1715,9 @@ func (s *StatsLanguagesItem) SetVisitorsPercentage(val float32) {
 	s.VisitorsPercentage = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsLanguagesItem) SetBounces(val OptInt) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsLanguagesItem) SetBouncePercentage(val OptFloat32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.
@@ -1736,9 +1736,9 @@ type StatsOSItem struct {
 	Visitors int `json:"visitors"`
 	// Percentage of unique visitors from OS.
 	VisitorsPercentage float32 `json:"visitors_percentage"`
-	// Number of bounces from referrer.
-	Bounces OptInt `json:"bounces"`
-	// Total time spent on page from referrer in milliseconds.
+	// Bounce rate percentage from OS.
+	BouncePercentage OptFloat32 `json:"bounce_percentage"`
+	// Total time spent on page from OS in milliseconds.
 	Duration OptInt `json:"duration"`
 }
 
@@ -1757,9 +1757,9 @@ func (s *StatsOSItem) GetVisitorsPercentage() float32 {
 	return s.VisitorsPercentage
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsOSItem) GetBounces() OptInt {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsOSItem) GetBouncePercentage() OptFloat32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -1782,9 +1782,9 @@ func (s *StatsOSItem) SetVisitorsPercentage(val float32) {
 	s.VisitorsPercentage = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsOSItem) SetBounces(val OptInt) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsOSItem) SetBouncePercentage(val OptFloat32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.
@@ -1807,8 +1807,8 @@ type StatsPagesItem struct {
 	Pageviews OptInt `json:"pageviews"`
 	// Percentage of page views.
 	PageviewsPercentage OptFloat32 `json:"pageviews_percentage"`
-	// Number of bounces.
-	Bounces OptInt `json:"bounces"`
+	// Bounce rate percentage.
+	BouncePercentage OptFloat32 `json:"bounce_percentage"`
 	// Total time spent on page in milliseconds.
 	Duration OptInt `json:"duration"`
 }
@@ -1838,9 +1838,9 @@ func (s *StatsPagesItem) GetPageviewsPercentage() OptFloat32 {
 	return s.PageviewsPercentage
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsPagesItem) GetBounces() OptInt {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsPagesItem) GetBouncePercentage() OptFloat32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -1873,9 +1873,9 @@ func (s *StatsPagesItem) SetPageviewsPercentage(val OptFloat32) {
 	s.PageviewsPercentage = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsPagesItem) SetBounces(val OptInt) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsPagesItem) SetBouncePercentage(val OptFloat32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.
@@ -1894,8 +1894,8 @@ type StatsReferrersItem struct {
 	Visitors int `json:"visitors"`
 	// Percentage of unique visitors from referrer.
 	VisitorsPercentage float32 `json:"visitors_percentage"`
-	// Number of bounces from referrer.
-	Bounces OptInt `json:"bounces"`
+	// Bounce rate percentage from referrer.
+	BouncePercentage OptFloat32 `json:"bounce_percentage"`
 	// Total time spent on page from referrer in milliseconds.
 	Duration OptInt `json:"duration"`
 }
@@ -1915,9 +1915,9 @@ func (s *StatsReferrersItem) GetVisitorsPercentage() float32 {
 	return s.VisitorsPercentage
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsReferrersItem) GetBounces() OptInt {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsReferrersItem) GetBouncePercentage() OptFloat32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -1940,9 +1940,9 @@ func (s *StatsReferrersItem) SetVisitorsPercentage(val float32) {
 	s.VisitorsPercentage = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsReferrersItem) SetBounces(val OptInt) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsReferrersItem) SetBouncePercentage(val OptFloat32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.
@@ -1990,10 +1990,10 @@ func (s *StatsSummary) SetInterval(val []StatsSummaryIntervalItem) {
 func (*StatsSummary) getWebsiteIDSummaryRes() {}
 
 type StatsSummaryCurrent struct {
-	Visitors  int `json:"visitors"`
-	Pageviews int `json:"pageviews"`
-	Bounces   int `json:"bounces"`
-	Duration  int `json:"duration"`
+	Visitors         int     `json:"visitors"`
+	Pageviews        int     `json:"pageviews"`
+	BouncePercentage float32 `json:"bounce_percentage"`
+	Duration         int     `json:"duration"`
 }
 
 // GetVisitors returns the value of Visitors.
@@ -2006,9 +2006,9 @@ func (s *StatsSummaryCurrent) GetPageviews() int {
 	return s.Pageviews
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsSummaryCurrent) GetBounces() int {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsSummaryCurrent) GetBouncePercentage() float32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -2026,9 +2026,9 @@ func (s *StatsSummaryCurrent) SetPageviews(val int) {
 	s.Pageviews = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsSummaryCurrent) SetBounces(val int) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsSummaryCurrent) SetBouncePercentage(val float32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.
@@ -2037,11 +2037,11 @@ func (s *StatsSummaryCurrent) SetDuration(val int) {
 }
 
 type StatsSummaryIntervalItem struct {
-	Date      string `json:"date"`
-	Visitors  OptInt `json:"visitors"`
-	Pageviews OptInt `json:"pageviews"`
-	Bounces   OptInt `json:"bounces"`
-	Duration  OptInt `json:"duration"`
+	Date             string     `json:"date"`
+	Visitors         OptInt     `json:"visitors"`
+	Pageviews        OptInt     `json:"pageviews"`
+	BouncePercentage OptFloat32 `json:"bounce_percentage"`
+	Duration         OptInt     `json:"duration"`
 }
 
 // GetDate returns the value of Date.
@@ -2059,9 +2059,9 @@ func (s *StatsSummaryIntervalItem) GetPageviews() OptInt {
 	return s.Pageviews
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsSummaryIntervalItem) GetBounces() OptInt {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsSummaryIntervalItem) GetBouncePercentage() OptFloat32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -2084,9 +2084,9 @@ func (s *StatsSummaryIntervalItem) SetPageviews(val OptInt) {
 	s.Pageviews = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsSummaryIntervalItem) SetBounces(val OptInt) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsSummaryIntervalItem) SetBouncePercentage(val OptFloat32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.
@@ -2095,10 +2095,10 @@ func (s *StatsSummaryIntervalItem) SetDuration(val OptInt) {
 }
 
 type StatsSummaryPrevious struct {
-	Visitors  int `json:"visitors"`
-	Pageviews int `json:"pageviews"`
-	Bounces   int `json:"bounces"`
-	Duration  int `json:"duration"`
+	Visitors         int     `json:"visitors"`
+	Pageviews        int     `json:"pageviews"`
+	BouncePercentage float32 `json:"bounce_percentage"`
+	Duration         int     `json:"duration"`
 }
 
 // GetVisitors returns the value of Visitors.
@@ -2111,9 +2111,9 @@ func (s *StatsSummaryPrevious) GetPageviews() int {
 	return s.Pageviews
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsSummaryPrevious) GetBounces() int {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsSummaryPrevious) GetBouncePercentage() float32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -2131,9 +2131,9 @@ func (s *StatsSummaryPrevious) SetPageviews(val int) {
 	s.Pageviews = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsSummaryPrevious) SetBounces(val int) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsSummaryPrevious) SetBouncePercentage(val float32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.
@@ -2231,9 +2231,9 @@ type StatsUTMCampaignsItem struct {
 	Visitors int `json:"visitors"`
 	// Percentage of unique visitors from UTM campaign.
 	VisitorsPercentage float32 `json:"visitors_percentage"`
-	// Number of bounces from referrer.
-	Bounces OptInt `json:"bounces"`
-	// Total time spent on page from referrer in milliseconds.
+	// Bounce rate percentage from UTM campaign.
+	BouncePercentage OptFloat32 `json:"bounce_percentage"`
+	// Total time spent on page from UTM campaign in milliseconds.
 	Duration OptInt `json:"duration"`
 }
 
@@ -2252,9 +2252,9 @@ func (s *StatsUTMCampaignsItem) GetVisitorsPercentage() float32 {
 	return s.VisitorsPercentage
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsUTMCampaignsItem) GetBounces() OptInt {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsUTMCampaignsItem) GetBouncePercentage() OptFloat32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -2277,9 +2277,9 @@ func (s *StatsUTMCampaignsItem) SetVisitorsPercentage(val float32) {
 	s.VisitorsPercentage = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsUTMCampaignsItem) SetBounces(val OptInt) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsUTMCampaignsItem) SetBouncePercentage(val OptFloat32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.
@@ -2298,9 +2298,9 @@ type StatsUTMMediumsItem struct {
 	Visitors int `json:"visitors"`
 	// Percentage of unique visitors from UTM medium.
 	VisitorsPercentage float32 `json:"visitors_percentage"`
-	// Number of bounces from referrer.
-	Bounces OptInt `json:"bounces"`
-	// Total time spent on page from referrer in milliseconds.
+	// Bounce rate percentage from UTM medium.
+	BouncePercentage OptFloat32 `json:"bounce_percentage"`
+	// Total time spent on page from UTM medium in milliseconds.
 	Duration OptInt `json:"duration"`
 }
 
@@ -2319,9 +2319,9 @@ func (s *StatsUTMMediumsItem) GetVisitorsPercentage() float32 {
 	return s.VisitorsPercentage
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsUTMMediumsItem) GetBounces() OptInt {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsUTMMediumsItem) GetBouncePercentage() OptFloat32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -2344,9 +2344,9 @@ func (s *StatsUTMMediumsItem) SetVisitorsPercentage(val float32) {
 	s.VisitorsPercentage = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsUTMMediumsItem) SetBounces(val OptInt) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsUTMMediumsItem) SetBouncePercentage(val OptFloat32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.
@@ -2365,9 +2365,9 @@ type StatsUTMSourcesItem struct {
 	Visitors int `json:"visitors"`
 	// Percentage of unique visitors from UTM source.
 	VisitorsPercentage float32 `json:"visitors_percentage"`
-	// Number of bounces from referrer.
-	Bounces OptInt `json:"bounces"`
-	// Total time spent on page from referrer in milliseconds.
+	// Bounce rate percentage from UTM source.
+	BouncePercentage OptFloat32 `json:"bounce_percentage"`
+	// Total time spent on page from UTM source in milliseconds.
 	Duration OptInt `json:"duration"`
 }
 
@@ -2386,9 +2386,9 @@ func (s *StatsUTMSourcesItem) GetVisitorsPercentage() float32 {
 	return s.VisitorsPercentage
 }
 
-// GetBounces returns the value of Bounces.
-func (s *StatsUTMSourcesItem) GetBounces() OptInt {
-	return s.Bounces
+// GetBouncePercentage returns the value of BouncePercentage.
+func (s *StatsUTMSourcesItem) GetBouncePercentage() OptFloat32 {
+	return s.BouncePercentage
 }
 
 // GetDuration returns the value of Duration.
@@ -2411,9 +2411,9 @@ func (s *StatsUTMSourcesItem) SetVisitorsPercentage(val float32) {
 	s.VisitorsPercentage = val
 }
 
-// SetBounces sets the value of Bounces.
-func (s *StatsUTMSourcesItem) SetBounces(val OptInt) {
-	s.Bounces = val
+// SetBouncePercentage sets the value of BouncePercentage.
+func (s *StatsUTMSourcesItem) SetBouncePercentage(val OptFloat32) {
+	s.BouncePercentage = val
 }
 
 // SetDuration sets the value of Duration.

--- a/core/api/oas_validators_gen.go
+++ b/core/api/oas_validators_gen.go
@@ -301,6 +301,24 @@ func (s *StatsBrowsersItem) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.BouncePercentage.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -346,6 +364,24 @@ func (s *StatsCountriesItem) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visitors_percentage",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.BouncePercentage.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
 			Error: err,
 		})
 	}
@@ -397,6 +433,24 @@ func (s *StatsDevicesItem) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.BouncePercentage.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -445,6 +499,24 @@ func (s *StatsLanguagesItem) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.BouncePercentage.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -490,6 +562,24 @@ func (s *StatsOSItem) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visitors_percentage",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.BouncePercentage.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
 			Error: err,
 		})
 	}
@@ -559,6 +649,24 @@ func (s *StatsPagesItem) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.BouncePercentage.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -604,6 +712,166 @@ func (s *StatsReferrersItem) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visitors_percentage",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.BouncePercentage.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *StatsSummary) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Current.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "current",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.Previous.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "previous",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		var failures []validate.FieldError
+		for i, elem := range s.Interval {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "interval",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *StatsSummaryCurrent) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := (validate.Float{}).Validate(float64(s.BouncePercentage)); err != nil {
+			return errors.Wrap(err, "float")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *StatsSummaryIntervalItem) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if value, ok := s.BouncePercentage.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *StatsSummaryPrevious) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := (validate.Float{}).Validate(float64(s.BouncePercentage)); err != nil {
+			return errors.Wrap(err, "float")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
 			Error: err,
 		})
 	}
@@ -703,6 +971,24 @@ func (s *StatsUTMCampaignsItem) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.BouncePercentage.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -751,6 +1037,24 @@ func (s *StatsUTMMediumsItem) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.BouncePercentage.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -796,6 +1100,24 @@ func (s *StatsUTMSourcesItem) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "visitors_percentage",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.BouncePercentage.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "bounce_percentage",
 			Error: err,
 		})
 	}

--- a/core/db/duckdb/__snapshots__/locale_test.snap
+++ b/core/db/duckdb/__snapshots__/locale_test.snap
@@ -1,29 +1,29 @@
 
 [TestGetWebsiteCountries/Base - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United States Visitors:166892 VisitorsPercentage:0.334} Bounces:41323 Duration:5014}
-&{StatsCountriesSummary:{Country:Japan Visitors:166747 VisitorsPercentage:0.3337} Bounces:41697 Duration:5007}
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:166018 VisitorsPercentage:0.3323} Bounces:41664 Duration:4986}
+&{StatsCountriesSummary:{Country:United States Visitors:166892 VisitorsPercentage:0.334} BounceRate:0.4996 Duration:5014}
+&{StatsCountriesSummary:{Country:Japan Visitors:166747 VisitorsPercentage:0.3337} BounceRate:0.4996 Duration:5007}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:166018 VisitorsPercentage:0.3323} BounceRate:0.4996 Duration:4986}
 
 ---
 
 [TestGetWebsiteCountries/Browser - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:Japan Visitors:55533 VisitorsPercentage:0.3344} Bounces:14047 Duration:4954}
-&{StatsCountriesSummary:{Country:United States Visitors:55314 VisitorsPercentage:0.333} Bounces:13749 Duration:4992}
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:55243 VisitorsPercentage:0.3326} Bounces:13844 Duration:4992}
+&{StatsCountriesSummary:{Country:Japan Visitors:55533 VisitorsPercentage:0.3344} BounceRate:0.5009 Duration:4954}
+&{StatsCountriesSummary:{Country:United States Visitors:55314 VisitorsPercentage:0.333} BounceRate:0.5009 Duration:4992}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:55243 VisitorsPercentage:0.3326} BounceRate:0.5009 Duration:4992}
 
 ---
 
 [TestGetWebsiteCountries/Country - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:55243 VisitorsPercentage:1} Bounces:13844 Duration:4992}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:55243 VisitorsPercentage:1} BounceRate:0.4978 Duration:4992}
 
 ---
 
 [TestGetWebsiteCountries/Device - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:18661 VisitorsPercentage:1} Bounces:4691 Duration:4997}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:18661 VisitorsPercentage:1} BounceRate:0.4947 Duration:4997}
 
 ---
 
@@ -34,43 +34,43 @@ RECORDS:
 
 [TestGetWebsiteCountries/Language - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:9486 VisitorsPercentage:1} Bounces:2355 Duration:5003}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:9486 VisitorsPercentage:1} BounceRate:0.4931 Duration:5003}
 
 ---
 
 [TestGetWebsiteCountries/OS - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:3116 VisitorsPercentage:1} Bounces:783 Duration:4971}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:3116 VisitorsPercentage:1} BounceRate:0.5 Duration:4971}
 
 ---
 
 [TestGetWebsiteCountries/Pathname - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:1090 VisitorsPercentage:1} Bounces:268 Duration:5098}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:1090 VisitorsPercentage:1} BounceRate:0.4945 Duration:5098}
 
 ---
 
 [TestGetWebsiteCountries/Referrer - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
 
 ---
 
 [TestGetWebsiteCountries/UTMCampaign - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:116 VisitorsPercentage:1} BounceRate:0.5439 Duration:4732}
 
 ---
 
 [TestGetWebsiteCountries/UTMMedium - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:35 VisitorsPercentage:1} BounceRate:0.4615 Duration:6547}
 
 ---
 
 [TestGetWebsiteCountries/UTMSource - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
 
 ---
 
@@ -151,29 +151,29 @@ RECORDS:
 
 [TestGetWebsiteLanguages/Base - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:250816 VisitorsPercentage:0.502} Bounces:62517 Duration:5010}
-&{StatsLanguagesSummary:{Language:Japanese Visitors:248841 VisitorsPercentage:0.498} Bounces:62167 Duration:4996}
+&{StatsLanguagesSummary:{Language:English Visitors:250816 VisitorsPercentage:0.502} BounceRate:0.4996 Duration:5010}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:248841 VisitorsPercentage:0.498} BounceRate:0.4996 Duration:4996}
 
 ---
 
 [TestGetWebsiteLanguages/Browser - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:83279 VisitorsPercentage:0.5014} Bounces:20816 Duration:4992}
-&{StatsLanguagesSummary:{Language:Japanese Visitors:82811 VisitorsPercentage:0.4986} Bounces:20824 Duration:4966}
+&{StatsLanguagesSummary:{Language:English Visitors:83279 VisitorsPercentage:0.5014} BounceRate:0.5009 Duration:4992}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:82811 VisitorsPercentage:0.4986} BounceRate:0.5009 Duration:4966}
 
 ---
 
 [TestGetWebsiteLanguages/Country - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:27676 VisitorsPercentage:0.501} Bounces:6923 Duration:5006}
-&{StatsLanguagesSummary:{Language:Japanese Visitors:27567 VisitorsPercentage:0.499} Bounces:6921 Duration:4980}
+&{StatsLanguagesSummary:{Language:English Visitors:27676 VisitorsPercentage:0.501} BounceRate:0.4978 Duration:5006}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:27567 VisitorsPercentage:0.499} BounceRate:0.4978 Duration:4980}
 
 ---
 
 [TestGetWebsiteLanguages/Device - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:9486 VisitorsPercentage:0.5083} Bounces:2355 Duration:5003}
-&{StatsLanguagesSummary:{Language:Japanese Visitors:9175 VisitorsPercentage:0.4917} Bounces:2336 Duration:4992}
+&{StatsLanguagesSummary:{Language:English Visitors:9486 VisitorsPercentage:0.5083} BounceRate:0.4947 Duration:5003}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:9175 VisitorsPercentage:0.4917} BounceRate:0.4947 Duration:4992}
 
 ---
 
@@ -184,75 +184,75 @@ RECORDS:
 
 [TestGetWebsiteLanguages/Language - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:9486 VisitorsPercentage:1} Bounces:2355 Duration:5003}
+&{StatsLanguagesSummary:{Language:English Visitors:9486 VisitorsPercentage:1} BounceRate:0.4931 Duration:5003}
 
 ---
 
 [TestGetWebsiteLanguages/OS - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:3116 VisitorsPercentage:1} Bounces:783 Duration:4971}
+&{StatsLanguagesSummary:{Language:English Visitors:3116 VisitorsPercentage:1} BounceRate:0.5 Duration:4971}
 
 ---
 
 [TestGetWebsiteLanguages/Pathname - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:1090 VisitorsPercentage:1} Bounces:268 Duration:5098}
+&{StatsLanguagesSummary:{Language:English Visitors:1090 VisitorsPercentage:1} BounceRate:0.4945 Duration:5098}
 
 ---
 
 [TestGetWebsiteLanguages/Referrer - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
+&{StatsLanguagesSummary:{Language:English Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
 
 ---
 
 [TestGetWebsiteLanguages/UTMCampaign - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
+&{StatsLanguagesSummary:{Language:English Visitors:116 VisitorsPercentage:1} BounceRate:0.5439 Duration:4732}
 
 ---
 
 [TestGetWebsiteLanguages/UTMMedium - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
+&{StatsLanguagesSummary:{Language:English Visitors:35 VisitorsPercentage:1} BounceRate:0.4615 Duration:6547}
 
 ---
 
 [TestGetWebsiteLanguages/UTMSource - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
+&{StatsLanguagesSummary:{Language:English Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/Base - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:Japanese Visitors:248841 VisitorsPercentage:0.498} Bounces:62167 Duration:4996}
-&{StatsLanguagesSummary:{Language:British English Visitors:125499 VisitorsPercentage:0.2512} Bounces:31490 Duration:5001}
-&{StatsLanguagesSummary:{Language:American English Visitors:125317 VisitorsPercentage:0.2508} Bounces:31027 Duration:5017}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:248841 VisitorsPercentage:0.498} BounceRate:0.4996 Duration:4996}
+&{StatsLanguagesSummary:{Language:British English Visitors:125499 VisitorsPercentage:0.2512} BounceRate:0.4996 Duration:5001}
+&{StatsLanguagesSummary:{Language:American English Visitors:125317 VisitorsPercentage:0.2508} BounceRate:0.4996 Duration:5017}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/Browser - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:Japanese Visitors:82811 VisitorsPercentage:0.4986} Bounces:20824 Duration:4966}
-&{StatsLanguagesSummary:{Language:American English Visitors:41719 VisitorsPercentage:0.2512} Bounces:10350 Duration:4991}
-&{StatsLanguagesSummary:{Language:British English Visitors:41560 VisitorsPercentage:0.2502} Bounces:10466 Duration:4994}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:82811 VisitorsPercentage:0.4986} BounceRate:0.5009 Duration:4966}
+&{StatsLanguagesSummary:{Language:American English Visitors:41719 VisitorsPercentage:0.2512} BounceRate:0.5009 Duration:4991}
+&{StatsLanguagesSummary:{Language:British English Visitors:41560 VisitorsPercentage:0.2502} BounceRate:0.5009 Duration:4994}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/Country - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:Japanese Visitors:27567 VisitorsPercentage:0.499} Bounces:6921 Duration:4980}
-&{StatsLanguagesSummary:{Language:American English Visitors:13901 VisitorsPercentage:0.2516} Bounces:3418 Duration:5008}
-&{StatsLanguagesSummary:{Language:British English Visitors:13775 VisitorsPercentage:0.2494} Bounces:3505 Duration:5004}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:27567 VisitorsPercentage:0.499} BounceRate:0.4978 Duration:4980}
+&{StatsLanguagesSummary:{Language:American English Visitors:13901 VisitorsPercentage:0.2516} BounceRate:0.4978 Duration:5008}
+&{StatsLanguagesSummary:{Language:British English Visitors:13775 VisitorsPercentage:0.2494} BounceRate:0.4978 Duration:5004}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/Device - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:Japanese Visitors:9175 VisitorsPercentage:0.4917} Bounces:2336 Duration:4992}
-&{StatsLanguagesSummary:{Language:American English Visitors:4829 VisitorsPercentage:0.2588} Bounces:1168 Duration:5041}
-&{StatsLanguagesSummary:{Language:British English Visitors:4657 VisitorsPercentage:0.2496} Bounces:1187 Duration:4946}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:9175 VisitorsPercentage:0.4917} BounceRate:0.4947 Duration:4992}
+&{StatsLanguagesSummary:{Language:American English Visitors:4829 VisitorsPercentage:0.2588} BounceRate:0.4947 Duration:5041}
+&{StatsLanguagesSummary:{Language:British English Visitors:4657 VisitorsPercentage:0.2496} BounceRate:0.4947 Duration:4946}
 
 ---
 
@@ -263,50 +263,50 @@ RECORDS:
 
 [TestGetWebsiteLanguagesLocale/Language - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:4829 VisitorsPercentage:0.5091} Bounces:1168 Duration:5041}
-&{StatsLanguagesSummary:{Language:British English Visitors:4657 VisitorsPercentage:0.4909} Bounces:1187 Duration:4946}
+&{StatsLanguagesSummary:{Language:American English Visitors:4829 VisitorsPercentage:0.5091} BounceRate:0.4931 Duration:5041}
+&{StatsLanguagesSummary:{Language:British English Visitors:4657 VisitorsPercentage:0.4909} BounceRate:0.4931 Duration:4946}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/OS - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:1623 VisitorsPercentage:0.5209} Bounces:390 Duration:5050}
-&{StatsLanguagesSummary:{Language:British English Visitors:1493 VisitorsPercentage:0.4791} Bounces:393 Duration:4858}
+&{StatsLanguagesSummary:{Language:American English Visitors:1623 VisitorsPercentage:0.5209} BounceRate:0.5 Duration:5050}
+&{StatsLanguagesSummary:{Language:British English Visitors:1493 VisitorsPercentage:0.4791} BounceRate:0.5 Duration:4858}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/Pathname - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:570 VisitorsPercentage:0.5229} Bounces:136 Duration:5294}
-&{StatsLanguagesSummary:{Language:British English Visitors:520 VisitorsPercentage:0.4771} Bounces:132 Duration:4987}
+&{StatsLanguagesSummary:{Language:American English Visitors:570 VisitorsPercentage:0.5229} BounceRate:0.4945 Duration:5294}
+&{StatsLanguagesSummary:{Language:British English Visitors:520 VisitorsPercentage:0.4771} BounceRate:0.4945 Duration:4987}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/Referrer - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:194 VisitorsPercentage:0.5092} Bounces:51 Duration:4677}
-&{StatsLanguagesSummary:{Language:British English Visitors:187 VisitorsPercentage:0.4908} Bounces:45 Duration:4761}
+&{StatsLanguagesSummary:{Language:American English Visitors:194 VisitorsPercentage:0.5092} BounceRate:0.5363 Duration:4677}
+&{StatsLanguagesSummary:{Language:British English Visitors:187 VisitorsPercentage:0.4908} BounceRate:0.5363 Duration:4761}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/UTMCampaign - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:58 VisitorsPercentage:0.5} Bounces:18 Duration:3943}
-&{StatsLanguagesSummary:{Language:British English Visitors:58 VisitorsPercentage:0.5} Bounces:13 Duration:5896}
+&{StatsLanguagesSummary:{Language:American English Visitors:58 VisitorsPercentage:0.5} BounceRate:0.5439 Duration:3943}
+&{StatsLanguagesSummary:{Language:British English Visitors:58 VisitorsPercentage:0.5} BounceRate:0.5439 Duration:5896}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/UTMMedium - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:18 VisitorsPercentage:0.5143} Bounces:4 Duration:3038}
-&{StatsLanguagesSummary:{Language:British English Visitors:17 VisitorsPercentage:0.4857} Bounces:2 Duration:7189}
+&{StatsLanguagesSummary:{Language:American English Visitors:18 VisitorsPercentage:0.5143} BounceRate:0.4615 Duration:3038}
+&{StatsLanguagesSummary:{Language:British English Visitors:17 VisitorsPercentage:0.4857} BounceRate:0.4615 Duration:7189}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/UTMSource - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:10 VisitorsPercentage:0.5882} Bounces:2 Duration:2631}
-&{StatsLanguagesSummary:{Language:British English Visitors:7 VisitorsPercentage:0.4118} Bounces:1 Duration:6547}
+&{StatsLanguagesSummary:{Language:American English Visitors:10 VisitorsPercentage:0.5882} BounceRate:0.6 Duration:2631}
+&{StatsLanguagesSummary:{Language:British English Visitors:7 VisitorsPercentage:0.4118} BounceRate:0.6 Duration:6547}
 
 ---
 

--- a/core/db/duckdb/__snapshots__/locale_test.snap
+++ b/core/db/duckdb/__snapshots__/locale_test.snap
@@ -1,29 +1,29 @@
 
 [TestGetWebsiteCountries/Base - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United States Visitors:166892 VisitorsPercentage:0.334} BounceRate:0.4996 Duration:5014}
-&{StatsCountriesSummary:{Country:Japan Visitors:166747 VisitorsPercentage:0.3337} BounceRate:0.4996 Duration:5007}
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:166018 VisitorsPercentage:0.3323} BounceRate:0.4996 Duration:4986}
+&{StatsCountriesSummary:{Country:United States Visitors:166892 VisitorsPercentage:0.334} BounceRate:0.4871 Duration:5014}
+&{StatsCountriesSummary:{Country:Japan Visitors:166747 VisitorsPercentage:0.3337} BounceRate:0.4908 Duration:5007}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:166018 VisitorsPercentage:0.3323} BounceRate:0.4906 Duration:4986}
 
 ---
 
 [TestGetWebsiteCountries/Browser - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:Japan Visitors:55533 VisitorsPercentage:0.3344} BounceRate:0.5009 Duration:4954}
-&{StatsCountriesSummary:{Country:United States Visitors:55314 VisitorsPercentage:0.333} BounceRate:0.5009 Duration:4992}
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:55243 VisitorsPercentage:0.3326} BounceRate:0.5009 Duration:4992}
+&{StatsCountriesSummary:{Country:Japan Visitors:55533 VisitorsPercentage:0.3344} BounceRate:0.4952 Duration:4954}
+&{StatsCountriesSummary:{Country:United States Visitors:55314 VisitorsPercentage:0.333} BounceRate:0.4893 Duration:4992}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:55243 VisitorsPercentage:0.3326} BounceRate:0.4887 Duration:4992}
 
 ---
 
 [TestGetWebsiteCountries/Country - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:55243 VisitorsPercentage:1} BounceRate:0.4978 Duration:4992}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:55243 VisitorsPercentage:1} BounceRate:0.4887 Duration:4992}
 
 ---
 
 [TestGetWebsiteCountries/Device - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:18661 VisitorsPercentage:1} BounceRate:0.4947 Duration:4997}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:18661 VisitorsPercentage:1} BounceRate:0.4852 Duration:4997}
 
 ---
 
@@ -34,25 +34,25 @@ RECORDS:
 
 [TestGetWebsiteCountries/Language - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:9486 VisitorsPercentage:1} BounceRate:0.4931 Duration:5003}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:9486 VisitorsPercentage:1} BounceRate:0.4824 Duration:5003}
 
 ---
 
 [TestGetWebsiteCountries/OS - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:3116 VisitorsPercentage:1} BounceRate:0.5 Duration:4971}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:3116 VisitorsPercentage:1} BounceRate:0.4898 Duration:4971}
 
 ---
 
 [TestGetWebsiteCountries/Pathname - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:1090 VisitorsPercentage:1} BounceRate:0.4945 Duration:5098}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:1090 VisitorsPercentage:1} BounceRate:0.4852 Duration:5098}
 
 ---
 
 [TestGetWebsiteCountries/Referrer - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:381 VisitorsPercentage:1} BounceRate:0.5196 Duration:4728}
 
 ---
 
@@ -70,7 +70,7 @@ RECORDS:
 
 [TestGetWebsiteCountries/UTMSource - 1]
 RECORDS:
-&{StatsCountriesSummary:{Country:United Kingdom Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
+&{StatsCountriesSummary:{Country:United Kingdom Visitors:17 VisitorsPercentage:1} BounceRate:0 Duration:3389}
 
 ---
 
@@ -151,29 +151,29 @@ RECORDS:
 
 [TestGetWebsiteLanguages/Base - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:250816 VisitorsPercentage:0.502} BounceRate:0.4996 Duration:5010}
-&{StatsLanguagesSummary:{Language:Japanese Visitors:248841 VisitorsPercentage:0.498} BounceRate:0.4996 Duration:4996}
+&{StatsLanguagesSummary:{Language:English Visitors:250816 VisitorsPercentage:0.502} BounceRate:0.4897 Duration:5010}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:248841 VisitorsPercentage:0.498} BounceRate:0.4893 Duration:4996}
 
 ---
 
 [TestGetWebsiteLanguages/Browser - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:83279 VisitorsPercentage:0.5014} BounceRate:0.5009 Duration:4992}
-&{StatsLanguagesSummary:{Language:Japanese Visitors:82811 VisitorsPercentage:0.4986} BounceRate:0.5009 Duration:4966}
+&{StatsLanguagesSummary:{Language:English Visitors:83279 VisitorsPercentage:0.5014} BounceRate:0.4898 Duration:4992}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:82811 VisitorsPercentage:0.4986} BounceRate:0.4924 Duration:4966}
 
 ---
 
 [TestGetWebsiteLanguages/Country - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:27676 VisitorsPercentage:0.501} BounceRate:0.4978 Duration:5006}
-&{StatsLanguagesSummary:{Language:Japanese Visitors:27567 VisitorsPercentage:0.499} BounceRate:0.4978 Duration:4980}
+&{StatsLanguagesSummary:{Language:English Visitors:27676 VisitorsPercentage:0.501} BounceRate:0.4877 Duration:5006}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:27567 VisitorsPercentage:0.499} BounceRate:0.4896 Duration:4980}
 
 ---
 
 [TestGetWebsiteLanguages/Device - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:9486 VisitorsPercentage:0.5083} BounceRate:0.4947 Duration:5003}
-&{StatsLanguagesSummary:{Language:Japanese Visitors:9175 VisitorsPercentage:0.4917} BounceRate:0.4947 Duration:4992}
+&{StatsLanguagesSummary:{Language:English Visitors:9486 VisitorsPercentage:0.5083} BounceRate:0.4824 Duration:5003}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:9175 VisitorsPercentage:0.4917} BounceRate:0.4881 Duration:4992}
 
 ---
 
@@ -184,25 +184,25 @@ RECORDS:
 
 [TestGetWebsiteLanguages/Language - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:9486 VisitorsPercentage:1} BounceRate:0.4931 Duration:5003}
+&{StatsLanguagesSummary:{Language:English Visitors:9486 VisitorsPercentage:1} BounceRate:0.4824 Duration:5003}
 
 ---
 
 [TestGetWebsiteLanguages/OS - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:3116 VisitorsPercentage:1} BounceRate:0.5 Duration:4971}
+&{StatsLanguagesSummary:{Language:English Visitors:3116 VisitorsPercentage:1} BounceRate:0.4898 Duration:4971}
 
 ---
 
 [TestGetWebsiteLanguages/Pathname - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:1090 VisitorsPercentage:1} BounceRate:0.4945 Duration:5098}
+&{StatsLanguagesSummary:{Language:English Visitors:1090 VisitorsPercentage:1} BounceRate:0.4852 Duration:5098}
 
 ---
 
 [TestGetWebsiteLanguages/Referrer - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
+&{StatsLanguagesSummary:{Language:English Visitors:381 VisitorsPercentage:1} BounceRate:0.5196 Duration:4728}
 
 ---
 
@@ -220,39 +220,39 @@ RECORDS:
 
 [TestGetWebsiteLanguages/UTMSource - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:English Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
+&{StatsLanguagesSummary:{Language:English Visitors:17 VisitorsPercentage:1} BounceRate:0 Duration:3389}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/Base - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:Japanese Visitors:248841 VisitorsPercentage:0.498} BounceRate:0.4996 Duration:4996}
-&{StatsLanguagesSummary:{Language:British English Visitors:125499 VisitorsPercentage:0.2512} BounceRate:0.4996 Duration:5001}
-&{StatsLanguagesSummary:{Language:American English Visitors:125317 VisitorsPercentage:0.2508} BounceRate:0.4996 Duration:5017}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:248841 VisitorsPercentage:0.498} BounceRate:0.4893 Duration:4996}
+&{StatsLanguagesSummary:{Language:British English Visitors:125499 VisitorsPercentage:0.2512} BounceRate:0.492 Duration:5001}
+&{StatsLanguagesSummary:{Language:American English Visitors:125317 VisitorsPercentage:0.2508} BounceRate:0.4874 Duration:5017}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/Browser - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:Japanese Visitors:82811 VisitorsPercentage:0.4986} BounceRate:0.5009 Duration:4966}
-&{StatsLanguagesSummary:{Language:American English Visitors:41719 VisitorsPercentage:0.2512} BounceRate:0.5009 Duration:4991}
-&{StatsLanguagesSummary:{Language:British English Visitors:41560 VisitorsPercentage:0.2502} BounceRate:0.5009 Duration:4994}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:82811 VisitorsPercentage:0.4986} BounceRate:0.4924 Duration:4966}
+&{StatsLanguagesSummary:{Language:American English Visitors:41719 VisitorsPercentage:0.2512} BounceRate:0.4874 Duration:4991}
+&{StatsLanguagesSummary:{Language:British English Visitors:41560 VisitorsPercentage:0.2502} BounceRate:0.4921 Duration:4994}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/Country - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:Japanese Visitors:27567 VisitorsPercentage:0.499} BounceRate:0.4978 Duration:4980}
-&{StatsLanguagesSummary:{Language:American English Visitors:13901 VisitorsPercentage:0.2516} BounceRate:0.4978 Duration:5008}
-&{StatsLanguagesSummary:{Language:British English Visitors:13775 VisitorsPercentage:0.2494} BounceRate:0.4978 Duration:5004}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:27567 VisitorsPercentage:0.499} BounceRate:0.4896 Duration:4980}
+&{StatsLanguagesSummary:{Language:American English Visitors:13901 VisitorsPercentage:0.2516} BounceRate:0.48 Duration:5008}
+&{StatsLanguagesSummary:{Language:British English Visitors:13775 VisitorsPercentage:0.2494} BounceRate:0.4955 Duration:5004}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/Device - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:Japanese Visitors:9175 VisitorsPercentage:0.4917} BounceRate:0.4947 Duration:4992}
-&{StatsLanguagesSummary:{Language:American English Visitors:4829 VisitorsPercentage:0.2588} BounceRate:0.4947 Duration:5041}
-&{StatsLanguagesSummary:{Language:British English Visitors:4657 VisitorsPercentage:0.2496} BounceRate:0.4947 Duration:4946}
+&{StatsLanguagesSummary:{Language:Japanese Visitors:9175 VisitorsPercentage:0.4917} BounceRate:0.4881 Duration:4992}
+&{StatsLanguagesSummary:{Language:American English Visitors:4829 VisitorsPercentage:0.2588} BounceRate:0.4741 Duration:5041}
+&{StatsLanguagesSummary:{Language:British English Visitors:4657 VisitorsPercentage:0.2496} BounceRate:0.4909 Duration:4946}
 
 ---
 
@@ -263,50 +263,50 @@ RECORDS:
 
 [TestGetWebsiteLanguagesLocale/Language - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:4829 VisitorsPercentage:0.5091} BounceRate:0.4931 Duration:5041}
-&{StatsLanguagesSummary:{Language:British English Visitors:4657 VisitorsPercentage:0.4909} BounceRate:0.4931 Duration:4946}
+&{StatsLanguagesSummary:{Language:American English Visitors:4829 VisitorsPercentage:0.5091} BounceRate:0.4741 Duration:5041}
+&{StatsLanguagesSummary:{Language:British English Visitors:4657 VisitorsPercentage:0.4909} BounceRate:0.4909 Duration:4946}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/OS - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:1623 VisitorsPercentage:0.5209} BounceRate:0.5 Duration:5050}
-&{StatsLanguagesSummary:{Language:British English Visitors:1493 VisitorsPercentage:0.4791} BounceRate:0.5 Duration:4858}
+&{StatsLanguagesSummary:{Language:American English Visitors:1623 VisitorsPercentage:0.5209} BounceRate:0.4739 Duration:5050}
+&{StatsLanguagesSummary:{Language:British English Visitors:1493 VisitorsPercentage:0.4791} BounceRate:0.5066 Duration:4858}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/Pathname - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:570 VisitorsPercentage:0.5229} BounceRate:0.4945 Duration:5294}
-&{StatsLanguagesSummary:{Language:British English Visitors:520 VisitorsPercentage:0.4771} BounceRate:0.4945 Duration:4987}
+&{StatsLanguagesSummary:{Language:American English Visitors:570 VisitorsPercentage:0.5229} BounceRate:0.4804 Duration:5294}
+&{StatsLanguagesSummary:{Language:British English Visitors:520 VisitorsPercentage:0.4771} BounceRate:0.4904 Duration:4987}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/Referrer - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:194 VisitorsPercentage:0.5092} BounceRate:0.5363 Duration:4677}
-&{StatsLanguagesSummary:{Language:British English Visitors:187 VisitorsPercentage:0.4908} BounceRate:0.5363 Duration:4761}
+&{StatsLanguagesSummary:{Language:American English Visitors:194 VisitorsPercentage:0.5092} BounceRate:0.573 Duration:4677}
+&{StatsLanguagesSummary:{Language:British English Visitors:187 VisitorsPercentage:0.4908} BounceRate:0.4667 Duration:4761}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/UTMCampaign - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:58 VisitorsPercentage:0.5} BounceRate:0.5439 Duration:3943}
-&{StatsLanguagesSummary:{Language:British English Visitors:58 VisitorsPercentage:0.5} BounceRate:0.5439 Duration:5896}
+&{StatsLanguagesSummary:{Language:American English Visitors:58 VisitorsPercentage:0.5} BounceRate:0.6207 Duration:3943}
+&{StatsLanguagesSummary:{Language:British English Visitors:58 VisitorsPercentage:0.5} BounceRate:0.4643 Duration:5896}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/UTMMedium - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:18 VisitorsPercentage:0.5143} BounceRate:0.4615 Duration:3038}
-&{StatsLanguagesSummary:{Language:British English Visitors:17 VisitorsPercentage:0.4857} BounceRate:0.4615 Duration:7189}
+&{StatsLanguagesSummary:{Language:American English Visitors:18 VisitorsPercentage:0.5143} BounceRate:0.5714 Duration:3038}
+&{StatsLanguagesSummary:{Language:British English Visitors:17 VisitorsPercentage:0.4857} BounceRate:0.3333 Duration:7189}
 
 ---
 
 [TestGetWebsiteLanguagesLocale/UTMSource - 1]
 RECORDS:
-&{StatsLanguagesSummary:{Language:American English Visitors:10 VisitorsPercentage:0.5882} BounceRate:0.6 Duration:2631}
-&{StatsLanguagesSummary:{Language:British English Visitors:7 VisitorsPercentage:0.4118} BounceRate:0.6 Duration:6547}
+&{StatsLanguagesSummary:{Language:American English Visitors:10 VisitorsPercentage:0.5882} BounceRate:0 Duration:2631}
+&{StatsLanguagesSummary:{Language:British English Visitors:7 VisitorsPercentage:0.4118} BounceRate:0 Duration:6547}
 
 ---
 

--- a/core/db/duckdb/__snapshots__/pages_test.snap
+++ b/core/db/duckdb/__snapshots__/pages_test.snap
@@ -1,33 +1,33 @@
 
 [TestGetWebsitePages/Base - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/about Visitors:166895 VisitorsPercentage:0.3339} Pageviews:333254 PageviewsPercentage:0.3333 Bounces:41454 Duration:5002}
-&{StatsPagesSummary:{Pathname:/ Visitors:166610 VisitorsPercentage:0.3333} Pageviews:332841 PageviewsPercentage:0.3328 Bounces:41785 Duration:5008}
-&{StatsPagesSummary:{Pathname:/contact Visitors:166353 VisitorsPercentage:0.3328} Pageviews:333905 PageviewsPercentage:0.3339 Bounces:41445 Duration:4998}
+&{StatsPagesSummary:{Pathname:/about Visitors:166895 VisitorsPercentage:0.3339} Pageviews:333254 PageviewsPercentage:0.3333 BounceRate:0.4996 Duration:5002}
+&{StatsPagesSummary:{Pathname:/ Visitors:166610 VisitorsPercentage:0.3333} Pageviews:332841 PageviewsPercentage:0.3328 BounceRate:0.4996 Duration:5008}
+&{StatsPagesSummary:{Pathname:/contact Visitors:166353 VisitorsPercentage:0.3328} Pageviews:333905 PageviewsPercentage:0.3339 BounceRate:0.4996 Duration:4998}
 
 ---
 
 [TestGetWebsitePages/Browser - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/about Visitors:55789 VisitorsPercentage:0.3357} Pageviews:111449 PageviewsPercentage:0.3348 Bounces:13747 Duration:5000}
-&{StatsPagesSummary:{Pathname:/ Visitors:55260 VisitorsPercentage:0.3326} Pageviews:110416 PageviewsPercentage:0.3317 Bounces:14069 Duration:4983}
-&{StatsPagesSummary:{Pathname:/contact Visitors:55121 VisitorsPercentage:0.3317} Pageviews:111014 PageviewsPercentage:0.3335 Bounces:13824 Duration:4956}
+&{StatsPagesSummary:{Pathname:/about Visitors:55789 VisitorsPercentage:0.3357} Pageviews:111449 PageviewsPercentage:0.3348 BounceRate:0.5009 Duration:5000}
+&{StatsPagesSummary:{Pathname:/ Visitors:55260 VisitorsPercentage:0.3326} Pageviews:110416 PageviewsPercentage:0.3317 BounceRate:0.5009 Duration:4983}
+&{StatsPagesSummary:{Pathname:/contact Visitors:55121 VisitorsPercentage:0.3317} Pageviews:111014 PageviewsPercentage:0.3335 BounceRate:0.5009 Duration:4956}
 
 ---
 
 [TestGetWebsitePages/Country - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:18558 VisitorsPercentage:0.3352} Pageviews:36995 PageviewsPercentage:0.3341 Bounces:4602 Duration:5041}
-&{StatsPagesSummary:{Pathname:/about Visitors:18499 VisitorsPercentage:0.3341} Pageviews:36933 PageviewsPercentage:0.3335 Bounces:4573 Duration:4975}
-&{StatsPagesSummary:{Pathname:/contact Visitors:18311 VisitorsPercentage:0.3307} Pageviews:36805 PageviewsPercentage:0.3324 Bounces:4669 Duration:4958}
+&{StatsPagesSummary:{Pathname:/ Visitors:18558 VisitorsPercentage:0.3352} Pageviews:36995 PageviewsPercentage:0.3341 BounceRate:0.4978 Duration:5041}
+&{StatsPagesSummary:{Pathname:/about Visitors:18499 VisitorsPercentage:0.3341} Pageviews:36933 PageviewsPercentage:0.3335 BounceRate:0.4978 Duration:4975}
+&{StatsPagesSummary:{Pathname:/contact Visitors:18311 VisitorsPercentage:0.3307} Pageviews:36805 PageviewsPercentage:0.3324 BounceRate:0.4978 Duration:4958}
 
 ---
 
 [TestGetWebsitePages/Device - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:6305 VisitorsPercentage:0.3391} Pageviews:12582 PageviewsPercentage:0.3385 Bounces:1560 Duration:5107}
-&{StatsPagesSummary:{Pathname:/about Visitors:6164 VisitorsPercentage:0.3315} Pageviews:12299 PageviewsPercentage:0.3309 Bounces:1522 Duration:4981}
-&{StatsPagesSummary:{Pathname:/contact Visitors:6124 VisitorsPercentage:0.3294} Pageviews:12289 PageviewsPercentage:0.3306 Bounces:1609 Duration:4894}
+&{StatsPagesSummary:{Pathname:/ Visitors:6305 VisitorsPercentage:0.3391} Pageviews:12582 PageviewsPercentage:0.3385 BounceRate:0.4947 Duration:5107}
+&{StatsPagesSummary:{Pathname:/about Visitors:6164 VisitorsPercentage:0.3315} Pageviews:12299 PageviewsPercentage:0.3309 BounceRate:0.4947 Duration:4981}
+&{StatsPagesSummary:{Pathname:/contact Visitors:6124 VisitorsPercentage:0.3294} Pageviews:12289 PageviewsPercentage:0.3306 BounceRate:0.4947 Duration:4894}
 
 ---
 
@@ -38,47 +38,47 @@ RECORDS:
 
 [TestGetWebsitePages/Language - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:3230 VisitorsPercentage:0.3444} Pageviews:6356 PageviewsPercentage:0.3383 Bounces:764 Duration:5145}
-&{StatsPagesSummary:{Pathname:/about Visitors:3075 VisitorsPercentage:0.3279} Pageviews:6211 PageviewsPercentage:0.3306 Bounces:797 Duration:4936}
-&{StatsPagesSummary:{Pathname:/contact Visitors:3073 VisitorsPercentage:0.3277} Pageviews:6222 PageviewsPercentage:0.3312 Bounces:794 Duration:4874}
+&{StatsPagesSummary:{Pathname:/ Visitors:3230 VisitorsPercentage:0.3444} Pageviews:6356 PageviewsPercentage:0.3383 BounceRate:0.4931 Duration:5145}
+&{StatsPagesSummary:{Pathname:/about Visitors:3075 VisitorsPercentage:0.3279} Pageviews:6211 PageviewsPercentage:0.3306 BounceRate:0.4931 Duration:4936}
+&{StatsPagesSummary:{Pathname:/contact Visitors:3073 VisitorsPercentage:0.3277} Pageviews:6222 PageviewsPercentage:0.3312 BounceRate:0.4931 Duration:4874}
 
 ---
 
 [TestGetWebsitePages/OS - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:1073 VisitorsPercentage:0.3478} Pageviews:2113 PageviewsPercentage:0.3427 Bounces:268 Duration:5098}
-&{StatsPagesSummary:{Pathname:/about Visitors:1068 VisitorsPercentage:0.3462} Pageviews:2086 PageviewsPercentage:0.3384 Bounces:261 Duration:4845}
-&{StatsPagesSummary:{Pathname:/contact Visitors:944 VisitorsPercentage:0.306} Pageviews:1966 PageviewsPercentage:0.3189 Bounces:254 Duration:4924}
+&{StatsPagesSummary:{Pathname:/ Visitors:1073 VisitorsPercentage:0.3478} Pageviews:2113 PageviewsPercentage:0.3427 BounceRate:0.5 Duration:5098}
+&{StatsPagesSummary:{Pathname:/about Visitors:1068 VisitorsPercentage:0.3462} Pageviews:2086 PageviewsPercentage:0.3384 BounceRate:0.5 Duration:4845}
+&{StatsPagesSummary:{Pathname:/contact Visitors:944 VisitorsPercentage:0.306} Pageviews:1966 PageviewsPercentage:0.3189 BounceRate:0.5 Duration:4924}
 
 ---
 
 [TestGetWebsitePages/Pathname - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:1073 VisitorsPercentage:1} Pageviews:2113 PageviewsPercentage:1 Bounces:268 Duration:5098}
+&{StatsPagesSummary:{Pathname:/ Visitors:1073 VisitorsPercentage:1} Pageviews:2113 PageviewsPercentage:1 BounceRate:0.4945 Duration:5098}
 
 ---
 
 [TestGetWebsitePages/Referrer - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:359 VisitorsPercentage:1} Pageviews:726 PageviewsPercentage:1 Bounces:96 Duration:4728}
+&{StatsPagesSummary:{Pathname:/ Visitors:359 VisitorsPercentage:1} Pageviews:726 PageviewsPercentage:1 BounceRate:0.5363 Duration:4728}
 
 ---
 
 [TestGetWebsitePages/UTMCampaign - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:110 VisitorsPercentage:1} Pageviews:220 PageviewsPercentage:1 Bounces:31 Duration:4732}
+&{StatsPagesSummary:{Pathname:/ Visitors:110 VisitorsPercentage:1} Pageviews:220 PageviewsPercentage:1 BounceRate:0.5439 Duration:4732}
 
 ---
 
 [TestGetWebsitePages/UTMMedium - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:36 VisitorsPercentage:1} Pageviews:67 PageviewsPercentage:1 Bounces:6 Duration:6547}
+&{StatsPagesSummary:{Pathname:/ Visitors:36 VisitorsPercentage:1} Pageviews:67 PageviewsPercentage:1 BounceRate:0.4615 Duration:6547}
 
 ---
 
 [TestGetWebsitePages/UTMSource - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:16 VisitorsPercentage:1} Pageviews:28 PageviewsPercentage:1 Bounces:3 Duration:3389}
+&{StatsPagesSummary:{Pathname:/ Visitors:16 VisitorsPercentage:1} Pageviews:28 PageviewsPercentage:1 BounceRate:0.6 Duration:3389}
 
 ---
 

--- a/core/db/duckdb/__snapshots__/pages_test.snap
+++ b/core/db/duckdb/__snapshots__/pages_test.snap
@@ -1,32 +1,32 @@
 
 [TestGetWebsitePages/Base - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/about Visitors:166895 VisitorsPercentage:0.3339} Pageviews:333254 PageviewsPercentage:0.3333 BounceRate:0.4996 Duration:5002}
-&{StatsPagesSummary:{Pathname:/ Visitors:166610 VisitorsPercentage:0.3333} Pageviews:332841 PageviewsPercentage:0.3328 BounceRate:0.4996 Duration:5008}
-&{StatsPagesSummary:{Pathname:/contact Visitors:166353 VisitorsPercentage:0.3328} Pageviews:333905 PageviewsPercentage:0.3339 BounceRate:0.4996 Duration:4998}
+&{StatsPagesSummary:{Pathname:/about Visitors:166895 VisitorsPercentage:0.3339} Pageviews:333254 PageviewsPercentage:0.3333 BounceRate:0.4913 Duration:5002}
+&{StatsPagesSummary:{Pathname:/ Visitors:166610 VisitorsPercentage:0.3333} Pageviews:332841 PageviewsPercentage:0.3328 BounceRate:0.4895 Duration:5008}
+&{StatsPagesSummary:{Pathname:/contact Visitors:166353 VisitorsPercentage:0.3328} Pageviews:333905 PageviewsPercentage:0.3339 BounceRate:0.4878 Duration:4998}
 
 ---
 
 [TestGetWebsitePages/Browser - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/about Visitors:55789 VisitorsPercentage:0.3357} Pageviews:111449 PageviewsPercentage:0.3348 BounceRate:0.5009 Duration:5000}
-&{StatsPagesSummary:{Pathname:/ Visitors:55260 VisitorsPercentage:0.3326} Pageviews:110416 PageviewsPercentage:0.3317 BounceRate:0.5009 Duration:4983}
-&{StatsPagesSummary:{Pathname:/contact Visitors:55121 VisitorsPercentage:0.3317} Pageviews:111014 PageviewsPercentage:0.3335 BounceRate:0.5009 Duration:4956}
+&{StatsPagesSummary:{Pathname:/about Visitors:55789 VisitorsPercentage:0.3357} Pageviews:111449 PageviewsPercentage:0.3348 BounceRate:0.4916 Duration:5000}
+&{StatsPagesSummary:{Pathname:/ Visitors:55260 VisitorsPercentage:0.3326} Pageviews:110416 PageviewsPercentage:0.3317 BounceRate:0.4927 Duration:4983}
+&{StatsPagesSummary:{Pathname:/contact Visitors:55121 VisitorsPercentage:0.3317} Pageviews:111014 PageviewsPercentage:0.3335 BounceRate:0.4889 Duration:4956}
 
 ---
 
 [TestGetWebsitePages/Country - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:18558 VisitorsPercentage:0.3352} Pageviews:36995 PageviewsPercentage:0.3341 BounceRate:0.4978 Duration:5041}
-&{StatsPagesSummary:{Pathname:/about Visitors:18499 VisitorsPercentage:0.3341} Pageviews:36933 PageviewsPercentage:0.3335 BounceRate:0.4978 Duration:4975}
-&{StatsPagesSummary:{Pathname:/contact Visitors:18311 VisitorsPercentage:0.3307} Pageviews:36805 PageviewsPercentage:0.3324 BounceRate:0.4978 Duration:4958}
+&{StatsPagesSummary:{Pathname:/ Visitors:18558 VisitorsPercentage:0.3352} Pageviews:36995 PageviewsPercentage:0.3341 BounceRate:0.4831 Duration:5041}
+&{StatsPagesSummary:{Pathname:/about Visitors:18499 VisitorsPercentage:0.3341} Pageviews:36933 PageviewsPercentage:0.3335 BounceRate:0.4944 Duration:4975}
+&{StatsPagesSummary:{Pathname:/contact Visitors:18311 VisitorsPercentage:0.3307} Pageviews:36805 PageviewsPercentage:0.3324 BounceRate:0.4886 Duration:4958}
 
 ---
 
 [TestGetWebsitePages/Device - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:6305 VisitorsPercentage:0.3391} Pageviews:12582 PageviewsPercentage:0.3385 BounceRate:0.4947 Duration:5107}
-&{StatsPagesSummary:{Pathname:/about Visitors:6164 VisitorsPercentage:0.3315} Pageviews:12299 PageviewsPercentage:0.3309 BounceRate:0.4947 Duration:4981}
+&{StatsPagesSummary:{Pathname:/ Visitors:6305 VisitorsPercentage:0.3391} Pageviews:12582 PageviewsPercentage:0.3385 BounceRate:0.4771 Duration:5107}
+&{StatsPagesSummary:{Pathname:/about Visitors:6164 VisitorsPercentage:0.3315} Pageviews:12299 PageviewsPercentage:0.3309 BounceRate:0.484 Duration:4981}
 &{StatsPagesSummary:{Pathname:/contact Visitors:6124 VisitorsPercentage:0.3294} Pageviews:12289 PageviewsPercentage:0.3306 BounceRate:0.4947 Duration:4894}
 
 ---
@@ -38,29 +38,29 @@ RECORDS:
 
 [TestGetWebsitePages/Language - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:3230 VisitorsPercentage:0.3444} Pageviews:6356 PageviewsPercentage:0.3383 BounceRate:0.4931 Duration:5145}
-&{StatsPagesSummary:{Pathname:/about Visitors:3075 VisitorsPercentage:0.3279} Pageviews:6211 PageviewsPercentage:0.3306 BounceRate:0.4931 Duration:4936}
-&{StatsPagesSummary:{Pathname:/contact Visitors:3073 VisitorsPercentage:0.3277} Pageviews:6222 PageviewsPercentage:0.3312 BounceRate:0.4931 Duration:4874}
+&{StatsPagesSummary:{Pathname:/ Visitors:3230 VisitorsPercentage:0.3444} Pageviews:6356 PageviewsPercentage:0.3383 BounceRate:0.466 Duration:5145}
+&{StatsPagesSummary:{Pathname:/about Visitors:3075 VisitorsPercentage:0.3279} Pageviews:6211 PageviewsPercentage:0.3306 BounceRate:0.4928 Duration:4936}
+&{StatsPagesSummary:{Pathname:/contact Visitors:3073 VisitorsPercentage:0.3277} Pageviews:6222 PageviewsPercentage:0.3312 BounceRate:0.4887 Duration:4874}
 
 ---
 
 [TestGetWebsitePages/OS - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:1073 VisitorsPercentage:0.3478} Pageviews:2113 PageviewsPercentage:0.3427 BounceRate:0.5 Duration:5098}
-&{StatsPagesSummary:{Pathname:/about Visitors:1068 VisitorsPercentage:0.3462} Pageviews:2086 PageviewsPercentage:0.3384 BounceRate:0.5 Duration:4845}
-&{StatsPagesSummary:{Pathname:/contact Visitors:944 VisitorsPercentage:0.306} Pageviews:1966 PageviewsPercentage:0.3189 BounceRate:0.5 Duration:4924}
+&{StatsPagesSummary:{Pathname:/ Visitors:1073 VisitorsPercentage:0.3478} Pageviews:2113 PageviewsPercentage:0.3427 BounceRate:0.4852 Duration:5098}
+&{StatsPagesSummary:{Pathname:/about Visitors:1068 VisitorsPercentage:0.3462} Pageviews:2086 PageviewsPercentage:0.3384 BounceRate:0.501 Duration:4845}
+&{StatsPagesSummary:{Pathname:/contact Visitors:944 VisitorsPercentage:0.306} Pageviews:1966 PageviewsPercentage:0.3189 BounceRate:0.4834 Duration:4924}
 
 ---
 
 [TestGetWebsitePages/Pathname - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:1073 VisitorsPercentage:1} Pageviews:2113 PageviewsPercentage:1 BounceRate:0.4945 Duration:5098}
+&{StatsPagesSummary:{Pathname:/ Visitors:1073 VisitorsPercentage:1} Pageviews:2113 PageviewsPercentage:1 BounceRate:0.4852 Duration:5098}
 
 ---
 
 [TestGetWebsitePages/Referrer - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:359 VisitorsPercentage:1} Pageviews:726 PageviewsPercentage:1 BounceRate:0.5363 Duration:4728}
+&{StatsPagesSummary:{Pathname:/ Visitors:359 VisitorsPercentage:1} Pageviews:726 PageviewsPercentage:1 BounceRate:0.5196 Duration:4728}
 
 ---
 
@@ -78,7 +78,7 @@ RECORDS:
 
 [TestGetWebsitePages/UTMSource - 1]
 RECORDS:
-&{StatsPagesSummary:{Pathname:/ Visitors:16 VisitorsPercentage:1} Pageviews:28 PageviewsPercentage:1 BounceRate:0.6 Duration:3389}
+&{StatsPagesSummary:{Pathname:/ Visitors:16 VisitorsPercentage:1} Pageviews:28 PageviewsPercentage:1 BounceRate:0 Duration:3389}
 
 ---
 

--- a/core/db/duckdb/__snapshots__/referrers_test.snap
+++ b/core/db/duckdb/__snapshots__/referrers_test.snap
@@ -1,33 +1,33 @@
 
 [TestGetWebsiteReferrers/Base - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:google.com Visitors:167163 VisitorsPercentage:0.3346} Bounces:41666 Duration:5018}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:166318 VisitorsPercentage:0.3329} Bounces:41704 Duration:4985}
-&{StatsReferrerSummary:{Referrer: Visitors:166176 VisitorsPercentage:0.3326} Bounces:41314 Duration:5005}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:167163 VisitorsPercentage:0.3346} BounceRate:0.4996 Duration:5018}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:166318 VisitorsPercentage:0.3329} BounceRate:0.4996 Duration:4985}
+&{StatsReferrerSummary:{Referrer: Visitors:166176 VisitorsPercentage:0.3326} BounceRate:0.4996 Duration:5005}
 
 ---
 
 [TestGetWebsiteReferrers/Browser - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:55495 VisitorsPercentage:0.3341} Bounces:14006 Duration:4944}
-&{StatsReferrerSummary:{Referrer: Visitors:55307 VisitorsPercentage:0.333} Bounces:13742 Duration:4980}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:55288 VisitorsPercentage:0.3329} Bounces:13892 Duration:5016}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:55495 VisitorsPercentage:0.3341} BounceRate:0.5009 Duration:4944}
+&{StatsReferrerSummary:{Referrer: Visitors:55307 VisitorsPercentage:0.333} BounceRate:0.5009 Duration:4980}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:55288 VisitorsPercentage:0.3329} BounceRate:0.5009 Duration:5016}
 
 ---
 
 [TestGetWebsiteReferrers/Country - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:18505 VisitorsPercentage:0.335} Bounces:4576 Duration:5008}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:18444 VisitorsPercentage:0.3339} Bounces:4661 Duration:5025}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:18294 VisitorsPercentage:0.3312} Bounces:4607 Duration:4938}
+&{StatsReferrerSummary:{Referrer: Visitors:18505 VisitorsPercentage:0.335} BounceRate:0.4978 Duration:5008}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:18444 VisitorsPercentage:0.3339} BounceRate:0.4978 Duration:5025}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:18294 VisitorsPercentage:0.3312} BounceRate:0.4978 Duration:4938}
 
 ---
 
 [TestGetWebsiteReferrers/Device - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:6264 VisitorsPercentage:0.3357} Bounces:1547 Duration:4975}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:6262 VisitorsPercentage:0.3356} Bounces:1540 Duration:5099}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:6135 VisitorsPercentage:0.3288} Bounces:1604 Duration:4901}
+&{StatsReferrerSummary:{Referrer: Visitors:6264 VisitorsPercentage:0.3357} BounceRate:0.4947 Duration:4975}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:6262 VisitorsPercentage:0.3356} BounceRate:0.4947 Duration:5099}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:6135 VisitorsPercentage:0.3288} BounceRate:0.4947 Duration:4901}
 
 ---
 
@@ -38,81 +38,81 @@ RECORDS:
 
 [TestGetWebsiteReferrers/Language - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:3189 VisitorsPercentage:0.3362} Bounces:777 Duration:4998}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:3159 VisitorsPercentage:0.333} Bounces:759 Duration:5096}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:3138 VisitorsPercentage:0.3308} Bounces:819 Duration:4909}
+&{StatsReferrerSummary:{Referrer: Visitors:3189 VisitorsPercentage:0.3362} BounceRate:0.4931 Duration:4998}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:3159 VisitorsPercentage:0.333} BounceRate:0.4931 Duration:5096}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:3138 VisitorsPercentage:0.3308} BounceRate:0.4931 Duration:4909}
 
 ---
 
 [TestGetWebsiteReferrers/OS - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:1055 VisitorsPercentage:0.3386} Bounces:264 Duration:4735}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:1036 VisitorsPercentage:0.3325} Bounces:272 Duration:4809}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:1025 VisitorsPercentage:0.3289} Bounces:247 Duration:5257}
+&{StatsReferrerSummary:{Referrer: Visitors:1055 VisitorsPercentage:0.3386} BounceRate:0.5 Duration:4735}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:1036 VisitorsPercentage:0.3325} BounceRate:0.5 Duration:4809}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:1025 VisitorsPercentage:0.3289} BounceRate:0.5 Duration:5257}
 
 ---
 
 [TestGetWebsiteReferrers/Pathname - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:0.3495} Bounces:96 Duration:4728}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:355 VisitorsPercentage:0.3257} Bounces:90 Duration:5308}
-&{StatsReferrerSummary:{Referrer: Visitors:354 VisitorsPercentage:0.3248} Bounces:82 Duration:5411}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:0.3495} BounceRate:0.4945 Duration:4728}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:355 VisitorsPercentage:0.3257} BounceRate:0.4945 Duration:5308}
+&{StatsReferrerSummary:{Referrer: Visitors:354 VisitorsPercentage:0.3248} BounceRate:0.4945 Duration:5411}
 
 ---
 
 [TestGetWebsiteReferrers/Referrer - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
 
 ---
 
 [TestGetWebsiteReferrers/UTMCampaign - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:116 VisitorsPercentage:1} BounceRate:0.5439 Duration:4732}
 
 ---
 
 [TestGetWebsiteReferrers/UTMMedium - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:35 VisitorsPercentage:1} BounceRate:0.4615 Duration:6547}
 
 ---
 
 [TestGetWebsiteReferrers/UTMSource - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/Base - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:google.com Visitors:167163 VisitorsPercentage:0.3346} Bounces:41666 Duration:5018}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:166318 VisitorsPercentage:0.3329} Bounces:41704 Duration:4985}
-&{StatsReferrerSummary:{Referrer: Visitors:166176 VisitorsPercentage:0.3326} Bounces:41314 Duration:5005}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:167163 VisitorsPercentage:0.3346} BounceRate:0.4996 Duration:5018}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:166318 VisitorsPercentage:0.3329} BounceRate:0.4996 Duration:4985}
+&{StatsReferrerSummary:{Referrer: Visitors:166176 VisitorsPercentage:0.3326} BounceRate:0.4996 Duration:5005}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/Browser - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:55495 VisitorsPercentage:0.3341} Bounces:14006 Duration:4944}
-&{StatsReferrerSummary:{Referrer: Visitors:55307 VisitorsPercentage:0.333} Bounces:13742 Duration:4980}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:55288 VisitorsPercentage:0.3329} Bounces:13892 Duration:5016}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:55495 VisitorsPercentage:0.3341} BounceRate:0.5009 Duration:4944}
+&{StatsReferrerSummary:{Referrer: Visitors:55307 VisitorsPercentage:0.333} BounceRate:0.5009 Duration:4980}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:55288 VisitorsPercentage:0.3329} BounceRate:0.5009 Duration:5016}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/Country - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:18505 VisitorsPercentage:0.335} Bounces:4576 Duration:5008}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:18444 VisitorsPercentage:0.3339} Bounces:4661 Duration:5025}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:18294 VisitorsPercentage:0.3312} Bounces:4607 Duration:4938}
+&{StatsReferrerSummary:{Referrer: Visitors:18505 VisitorsPercentage:0.335} BounceRate:0.4978 Duration:5008}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:18444 VisitorsPercentage:0.3339} BounceRate:0.4978 Duration:5025}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:18294 VisitorsPercentage:0.3312} BounceRate:0.4978 Duration:4938}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/Device - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:6264 VisitorsPercentage:0.3357} Bounces:1547 Duration:4975}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:6262 VisitorsPercentage:0.3356} Bounces:1540 Duration:5099}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:6135 VisitorsPercentage:0.3288} Bounces:1604 Duration:4901}
+&{StatsReferrerSummary:{Referrer: Visitors:6264 VisitorsPercentage:0.3357} BounceRate:0.4947 Duration:4975}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:6262 VisitorsPercentage:0.3356} BounceRate:0.4947 Duration:5099}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:6135 VisitorsPercentage:0.3288} BounceRate:0.4947 Duration:4901}
 
 ---
 
@@ -123,49 +123,49 @@ RECORDS:
 
 [TestGetWebsiteReferrersGrouped/Language - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:3189 VisitorsPercentage:0.3362} Bounces:777 Duration:4998}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:3159 VisitorsPercentage:0.333} Bounces:759 Duration:5096}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:3138 VisitorsPercentage:0.3308} Bounces:819 Duration:4909}
+&{StatsReferrerSummary:{Referrer: Visitors:3189 VisitorsPercentage:0.3362} BounceRate:0.4931 Duration:4998}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:3159 VisitorsPercentage:0.333} BounceRate:0.4931 Duration:5096}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:3138 VisitorsPercentage:0.3308} BounceRate:0.4931 Duration:4909}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/OS - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:1055 VisitorsPercentage:0.3386} Bounces:264 Duration:4735}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:1036 VisitorsPercentage:0.3325} Bounces:272 Duration:4809}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:1025 VisitorsPercentage:0.3289} Bounces:247 Duration:5257}
+&{StatsReferrerSummary:{Referrer: Visitors:1055 VisitorsPercentage:0.3386} BounceRate:0.5 Duration:4735}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:1036 VisitorsPercentage:0.3325} BounceRate:0.5 Duration:4809}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:1025 VisitorsPercentage:0.3289} BounceRate:0.5 Duration:5257}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/Pathname - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:0.3495} Bounces:96 Duration:4728}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:355 VisitorsPercentage:0.3257} Bounces:90 Duration:5308}
-&{StatsReferrerSummary:{Referrer: Visitors:354 VisitorsPercentage:0.3248} Bounces:82 Duration:5411}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:0.3495} BounceRate:0.4945 Duration:4728}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:355 VisitorsPercentage:0.3257} BounceRate:0.4945 Duration:5308}
+&{StatsReferrerSummary:{Referrer: Visitors:354 VisitorsPercentage:0.3248} BounceRate:0.4945 Duration:5411}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/Referrer - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/UTMCampaign - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:116 VisitorsPercentage:1} BounceRate:0.5439 Duration:4732}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/UTMMedium - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:35 VisitorsPercentage:1} BounceRate:0.4615 Duration:6547}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/UTMSource - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
 
 ---
 

--- a/core/db/duckdb/__snapshots__/referrers_test.snap
+++ b/core/db/duckdb/__snapshots__/referrers_test.snap
@@ -1,33 +1,33 @@
 
 [TestGetWebsiteReferrers/Base - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:google.com Visitors:167163 VisitorsPercentage:0.3346} BounceRate:0.4996 Duration:5018}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:166318 VisitorsPercentage:0.3329} BounceRate:0.4996 Duration:4985}
-&{StatsReferrerSummary:{Referrer: Visitors:166176 VisitorsPercentage:0.3326} BounceRate:0.4996 Duration:5005}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:167163 VisitorsPercentage:0.3346} BounceRate:0.487 Duration:5018}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:166318 VisitorsPercentage:0.3329} BounceRate:0.4931 Duration:4985}
+&{StatsReferrerSummary:{Referrer: Visitors:166176 VisitorsPercentage:0.3326} BounceRate:0.4885 Duration:5005}
 
 ---
 
 [TestGetWebsiteReferrers/Browser - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:55495 VisitorsPercentage:0.3341} BounceRate:0.5009 Duration:4944}
-&{StatsReferrerSummary:{Referrer: Visitors:55307 VisitorsPercentage:0.333} BounceRate:0.5009 Duration:4980}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:55288 VisitorsPercentage:0.3329} BounceRate:0.5009 Duration:5016}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:55495 VisitorsPercentage:0.3341} BounceRate:0.4955 Duration:4944}
+&{StatsReferrerSummary:{Referrer: Visitors:55307 VisitorsPercentage:0.333} BounceRate:0.4888 Duration:4980}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:55288 VisitorsPercentage:0.3329} BounceRate:0.4888 Duration:5016}
 
 ---
 
 [TestGetWebsiteReferrers/Country - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:18505 VisitorsPercentage:0.335} BounceRate:0.4978 Duration:5008}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:18444 VisitorsPercentage:0.3339} BounceRate:0.4978 Duration:5025}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:18294 VisitorsPercentage:0.3312} BounceRate:0.4978 Duration:4938}
+&{StatsReferrerSummary:{Referrer: Visitors:18505 VisitorsPercentage:0.335} BounceRate:0.4867 Duration:5008}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:18444 VisitorsPercentage:0.3339} BounceRate:0.4881 Duration:5025}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:18294 VisitorsPercentage:0.3312} BounceRate:0.4912 Duration:4938}
 
 ---
 
 [TestGetWebsiteReferrers/Device - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:6264 VisitorsPercentage:0.3357} BounceRate:0.4947 Duration:4975}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:6262 VisitorsPercentage:0.3356} BounceRate:0.4947 Duration:5099}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:6135 VisitorsPercentage:0.3288} BounceRate:0.4947 Duration:4901}
+&{StatsReferrerSummary:{Referrer: Visitors:6264 VisitorsPercentage:0.3357} BounceRate:0.476 Duration:4975}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:6262 VisitorsPercentage:0.3356} BounceRate:0.4772 Duration:5099}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:6135 VisitorsPercentage:0.3288} BounceRate:0.5029 Duration:4901}
 
 ---
 
@@ -38,31 +38,31 @@ RECORDS:
 
 [TestGetWebsiteReferrers/Language - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:3189 VisitorsPercentage:0.3362} BounceRate:0.4931 Duration:4998}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:3159 VisitorsPercentage:0.333} BounceRate:0.4931 Duration:5096}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:3138 VisitorsPercentage:0.3308} BounceRate:0.4931 Duration:4909}
+&{StatsReferrerSummary:{Referrer: Visitors:3189 VisitorsPercentage:0.3362} BounceRate:0.4789 Duration:4998}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:3159 VisitorsPercentage:0.333} BounceRate:0.4686 Duration:5096}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:3138 VisitorsPercentage:0.3308} BounceRate:0.4997 Duration:4909}
 
 ---
 
 [TestGetWebsiteReferrers/OS - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:1055 VisitorsPercentage:0.3386} BounceRate:0.5 Duration:4735}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:1036 VisitorsPercentage:0.3325} BounceRate:0.5 Duration:4809}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:1025 VisitorsPercentage:0.3289} BounceRate:0.5 Duration:5257}
+&{StatsReferrerSummary:{Referrer: Visitors:1055 VisitorsPercentage:0.3386} BounceRate:0.5159 Duration:4735}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:1036 VisitorsPercentage:0.3325} BounceRate:0.5087 Duration:4809}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:1025 VisitorsPercentage:0.3289} BounceRate:0.4477 Duration:5257}
 
 ---
 
 [TestGetWebsiteReferrers/Pathname - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:0.3495} BounceRate:0.4945 Duration:4728}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:355 VisitorsPercentage:0.3257} BounceRate:0.4945 Duration:5308}
-&{StatsReferrerSummary:{Referrer: Visitors:354 VisitorsPercentage:0.3248} BounceRate:0.4945 Duration:5411}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:0.3495} BounceRate:0.5196 Duration:4728}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:355 VisitorsPercentage:0.3257} BounceRate:0.45 Duration:5308}
+&{StatsReferrerSummary:{Referrer: Visitors:354 VisitorsPercentage:0.3248} BounceRate:0.4908 Duration:5411}
 
 ---
 
 [TestGetWebsiteReferrers/Referrer - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:1} BounceRate:0.5196 Duration:4728}
 
 ---
 
@@ -80,39 +80,39 @@ RECORDS:
 
 [TestGetWebsiteReferrers/UTMSource - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:17 VisitorsPercentage:1} BounceRate:0 Duration:3389}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/Base - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:google.com Visitors:167163 VisitorsPercentage:0.3346} BounceRate:0.4996 Duration:5018}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:166318 VisitorsPercentage:0.3329} BounceRate:0.4996 Duration:4985}
-&{StatsReferrerSummary:{Referrer: Visitors:166176 VisitorsPercentage:0.3326} BounceRate:0.4996 Duration:5005}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:167163 VisitorsPercentage:0.3346} BounceRate:0.487 Duration:5018}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:166318 VisitorsPercentage:0.3329} BounceRate:0.4931 Duration:4985}
+&{StatsReferrerSummary:{Referrer: Visitors:166176 VisitorsPercentage:0.3326} BounceRate:0.4885 Duration:5005}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/Browser - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:55495 VisitorsPercentage:0.3341} BounceRate:0.5009 Duration:4944}
-&{StatsReferrerSummary:{Referrer: Visitors:55307 VisitorsPercentage:0.333} BounceRate:0.5009 Duration:4980}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:55288 VisitorsPercentage:0.3329} BounceRate:0.5009 Duration:5016}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:55495 VisitorsPercentage:0.3341} BounceRate:0.4955 Duration:4944}
+&{StatsReferrerSummary:{Referrer: Visitors:55307 VisitorsPercentage:0.333} BounceRate:0.4888 Duration:4980}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:55288 VisitorsPercentage:0.3329} BounceRate:0.4888 Duration:5016}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/Country - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:18505 VisitorsPercentage:0.335} BounceRate:0.4978 Duration:5008}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:18444 VisitorsPercentage:0.3339} BounceRate:0.4978 Duration:5025}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:18294 VisitorsPercentage:0.3312} BounceRate:0.4978 Duration:4938}
+&{StatsReferrerSummary:{Referrer: Visitors:18505 VisitorsPercentage:0.335} BounceRate:0.4867 Duration:5008}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:18444 VisitorsPercentage:0.3339} BounceRate:0.4881 Duration:5025}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:18294 VisitorsPercentage:0.3312} BounceRate:0.4912 Duration:4938}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/Device - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:6264 VisitorsPercentage:0.3357} BounceRate:0.4947 Duration:4975}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:6262 VisitorsPercentage:0.3356} BounceRate:0.4947 Duration:5099}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:6135 VisitorsPercentage:0.3288} BounceRate:0.4947 Duration:4901}
+&{StatsReferrerSummary:{Referrer: Visitors:6264 VisitorsPercentage:0.3357} BounceRate:0.476 Duration:4975}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:6262 VisitorsPercentage:0.3356} BounceRate:0.4772 Duration:5099}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:6135 VisitorsPercentage:0.3288} BounceRate:0.5029 Duration:4901}
 
 ---
 
@@ -123,31 +123,31 @@ RECORDS:
 
 [TestGetWebsiteReferrersGrouped/Language - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:3189 VisitorsPercentage:0.3362} BounceRate:0.4931 Duration:4998}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:3159 VisitorsPercentage:0.333} BounceRate:0.4931 Duration:5096}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:3138 VisitorsPercentage:0.3308} BounceRate:0.4931 Duration:4909}
+&{StatsReferrerSummary:{Referrer: Visitors:3189 VisitorsPercentage:0.3362} BounceRate:0.4789 Duration:4998}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:3159 VisitorsPercentage:0.333} BounceRate:0.4686 Duration:5096}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:3138 VisitorsPercentage:0.3308} BounceRate:0.4997 Duration:4909}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/OS - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer: Visitors:1055 VisitorsPercentage:0.3386} BounceRate:0.5 Duration:4735}
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:1036 VisitorsPercentage:0.3325} BounceRate:0.5 Duration:4809}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:1025 VisitorsPercentage:0.3289} BounceRate:0.5 Duration:5257}
+&{StatsReferrerSummary:{Referrer: Visitors:1055 VisitorsPercentage:0.3386} BounceRate:0.5159 Duration:4735}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:1036 VisitorsPercentage:0.3325} BounceRate:0.5087 Duration:4809}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:1025 VisitorsPercentage:0.3289} BounceRate:0.4477 Duration:5257}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/Pathname - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:0.3495} BounceRate:0.4945 Duration:4728}
-&{StatsReferrerSummary:{Referrer:google.com Visitors:355 VisitorsPercentage:0.3257} BounceRate:0.4945 Duration:5308}
-&{StatsReferrerSummary:{Referrer: Visitors:354 VisitorsPercentage:0.3248} BounceRate:0.4945 Duration:5411}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:0.3495} BounceRate:0.5196 Duration:4728}
+&{StatsReferrerSummary:{Referrer:google.com Visitors:355 VisitorsPercentage:0.3257} BounceRate:0.45 Duration:5308}
+&{StatsReferrerSummary:{Referrer: Visitors:354 VisitorsPercentage:0.3248} BounceRate:0.4908 Duration:5411}
 
 ---
 
 [TestGetWebsiteReferrersGrouped/Referrer - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:381 VisitorsPercentage:1} BounceRate:0.5196 Duration:4728}
 
 ---
 
@@ -165,7 +165,7 @@ RECORDS:
 
 [TestGetWebsiteReferrersGrouped/UTMSource - 1]
 RECORDS:
-&{StatsReferrerSummary:{Referrer:medama.io Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
+&{StatsReferrerSummary:{Referrer:medama.io Visitors:17 VisitorsPercentage:1} BounceRate:0 Duration:3389}
 
 ---
 

--- a/core/db/duckdb/__snapshots__/summary_test.snap
+++ b/core/db/duckdb/__snapshots__/summary_test.snap
@@ -1,7 +1,7 @@
 
 [TestGetWebsiteSummary - 1]
 {
- "BounceRate": 0.4996,
+ "BounceRate": 0.4895,
  "Duration": 5003,
  "Pageviews": 1000000,
  "Visitors": 499657
@@ -10,7 +10,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 1]
 {
- "BounceRate": 0.5009,
+ "BounceRate": 0.4911,
  "Duration": 4980,
  "Pageviews": 332879,
  "Visitors": 166090
@@ -19,7 +19,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 2]
 {
- "BounceRate": 0.4978,
+ "BounceRate": 0.4887,
  "Duration": 4992,
  "Pageviews": 110733,
  "Visitors": 55243
@@ -28,7 +28,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 3]
 {
- "BounceRate": 0.4947,
+ "BounceRate": 0.4852,
  "Duration": 4997,
  "Pageviews": 37170,
  "Visitors": 18661
@@ -37,7 +37,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 4]
 {
- "BounceRate": 0.4931,
+ "BounceRate": 0.4824,
  "Duration": 5003,
  "Pageviews": 18789,
  "Visitors": 9486
@@ -46,7 +46,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 5]
 {
- "BounceRate": 0.5,
+ "BounceRate": 0.4898,
  "Duration": 4971,
  "Pageviews": 6165,
  "Visitors": 3116
@@ -55,7 +55,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 6]
 {
- "BounceRate": 0.4945,
+ "BounceRate": 0.4852,
  "Duration": 5098,
  "Pageviews": 2113,
  "Visitors": 1090
@@ -64,7 +64,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 7]
 {
- "BounceRate": 0.5363,
+ "BounceRate": 0.5196,
  "Duration": 4728,
  "Pageviews": 726,
  "Visitors": 381
@@ -91,7 +91,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 10]
 {
- "BounceRate": 0.6,
+ "BounceRate": 0,
  "Duration": 3389,
  "Pageviews": 28,
  "Visitors": 17

--- a/core/db/duckdb/__snapshots__/summary_test.snap
+++ b/core/db/duckdb/__snapshots__/summary_test.snap
@@ -1,7 +1,7 @@
 
 [TestGetWebsiteSummary - 1]
 {
- "Bounces": 124684,
+ "BounceRate": 0.4996,
  "Duration": 5003,
  "Pageviews": 1000000,
  "Visitors": 499657
@@ -10,7 +10,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 1]
 {
- "Bounces": 41640,
+ "BounceRate": 0.5009,
  "Duration": 4980,
  "Pageviews": 332879,
  "Visitors": 166090
@@ -19,7 +19,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 2]
 {
- "Bounces": 13844,
+ "BounceRate": 0.4978,
  "Duration": 4992,
  "Pageviews": 110733,
  "Visitors": 55243
@@ -28,7 +28,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 3]
 {
- "Bounces": 4691,
+ "BounceRate": 0.4947,
  "Duration": 4997,
  "Pageviews": 37170,
  "Visitors": 18661
@@ -37,7 +37,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 4]
 {
- "Bounces": 2355,
+ "BounceRate": 0.4931,
  "Duration": 5003,
  "Pageviews": 18789,
  "Visitors": 9486
@@ -46,7 +46,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 5]
 {
- "Bounces": 783,
+ "BounceRate": 0.5,
  "Duration": 4971,
  "Pageviews": 6165,
  "Visitors": 3116
@@ -55,7 +55,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 6]
 {
- "Bounces": 268,
+ "BounceRate": 0.4945,
  "Duration": 5098,
  "Pageviews": 2113,
  "Visitors": 1090
@@ -64,7 +64,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 7]
 {
- "Bounces": 96,
+ "BounceRate": 0.5363,
  "Duration": 4728,
  "Pageviews": 726,
  "Visitors": 381
@@ -73,7 +73,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 8]
 {
- "Bounces": 31,
+ "BounceRate": 0.5439,
  "Duration": 4732,
  "Pageviews": 220,
  "Visitors": 116
@@ -82,7 +82,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 9]
 {
- "Bounces": 6,
+ "BounceRate": 0.4615,
  "Duration": 6547,
  "Pageviews": 67,
  "Visitors": 35
@@ -91,7 +91,7 @@
 
 [TestGetWebsiteSummaryFilterAll - 10]
 {
- "Bounces": 3,
+ "BounceRate": 0.6,
  "Duration": 3389,
  "Pageviews": 28,
  "Visitors": 17

--- a/core/db/duckdb/__snapshots__/types_test.snap
+++ b/core/db/duckdb/__snapshots__/types_test.snap
@@ -1,27 +1,27 @@
 
 [TestGetWebsiteBrowsers/Base - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Safari Visitors:166918 VisitorsPercentage:0.3341} Bounces:41597 Duration:5002}
-&{StatsBrowsersSummary:{Browser:Firefox Visitors:166649 VisitorsPercentage:0.3335} Bounces:41447 Duration:5027}
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:166090 VisitorsPercentage:0.3324} Bounces:41640 Duration:4980}
+&{StatsBrowsersSummary:{Browser:Safari Visitors:166918 VisitorsPercentage:0.3341} BounceRate:0.4996 Duration:5002}
+&{StatsBrowsersSummary:{Browser:Firefox Visitors:166649 VisitorsPercentage:0.3335} BounceRate:0.4996 Duration:5027}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:166090 VisitorsPercentage:0.3324} BounceRate:0.4996 Duration:4980}
 
 ---
 
 [TestGetWebsiteBrowsers/Browser - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:166090 VisitorsPercentage:1} Bounces:41640 Duration:4980}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:166090 VisitorsPercentage:1} BounceRate:0.5009 Duration:4980}
 
 ---
 
 [TestGetWebsiteBrowsers/Country - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:55243 VisitorsPercentage:1} Bounces:13844 Duration:4992}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:55243 VisitorsPercentage:1} BounceRate:0.4978 Duration:4992}
 
 ---
 
 [TestGetWebsiteBrowsers/Device - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:18661 VisitorsPercentage:1} Bounces:4691 Duration:4997}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:18661 VisitorsPercentage:1} BounceRate:0.4947 Duration:4997}
 
 ---
 
@@ -32,43 +32,43 @@ RECORDS:
 
 [TestGetWebsiteBrowsers/Language - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:9486 VisitorsPercentage:1} Bounces:2355 Duration:5003}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:9486 VisitorsPercentage:1} BounceRate:0.4931 Duration:5003}
 
 ---
 
 [TestGetWebsiteBrowsers/OS - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:3116 VisitorsPercentage:1} Bounces:783 Duration:4971}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:3116 VisitorsPercentage:1} BounceRate:0.5 Duration:4971}
 
 ---
 
 [TestGetWebsiteBrowsers/Pathname - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:1090 VisitorsPercentage:1} Bounces:268 Duration:5098}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:1090 VisitorsPercentage:1} BounceRate:0.4945 Duration:5098}
 
 ---
 
 [TestGetWebsiteBrowsers/Referrer - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
 
 ---
 
 [TestGetWebsiteBrowsers/UTMCampaign - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:116 VisitorsPercentage:1} BounceRate:0.5439 Duration:4732}
 
 ---
 
 [TestGetWebsiteBrowsers/UTMMedium - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:35 VisitorsPercentage:1} BounceRate:0.4615 Duration:6547}
 
 ---
 
 [TestGetWebsiteBrowsers/UTMSource - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
 
 ---
 
@@ -147,31 +147,31 @@ RECORDS:
 
 [TestGetWebsiteDevices/Base - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:166959 VisitorsPercentage:0.3341} Bounces:41553 Duration:5005}
-&{StatsDevicesSummary:{Device:Tablet Visitors:166722 VisitorsPercentage:0.3337} Bounces:41786 Duration:4995}
-&{StatsDevicesSummary:{Device:Mobile Visitors:165976 VisitorsPercentage:0.3322} Bounces:41345 Duration:5006}
+&{StatsDevicesSummary:{Device:Desktop Visitors:166959 VisitorsPercentage:0.3341} BounceRate:0.4996 Duration:5005}
+&{StatsDevicesSummary:{Device:Tablet Visitors:166722 VisitorsPercentage:0.3337} BounceRate:0.4996 Duration:4995}
+&{StatsDevicesSummary:{Device:Mobile Visitors:165976 VisitorsPercentage:0.3322} BounceRate:0.4996 Duration:5006}
 
 ---
 
 [TestGetWebsiteDevices/Browser - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:55422 VisitorsPercentage:0.3337} Bounces:13790 Duration:4995}
-&{StatsDevicesSummary:{Device:Mobile Visitors:55360 VisitorsPercentage:0.3333} Bounces:13886 Duration:4999}
-&{StatsDevicesSummary:{Device:Tablet Visitors:55308 VisitorsPercentage:0.333} Bounces:13964 Duration:4940}
+&{StatsDevicesSummary:{Device:Desktop Visitors:55422 VisitorsPercentage:0.3337} BounceRate:0.5009 Duration:4995}
+&{StatsDevicesSummary:{Device:Mobile Visitors:55360 VisitorsPercentage:0.3333} BounceRate:0.5009 Duration:4999}
+&{StatsDevicesSummary:{Device:Tablet Visitors:55308 VisitorsPercentage:0.333} BounceRate:0.5009 Duration:4940}
 
 ---
 
 [TestGetWebsiteDevices/Country - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:18661 VisitorsPercentage:0.3378} Bounces:4691 Duration:4997}
-&{StatsDevicesSummary:{Device:Mobile Visitors:18333 VisitorsPercentage:0.3319} Bounces:4603 Duration:4994}
-&{StatsDevicesSummary:{Device:Tablet Visitors:18249 VisitorsPercentage:0.3303} Bounces:4550 Duration:4983}
+&{StatsDevicesSummary:{Device:Desktop Visitors:18661 VisitorsPercentage:0.3378} BounceRate:0.4978 Duration:4997}
+&{StatsDevicesSummary:{Device:Mobile Visitors:18333 VisitorsPercentage:0.3319} BounceRate:0.4978 Duration:4994}
+&{StatsDevicesSummary:{Device:Tablet Visitors:18249 VisitorsPercentage:0.3303} BounceRate:0.4978 Duration:4983}
 
 ---
 
 [TestGetWebsiteDevices/Device - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:18661 VisitorsPercentage:1} Bounces:4691 Duration:4997}
+&{StatsDevicesSummary:{Device:Desktop Visitors:18661 VisitorsPercentage:1} BounceRate:0.4947 Duration:4997}
 
 ---
 
@@ -182,43 +182,43 @@ RECORDS:
 
 [TestGetWebsiteDevices/Language - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:9486 VisitorsPercentage:1} Bounces:2355 Duration:5003}
+&{StatsDevicesSummary:{Device:Desktop Visitors:9486 VisitorsPercentage:1} BounceRate:0.4931 Duration:5003}
 
 ---
 
 [TestGetWebsiteDevices/OS - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:3116 VisitorsPercentage:1} Bounces:783 Duration:4971}
+&{StatsDevicesSummary:{Device:Desktop Visitors:3116 VisitorsPercentage:1} BounceRate:0.5 Duration:4971}
 
 ---
 
 [TestGetWebsiteDevices/Pathname - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:1090 VisitorsPercentage:1} Bounces:268 Duration:5098}
+&{StatsDevicesSummary:{Device:Desktop Visitors:1090 VisitorsPercentage:1} BounceRate:0.4945 Duration:5098}
 
 ---
 
 [TestGetWebsiteDevices/Referrer - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
+&{StatsDevicesSummary:{Device:Desktop Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
 
 ---
 
 [TestGetWebsiteDevices/UTMCampaign - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
+&{StatsDevicesSummary:{Device:Desktop Visitors:116 VisitorsPercentage:1} BounceRate:0.5439 Duration:4732}
 
 ---
 
 [TestGetWebsiteDevices/UTMMedium - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
+&{StatsDevicesSummary:{Device:Desktop Visitors:35 VisitorsPercentage:1} BounceRate:0.4615 Duration:6547}
 
 ---
 
 [TestGetWebsiteDevices/UTMSource - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
+&{StatsDevicesSummary:{Device:Desktop Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
 
 ---
 
@@ -301,33 +301,33 @@ RECORDS:
 
 [TestGetWebsiteOS/Base - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:166647 VisitorsPercentage:0.3335} Bounces:41649 Duration:5006}
-&{StatsOSSummary:{OS:Windows Visitors:166538 VisitorsPercentage:0.3333} Bounces:41565 Duration:5001}
-&{StatsOSSummary:{OS:Linux Visitors:166472 VisitorsPercentage:0.3332} Bounces:41470 Duration:5002}
+&{StatsOSSummary:{OS:iOS Visitors:166647 VisitorsPercentage:0.3335} BounceRate:0.4996 Duration:5006}
+&{StatsOSSummary:{OS:Windows Visitors:166538 VisitorsPercentage:0.3333} BounceRate:0.4996 Duration:5001}
+&{StatsOSSummary:{OS:Linux Visitors:166472 VisitorsPercentage:0.3332} BounceRate:0.4996 Duration:5002}
 
 ---
 
 [TestGetWebsiteOS/Browser - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Linux Visitors:55412 VisitorsPercentage:0.3336} Bounces:13814 Duration:4997}
-&{StatsOSSummary:{OS:Windows Visitors:55394 VisitorsPercentage:0.3335} Bounces:13832 Duration:4969}
-&{StatsOSSummary:{OS:iOS Visitors:55284 VisitorsPercentage:0.3329} Bounces:13994 Duration:4975}
+&{StatsOSSummary:{OS:Linux Visitors:55412 VisitorsPercentage:0.3336} BounceRate:0.5009 Duration:4997}
+&{StatsOSSummary:{OS:Windows Visitors:55394 VisitorsPercentage:0.3335} BounceRate:0.5009 Duration:4969}
+&{StatsOSSummary:{OS:iOS Visitors:55284 VisitorsPercentage:0.3329} BounceRate:0.5009 Duration:4975}
 
 ---
 
 [TestGetWebsiteOS/Country - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:18554 VisitorsPercentage:0.3359} Bounces:4655 Duration:5002}
-&{StatsOSSummary:{OS:Linux Visitors:18365 VisitorsPercentage:0.3324} Bounces:4551 Duration:5046}
-&{StatsOSSummary:{OS:Windows Visitors:18324 VisitorsPercentage:0.3317} Bounces:4638 Duration:4930}
+&{StatsOSSummary:{OS:iOS Visitors:18554 VisitorsPercentage:0.3359} BounceRate:0.4978 Duration:5002}
+&{StatsOSSummary:{OS:Linux Visitors:18365 VisitorsPercentage:0.3324} BounceRate:0.4978 Duration:5046}
+&{StatsOSSummary:{OS:Windows Visitors:18324 VisitorsPercentage:0.3317} BounceRate:0.4978 Duration:4930}
 
 ---
 
 [TestGetWebsiteOS/Device - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:6314 VisitorsPercentage:0.3384} Bounces:1608 Duration:4996}
-&{StatsOSSummary:{OS:Linux Visitors:6175 VisitorsPercentage:0.3309} Bounces:1543 Duration:5021}
-&{StatsOSSummary:{OS:Windows Visitors:6172 VisitorsPercentage:0.3307} Bounces:1540 Duration:4978}
+&{StatsOSSummary:{OS:iOS Visitors:6314 VisitorsPercentage:0.3384} BounceRate:0.4947 Duration:4996}
+&{StatsOSSummary:{OS:Linux Visitors:6175 VisitorsPercentage:0.3309} BounceRate:0.4947 Duration:5021}
+&{StatsOSSummary:{OS:Windows Visitors:6172 VisitorsPercentage:0.3307} BounceRate:0.4947 Duration:4978}
 
 ---
 
@@ -338,45 +338,45 @@ RECORDS:
 
 [TestGetWebsiteOS/Language - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:3246 VisitorsPercentage:0.3422} Bounces:829 Duration:5011}
-&{StatsOSSummary:{OS:Linux Visitors:3124 VisitorsPercentage:0.3293} Bounces:743 Duration:5040}
-&{StatsOSSummary:{OS:Windows Visitors:3116 VisitorsPercentage:0.3285} Bounces:783 Duration:4971}
+&{StatsOSSummary:{OS:iOS Visitors:3246 VisitorsPercentage:0.3422} BounceRate:0.4931 Duration:5011}
+&{StatsOSSummary:{OS:Linux Visitors:3124 VisitorsPercentage:0.3293} BounceRate:0.4931 Duration:5040}
+&{StatsOSSummary:{OS:Windows Visitors:3116 VisitorsPercentage:0.3285} BounceRate:0.4931 Duration:4971}
 
 ---
 
 [TestGetWebsiteOS/OS - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:3116 VisitorsPercentage:1} Bounces:783 Duration:4971}
+&{StatsOSSummary:{OS:Windows Visitors:3116 VisitorsPercentage:1} BounceRate:0.5 Duration:4971}
 
 ---
 
 [TestGetWebsiteOS/Pathname - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:1090 VisitorsPercentage:1} Bounces:268 Duration:5098}
+&{StatsOSSummary:{OS:Windows Visitors:1090 VisitorsPercentage:1} BounceRate:0.4945 Duration:5098}
 
 ---
 
 [TestGetWebsiteOS/Referrer - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:381 VisitorsPercentage:1} Bounces:96 Duration:4728}
+&{StatsOSSummary:{OS:Windows Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
 
 ---
 
 [TestGetWebsiteOS/UTMCampaign - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
+&{StatsOSSummary:{OS:Windows Visitors:116 VisitorsPercentage:1} BounceRate:0.5439 Duration:4732}
 
 ---
 
 [TestGetWebsiteOS/UTMMedium - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
+&{StatsOSSummary:{OS:Windows Visitors:35 VisitorsPercentage:1} BounceRate:0.4615 Duration:6547}
 
 ---
 
 [TestGetWebsiteOS/UTMSource - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
+&{StatsOSSummary:{OS:Windows Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
 
 ---
 

--- a/core/db/duckdb/__snapshots__/types_test.snap
+++ b/core/db/duckdb/__snapshots__/types_test.snap
@@ -1,27 +1,27 @@
 
 [TestGetWebsiteBrowsers/Base - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Safari Visitors:166918 VisitorsPercentage:0.3341} BounceRate:0.4996 Duration:5002}
-&{StatsBrowsersSummary:{Browser:Firefox Visitors:166649 VisitorsPercentage:0.3335} BounceRate:0.4996 Duration:5027}
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:166090 VisitorsPercentage:0.3324} BounceRate:0.4996 Duration:4980}
+&{StatsBrowsersSummary:{Browser:Safari Visitors:166918 VisitorsPercentage:0.3341} BounceRate:0.4893 Duration:5002}
+&{StatsBrowsersSummary:{Browser:Firefox Visitors:166649 VisitorsPercentage:0.3335} BounceRate:0.4882 Duration:5027}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:166090 VisitorsPercentage:0.3324} BounceRate:0.4911 Duration:4980}
 
 ---
 
 [TestGetWebsiteBrowsers/Browser - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:166090 VisitorsPercentage:1} BounceRate:0.5009 Duration:4980}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:166090 VisitorsPercentage:1} BounceRate:0.4911 Duration:4980}
 
 ---
 
 [TestGetWebsiteBrowsers/Country - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:55243 VisitorsPercentage:1} BounceRate:0.4978 Duration:4992}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:55243 VisitorsPercentage:1} BounceRate:0.4887 Duration:4992}
 
 ---
 
 [TestGetWebsiteBrowsers/Device - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:18661 VisitorsPercentage:1} BounceRate:0.4947 Duration:4997}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:18661 VisitorsPercentage:1} BounceRate:0.4852 Duration:4997}
 
 ---
 
@@ -32,25 +32,25 @@ RECORDS:
 
 [TestGetWebsiteBrowsers/Language - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:9486 VisitorsPercentage:1} BounceRate:0.4931 Duration:5003}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:9486 VisitorsPercentage:1} BounceRate:0.4824 Duration:5003}
 
 ---
 
 [TestGetWebsiteBrowsers/OS - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:3116 VisitorsPercentage:1} BounceRate:0.5 Duration:4971}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:3116 VisitorsPercentage:1} BounceRate:0.4898 Duration:4971}
 
 ---
 
 [TestGetWebsiteBrowsers/Pathname - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:1090 VisitorsPercentage:1} BounceRate:0.4945 Duration:5098}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:1090 VisitorsPercentage:1} BounceRate:0.4852 Duration:5098}
 
 ---
 
 [TestGetWebsiteBrowsers/Referrer - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:381 VisitorsPercentage:1} BounceRate:0.5196 Duration:4728}
 
 ---
 
@@ -68,7 +68,7 @@ RECORDS:
 
 [TestGetWebsiteBrowsers/UTMSource - 1]
 RECORDS:
-&{StatsBrowsersSummary:{Browser:Chrome Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
+&{StatsBrowsersSummary:{Browser:Chrome Visitors:17 VisitorsPercentage:1} BounceRate:0 Duration:3389}
 
 ---
 
@@ -147,31 +147,31 @@ RECORDS:
 
 [TestGetWebsiteDevices/Base - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:166959 VisitorsPercentage:0.3341} BounceRate:0.4996 Duration:5005}
-&{StatsDevicesSummary:{Device:Tablet Visitors:166722 VisitorsPercentage:0.3337} BounceRate:0.4996 Duration:4995}
-&{StatsDevicesSummary:{Device:Mobile Visitors:165976 VisitorsPercentage:0.3322} BounceRate:0.4996 Duration:5006}
+&{StatsDevicesSummary:{Device:Desktop Visitors:166959 VisitorsPercentage:0.3341} BounceRate:0.4878 Duration:5005}
+&{StatsDevicesSummary:{Device:Tablet Visitors:166722 VisitorsPercentage:0.3337} BounceRate:0.4913 Duration:4995}
+&{StatsDevicesSummary:{Device:Mobile Visitors:165976 VisitorsPercentage:0.3322} BounceRate:0.4894 Duration:5006}
 
 ---
 
 [TestGetWebsiteDevices/Browser - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:55422 VisitorsPercentage:0.3337} BounceRate:0.5009 Duration:4995}
-&{StatsDevicesSummary:{Device:Mobile Visitors:55360 VisitorsPercentage:0.3333} BounceRate:0.5009 Duration:4999}
-&{StatsDevicesSummary:{Device:Tablet Visitors:55308 VisitorsPercentage:0.333} BounceRate:0.5009 Duration:4940}
+&{StatsDevicesSummary:{Device:Desktop Visitors:55422 VisitorsPercentage:0.3337} BounceRate:0.4873 Duration:4995}
+&{StatsDevicesSummary:{Device:Mobile Visitors:55360 VisitorsPercentage:0.3333} BounceRate:0.4912 Duration:4999}
+&{StatsDevicesSummary:{Device:Tablet Visitors:55308 VisitorsPercentage:0.333} BounceRate:0.4946 Duration:4940}
 
 ---
 
 [TestGetWebsiteDevices/Country - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:18661 VisitorsPercentage:0.3378} BounceRate:0.4978 Duration:4997}
-&{StatsDevicesSummary:{Device:Mobile Visitors:18333 VisitorsPercentage:0.3319} BounceRate:0.4978 Duration:4994}
-&{StatsDevicesSummary:{Device:Tablet Visitors:18249 VisitorsPercentage:0.3303} BounceRate:0.4978 Duration:4983}
+&{StatsDevicesSummary:{Device:Desktop Visitors:18661 VisitorsPercentage:0.3378} BounceRate:0.4852 Duration:4997}
+&{StatsDevicesSummary:{Device:Mobile Visitors:18333 VisitorsPercentage:0.3319} BounceRate:0.4913 Duration:4994}
+&{StatsDevicesSummary:{Device:Tablet Visitors:18249 VisitorsPercentage:0.3303} BounceRate:0.4896 Duration:4983}
 
 ---
 
 [TestGetWebsiteDevices/Device - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:18661 VisitorsPercentage:1} BounceRate:0.4947 Duration:4997}
+&{StatsDevicesSummary:{Device:Desktop Visitors:18661 VisitorsPercentage:1} BounceRate:0.4852 Duration:4997}
 
 ---
 
@@ -182,25 +182,25 @@ RECORDS:
 
 [TestGetWebsiteDevices/Language - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:9486 VisitorsPercentage:1} BounceRate:0.4931 Duration:5003}
+&{StatsDevicesSummary:{Device:Desktop Visitors:9486 VisitorsPercentage:1} BounceRate:0.4824 Duration:5003}
 
 ---
 
 [TestGetWebsiteDevices/OS - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:3116 VisitorsPercentage:1} BounceRate:0.5 Duration:4971}
+&{StatsDevicesSummary:{Device:Desktop Visitors:3116 VisitorsPercentage:1} BounceRate:0.4898 Duration:4971}
 
 ---
 
 [TestGetWebsiteDevices/Pathname - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:1090 VisitorsPercentage:1} BounceRate:0.4945 Duration:5098}
+&{StatsDevicesSummary:{Device:Desktop Visitors:1090 VisitorsPercentage:1} BounceRate:0.4852 Duration:5098}
 
 ---
 
 [TestGetWebsiteDevices/Referrer - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
+&{StatsDevicesSummary:{Device:Desktop Visitors:381 VisitorsPercentage:1} BounceRate:0.5196 Duration:4728}
 
 ---
 
@@ -218,7 +218,7 @@ RECORDS:
 
 [TestGetWebsiteDevices/UTMSource - 1]
 RECORDS:
-&{StatsDevicesSummary:{Device:Desktop Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
+&{StatsDevicesSummary:{Device:Desktop Visitors:17 VisitorsPercentage:1} BounceRate:0 Duration:3389}
 
 ---
 
@@ -301,33 +301,33 @@ RECORDS:
 
 [TestGetWebsiteOS/Base - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:166647 VisitorsPercentage:0.3335} BounceRate:0.4996 Duration:5006}
-&{StatsOSSummary:{OS:Windows Visitors:166538 VisitorsPercentage:0.3333} BounceRate:0.4996 Duration:5001}
-&{StatsOSSummary:{OS:Linux Visitors:166472 VisitorsPercentage:0.3332} BounceRate:0.4996 Duration:5002}
+&{StatsOSSummary:{OS:iOS Visitors:166647 VisitorsPercentage:0.3335} BounceRate:0.4907 Duration:5006}
+&{StatsOSSummary:{OS:Windows Visitors:166538 VisitorsPercentage:0.3333} BounceRate:0.4893 Duration:5001}
+&{StatsOSSummary:{OS:Linux Visitors:166472 VisitorsPercentage:0.3332} BounceRate:0.4885 Duration:5002}
 
 ---
 
 [TestGetWebsiteOS/Browser - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Linux Visitors:55412 VisitorsPercentage:0.3336} BounceRate:0.5009 Duration:4997}
-&{StatsOSSummary:{OS:Windows Visitors:55394 VisitorsPercentage:0.3335} BounceRate:0.5009 Duration:4969}
-&{StatsOSSummary:{OS:iOS Visitors:55284 VisitorsPercentage:0.3329} BounceRate:0.5009 Duration:4975}
+&{StatsOSSummary:{OS:Linux Visitors:55412 VisitorsPercentage:0.3336} BounceRate:0.4887 Duration:4997}
+&{StatsOSSummary:{OS:Windows Visitors:55394 VisitorsPercentage:0.3335} BounceRate:0.4904 Duration:4969}
+&{StatsOSSummary:{OS:iOS Visitors:55284 VisitorsPercentage:0.3329} BounceRate:0.4941 Duration:4975}
 
 ---
 
 [TestGetWebsiteOS/Country - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:18554 VisitorsPercentage:0.3359} BounceRate:0.4978 Duration:5002}
-&{StatsOSSummary:{OS:Linux Visitors:18365 VisitorsPercentage:0.3324} BounceRate:0.4978 Duration:5046}
-&{StatsOSSummary:{OS:Windows Visitors:18324 VisitorsPercentage:0.3317} BounceRate:0.4978 Duration:4930}
+&{StatsOSSummary:{OS:iOS Visitors:18554 VisitorsPercentage:0.3359} BounceRate:0.4896 Duration:5002}
+&{StatsOSSummary:{OS:Linux Visitors:18365 VisitorsPercentage:0.3324} BounceRate:0.4847 Duration:5046}
+&{StatsOSSummary:{OS:Windows Visitors:18324 VisitorsPercentage:0.3317} BounceRate:0.4917 Duration:4930}
 
 ---
 
 [TestGetWebsiteOS/Device - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:6314 VisitorsPercentage:0.3384} BounceRate:0.4947 Duration:4996}
-&{StatsOSSummary:{OS:Linux Visitors:6175 VisitorsPercentage:0.3309} BounceRate:0.4947 Duration:5021}
-&{StatsOSSummary:{OS:Windows Visitors:6172 VisitorsPercentage:0.3307} BounceRate:0.4947 Duration:4978}
+&{StatsOSSummary:{OS:iOS Visitors:6314 VisitorsPercentage:0.3384} BounceRate:0.4865 Duration:4996}
+&{StatsOSSummary:{OS:Linux Visitors:6175 VisitorsPercentage:0.3309} BounceRate:0.485 Duration:5021}
+&{StatsOSSummary:{OS:Windows Visitors:6172 VisitorsPercentage:0.3307} BounceRate:0.4841 Duration:4978}
 
 ---
 
@@ -338,27 +338,27 @@ RECORDS:
 
 [TestGetWebsiteOS/Language - 1]
 RECORDS:
-&{StatsOSSummary:{OS:iOS Visitors:3246 VisitorsPercentage:0.3422} BounceRate:0.4931 Duration:5011}
-&{StatsOSSummary:{OS:Linux Visitors:3124 VisitorsPercentage:0.3293} BounceRate:0.4931 Duration:5040}
-&{StatsOSSummary:{OS:Windows Visitors:3116 VisitorsPercentage:0.3285} BounceRate:0.4931 Duration:4971}
+&{StatsOSSummary:{OS:iOS Visitors:3246 VisitorsPercentage:0.3422} BounceRate:0.4894 Duration:5011}
+&{StatsOSSummary:{OS:Linux Visitors:3124 VisitorsPercentage:0.3293} BounceRate:0.4677 Duration:5040}
+&{StatsOSSummary:{OS:Windows Visitors:3116 VisitorsPercentage:0.3285} BounceRate:0.4898 Duration:4971}
 
 ---
 
 [TestGetWebsiteOS/OS - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:3116 VisitorsPercentage:1} BounceRate:0.5 Duration:4971}
+&{StatsOSSummary:{OS:Windows Visitors:3116 VisitorsPercentage:1} BounceRate:0.4898 Duration:4971}
 
 ---
 
 [TestGetWebsiteOS/Pathname - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:1090 VisitorsPercentage:1} BounceRate:0.4945 Duration:5098}
+&{StatsOSSummary:{OS:Windows Visitors:1090 VisitorsPercentage:1} BounceRate:0.4852 Duration:5098}
 
 ---
 
 [TestGetWebsiteOS/Referrer - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:381 VisitorsPercentage:1} BounceRate:0.5363 Duration:4728}
+&{StatsOSSummary:{OS:Windows Visitors:381 VisitorsPercentage:1} BounceRate:0.5196 Duration:4728}
 
 ---
 
@@ -376,7 +376,7 @@ RECORDS:
 
 [TestGetWebsiteOS/UTMSource - 1]
 RECORDS:
-&{StatsOSSummary:{OS:Windows Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
+&{StatsOSSummary:{OS:Windows Visitors:17 VisitorsPercentage:1} BounceRate:0 Duration:3389}
 
 ---
 

--- a/core/db/duckdb/__snapshots__/utm_test.snap
+++ b/core/db/duckdb/__snapshots__/utm_test.snap
@@ -1,33 +1,33 @@
 
 [TestGetWebsiteUTMCampaigns/Base - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:166923 VisitorsPercentage:0.3341} Bounces:41554 Duration:5000}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:166654 VisitorsPercentage:0.3335} Bounces:41720 Duration:5002}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:166080 VisitorsPercentage:0.3324} Bounces:41410 Duration:5007}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:166923 VisitorsPercentage:0.3341} BounceRate:0.4996 Duration:5000}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:166654 VisitorsPercentage:0.3335} BounceRate:0.4996 Duration:5002}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:166080 VisitorsPercentage:0.3324} BounceRate:0.4996 Duration:5007}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Browser - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:55517 VisitorsPercentage:0.3343} Bounces:13819 Duration:4977}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:55310 VisitorsPercentage:0.333} Bounces:13910 Duration:4992}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:55263 VisitorsPercentage:0.3327} Bounces:13911 Duration:4970}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:55517 VisitorsPercentage:0.3343} BounceRate:0.5009 Duration:4977}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:55310 VisitorsPercentage:0.333} BounceRate:0.5009 Duration:4992}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:55263 VisitorsPercentage:0.3327} BounceRate:0.5009 Duration:4970}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Country - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:18468 VisitorsPercentage:0.3343} Bounces:4588 Duration:5002}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:18406 VisitorsPercentage:0.3332} Bounces:4657 Duration:5017}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:18369 VisitorsPercentage:0.3325} Bounces:4599 Duration:4958}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:18468 VisitorsPercentage:0.3343} BounceRate:0.4978 Duration:5002}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:18406 VisitorsPercentage:0.3332} BounceRate:0.4978 Duration:5017}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:18369 VisitorsPercentage:0.3325} BounceRate:0.4978 Duration:4958}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Device - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:6260 VisitorsPercentage:0.3355} Bounces:1568 Duration:5040}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:6228 VisitorsPercentage:0.3337} Bounces:1579 Duration:4970}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:6173 VisitorsPercentage:0.3308} Bounces:1544 Duration:4982}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:6260 VisitorsPercentage:0.3355} BounceRate:0.4947 Duration:5040}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:6228 VisitorsPercentage:0.3337} BounceRate:0.4947 Duration:4970}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:6173 VisitorsPercentage:0.3308} BounceRate:0.4947 Duration:4982}
 
 ---
 
@@ -38,51 +38,51 @@ RECORDS:
 
 [TestGetWebsiteUTMCampaigns/Language - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:3215 VisitorsPercentage:0.3389} Bounces:812 Duration:4972}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:3150 VisitorsPercentage:0.3321} Bounces:758 Duration:5105}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:3121 VisitorsPercentage:0.329} Bounces:785 Duration:4872}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:3215 VisitorsPercentage:0.3389} BounceRate:0.4931 Duration:4972}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:3150 VisitorsPercentage:0.3321} BounceRate:0.4931 Duration:5105}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:3121 VisitorsPercentage:0.329} BounceRate:0.4931 Duration:4872}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/OS - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:1068 VisitorsPercentage:0.3427} Bounces:258 Duration:4997}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:1043 VisitorsPercentage:0.3347} Bounces:255 Duration:5131}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:1005 VisitorsPercentage:0.3225} Bounces:270 Duration:4736}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:1068 VisitorsPercentage:0.3427} BounceRate:0.5 Duration:4997}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:1043 VisitorsPercentage:0.3347} BounceRate:0.5 Duration:5131}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:1005 VisitorsPercentage:0.3225} BounceRate:0.5 Duration:4736}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Pathname - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:369 VisitorsPercentage:0.3385} Bounces:92 Duration:4948}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:361 VisitorsPercentage:0.3312} Bounces:86 Duration:5038}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:360 VisitorsPercentage:0.3303} Bounces:90 Duration:5509}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:369 VisitorsPercentage:0.3385} BounceRate:0.4945 Duration:4948}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:361 VisitorsPercentage:0.3312} BounceRate:0.4945 Duration:5038}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:360 VisitorsPercentage:0.3303} BounceRate:0.4945 Duration:5509}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Referrer - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:141 VisitorsPercentage:0.3701} Bounces:38 Duration:4761}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:124 VisitorsPercentage:0.3255} Bounces:27 Duration:4700}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:116 VisitorsPercentage:0.3045} Bounces:31 Duration:4732}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:141 VisitorsPercentage:0.3701} BounceRate:0.5363 Duration:4761}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:124 VisitorsPercentage:0.3255} BounceRate:0.5363 Duration:4700}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:116 VisitorsPercentage:0.3045} BounceRate:0.5363 Duration:4732}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/UTMCampaign - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:116 VisitorsPercentage:1} Bounces:31 Duration:4732}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:116 VisitorsPercentage:1} BounceRate:0.5439 Duration:4732}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/UTMMedium - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:35 VisitorsPercentage:1} BounceRate:0.4615 Duration:6547}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/UTMSource - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
 
 ---
 
@@ -175,33 +175,33 @@ RECORDS:
 
 [TestGetWebsiteUTMMediums/Base - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:167067 VisitorsPercentage:0.3344} Bounces:41702 Duration:5008}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:166355 VisitorsPercentage:0.3329} Bounces:41466 Duration:5004}
-&{StatsUTMMediumsSummary:{Medium: Visitors:166235 VisitorsPercentage:0.3327} Bounces:41516 Duration:4995}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:167067 VisitorsPercentage:0.3344} BounceRate:0.4996 Duration:5008}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:166355 VisitorsPercentage:0.3329} BounceRate:0.4996 Duration:5004}
+&{StatsUTMMediumsSummary:{Medium: Visitors:166235 VisitorsPercentage:0.3327} BounceRate:0.4996 Duration:4995}
 
 ---
 
 [TestGetWebsiteUTMMediums/Browser - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:55415 VisitorsPercentage:0.3336} Bounces:13833 Duration:4992}
-&{StatsUTMMediumsSummary:{Medium: Visitors:55402 VisitorsPercentage:0.3336} Bounces:13902 Duration:4976}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:55273 VisitorsPercentage:0.3328} Bounces:13905 Duration:4973}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:55415 VisitorsPercentage:0.3336} BounceRate:0.5009 Duration:4992}
+&{StatsUTMMediumsSummary:{Medium: Visitors:55402 VisitorsPercentage:0.3336} BounceRate:0.5009 Duration:4976}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:55273 VisitorsPercentage:0.3328} BounceRate:0.5009 Duration:4973}
 
 ---
 
 [TestGetWebsiteUTMMediums/Country - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:18538 VisitorsPercentage:0.3356} Bounces:4668 Duration:5006}
-&{StatsUTMMediumsSummary:{Medium: Visitors:18528 VisitorsPercentage:0.3354} Bounces:4607 Duration:4995}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:18177 VisitorsPercentage:0.329} Bounces:4569 Duration:4977}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:18538 VisitorsPercentage:0.3356} BounceRate:0.4978 Duration:5006}
+&{StatsUTMMediumsSummary:{Medium: Visitors:18528 VisitorsPercentage:0.3354} BounceRate:0.4978 Duration:4995}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:18177 VisitorsPercentage:0.329} BounceRate:0.4978 Duration:4977}
 
 ---
 
 [TestGetWebsiteUTMMediums/Device - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:6299 VisitorsPercentage:0.3375} Bounces:1579 Duration:5036}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:6293 VisitorsPercentage:0.3372} Bounces:1618 Duration:4916}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:6069 VisitorsPercentage:0.3252} Bounces:1494 Duration:5028}
+&{StatsUTMMediumsSummary:{Medium: Visitors:6299 VisitorsPercentage:0.3375} BounceRate:0.4947 Duration:5036}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:6293 VisitorsPercentage:0.3372} BounceRate:0.4947 Duration:4916}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:6069 VisitorsPercentage:0.3252} BounceRate:0.4947 Duration:5028}
 
 ---
 
@@ -212,53 +212,53 @@ RECORDS:
 
 [TestGetWebsiteUTMMediums/Language - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:3216 VisitorsPercentage:0.339} Bounces:782 Duration:5126}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:3193 VisitorsPercentage:0.3366} Bounces:804 Duration:4909}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:3077 VisitorsPercentage:0.3244} Bounces:769 Duration:4968}
+&{StatsUTMMediumsSummary:{Medium: Visitors:3216 VisitorsPercentage:0.339} BounceRate:0.4931 Duration:5126}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:3193 VisitorsPercentage:0.3366} BounceRate:0.4931 Duration:4909}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:3077 VisitorsPercentage:0.3244} BounceRate:0.4931 Duration:4968}
 
 ---
 
 [TestGetWebsiteUTMMediums/OS - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:1052 VisitorsPercentage:0.3376} Bounces:275 Duration:4848}
-&{StatsUTMMediumsSummary:{Medium: Visitors:1043 VisitorsPercentage:0.3347} Bounces:249 Duration:5072}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:1021 VisitorsPercentage:0.3277} Bounces:259 Duration:4970}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:1052 VisitorsPercentage:0.3376} BounceRate:0.5 Duration:4848}
+&{StatsUTMMediumsSummary:{Medium: Visitors:1043 VisitorsPercentage:0.3347} BounceRate:0.5 Duration:5072}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:1021 VisitorsPercentage:0.3277} BounceRate:0.5 Duration:4970}
 
 ---
 
 [TestGetWebsiteUTMMediums/Pathname - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:384 VisitorsPercentage:0.3523} Bounces:94 Duration:4950}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:364 VisitorsPercentage:0.3339} Bounces:101 Duration:4826}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:342 VisitorsPercentage:0.3138} Bounces:73 Duration:5556}
+&{StatsUTMMediumsSummary:{Medium: Visitors:384 VisitorsPercentage:0.3523} BounceRate:0.4945 Duration:4950}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:364 VisitorsPercentage:0.3339} BounceRate:0.4945 Duration:4826}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:342 VisitorsPercentage:0.3138} BounceRate:0.4945 Duration:5556}
 
 ---
 
 [TestGetWebsiteUTMMediums/Referrer - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:132 VisitorsPercentage:0.3465} Bounces:41 Duration:4180}
-&{StatsUTMMediumsSummary:{Medium: Visitors:131 VisitorsPercentage:0.3438} Bounces:34 Duration:4812}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:118 VisitorsPercentage:0.3097} Bounces:21 Duration:5558}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:132 VisitorsPercentage:0.3465} BounceRate:0.5363 Duration:4180}
+&{StatsUTMMediumsSummary:{Medium: Visitors:131 VisitorsPercentage:0.3438} BounceRate:0.5363 Duration:4812}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:118 VisitorsPercentage:0.3097} BounceRate:0.5363 Duration:5558}
 
 ---
 
 [TestGetWebsiteUTMMediums/UTMCampaign - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:42 VisitorsPercentage:0.3621} Bounces:16 Duration:4395}
-&{StatsUTMMediumsSummary:{Medium: Visitors:39 VisitorsPercentage:0.3362} Bounces:9 Duration:5240}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:35 VisitorsPercentage:0.3017} Bounces:6 Duration:6547}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:42 VisitorsPercentage:0.3621} BounceRate:0.5439 Duration:4395}
+&{StatsUTMMediumsSummary:{Medium: Visitors:39 VisitorsPercentage:0.3362} BounceRate:0.5439 Duration:5240}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:35 VisitorsPercentage:0.3017} BounceRate:0.5439 Duration:6547}
 
 ---
 
 [TestGetWebsiteUTMMediums/UTMMedium - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:35 VisitorsPercentage:1} Bounces:6 Duration:6547}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:35 VisitorsPercentage:1} BounceRate:0.4615 Duration:6547}
 
 ---
 
 [TestGetWebsiteUTMMediums/UTMSource - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
 
 ---
 
@@ -353,33 +353,33 @@ RECORDS:
 
 [TestGetWebsiteUTMSources/Base - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:166720 VisitorsPercentage:0.3337} Bounces:41302 Duration:5006}
-&{StatsUTMSourcesSummary:{Source:bing Visitors:166575 VisitorsPercentage:0.3334} Bounces:41910 Duration:4990}
-&{StatsUTMSourcesSummary:{Source: Visitors:166362 VisitorsPercentage:0.333} Bounces:41472 Duration:5013}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:166720 VisitorsPercentage:0.3337} BounceRate:0.4996 Duration:5006}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:166575 VisitorsPercentage:0.3334} BounceRate:0.4996 Duration:4990}
+&{StatsUTMSourcesSummary:{Source: Visitors:166362 VisitorsPercentage:0.333} BounceRate:0.4996 Duration:5013}
 
 ---
 
 [TestGetWebsiteUTMSources/Browser - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:55742 VisitorsPercentage:0.3356} Bounces:14094 Duration:4976}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:55251 VisitorsPercentage:0.3327} Bounces:13803 Duration:4978}
-&{StatsUTMSourcesSummary:{Source: Visitors:55097 VisitorsPercentage:0.3317} Bounces:13743 Duration:4989}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:55742 VisitorsPercentage:0.3356} BounceRate:0.5009 Duration:4976}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:55251 VisitorsPercentage:0.3327} BounceRate:0.5009 Duration:4978}
+&{StatsUTMSourcesSummary:{Source: Visitors:55097 VisitorsPercentage:0.3317} BounceRate:0.5009 Duration:4989}
 
 ---
 
 [TestGetWebsiteUTMSources/Country - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:18552 VisitorsPercentage:0.3358} Bounces:4676 Duration:4993}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:18490 VisitorsPercentage:0.3347} Bounces:4614 Duration:5014}
-&{StatsUTMSourcesSummary:{Source: Visitors:18201 VisitorsPercentage:0.3295} Bounces:4554 Duration:4965}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:18552 VisitorsPercentage:0.3358} BounceRate:0.4978 Duration:4993}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:18490 VisitorsPercentage:0.3347} BounceRate:0.4978 Duration:5014}
+&{StatsUTMSourcesSummary:{Source: Visitors:18201 VisitorsPercentage:0.3295} BounceRate:0.4978 Duration:4965}
 
 ---
 
 [TestGetWebsiteUTMSources/Device - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:6267 VisitorsPercentage:0.3358} Bounces:1566 Duration:5044}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:6213 VisitorsPercentage:0.3329} Bounces:1553 Duration:5031}
-&{StatsUTMSourcesSummary:{Source: Visitors:6181 VisitorsPercentage:0.3312} Bounces:1572 Duration:4915}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:6267 VisitorsPercentage:0.3358} BounceRate:0.4947 Duration:5044}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:6213 VisitorsPercentage:0.3329} BounceRate:0.4947 Duration:5031}
+&{StatsUTMSourcesSummary:{Source: Visitors:6181 VisitorsPercentage:0.3312} BounceRate:0.4947 Duration:4915}
 
 ---
 
@@ -390,55 +390,55 @@ RECORDS:
 
 [TestGetWebsiteUTMSources/Language - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:3206 VisitorsPercentage:0.338} Bounces:785 Duration:5120}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:3190 VisitorsPercentage:0.3363} Bounces:792 Duration:5028}
-&{StatsUTMSourcesSummary:{Source: Visitors:3090 VisitorsPercentage:0.3257} Bounces:778 Duration:4835}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:3206 VisitorsPercentage:0.338} BounceRate:0.4931 Duration:5120}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:3190 VisitorsPercentage:0.3363} BounceRate:0.4931 Duration:5028}
+&{StatsUTMSourcesSummary:{Source: Visitors:3090 VisitorsPercentage:0.3257} BounceRate:0.4931 Duration:4835}
 
 ---
 
 [TestGetWebsiteUTMSources/OS - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:1064 VisitorsPercentage:0.3415} Bounces:261 Duration:5071}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:1034 VisitorsPercentage:0.3318} Bounces:268 Duration:4861}
-&{StatsUTMSourcesSummary:{Source: Visitors:1018 VisitorsPercentage:0.3267} Bounces:254 Duration:4954}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:1064 VisitorsPercentage:0.3415} BounceRate:0.5 Duration:5071}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:1034 VisitorsPercentage:0.3318} BounceRate:0.5 Duration:4861}
+&{StatsUTMSourcesSummary:{Source: Visitors:1018 VisitorsPercentage:0.3267} BounceRate:0.5 Duration:4954}
 
 ---
 
 [TestGetWebsiteUTMSources/Pathname - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:381 VisitorsPercentage:0.3495} Bounces:88 Duration:5441}
-&{StatsUTMSourcesSummary:{Source: Visitors:365 VisitorsPercentage:0.3349} Bounces:96 Duration:5028}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:344 VisitorsPercentage:0.3156} Bounces:84 Duration:4985}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:381 VisitorsPercentage:0.3495} BounceRate:0.4945 Duration:5441}
+&{StatsUTMSourcesSummary:{Source: Visitors:365 VisitorsPercentage:0.3349} BounceRate:0.4945 Duration:5028}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:344 VisitorsPercentage:0.3156} BounceRate:0.4945 Duration:4985}
 
 ---
 
 [TestGetWebsiteUTMSources/Referrer - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:140 VisitorsPercentage:0.3675} Bounces:32 Duration:4694}
-&{StatsUTMSourcesSummary:{Source: Visitors:126 VisitorsPercentage:0.3307} Bounces:38 Duration:4723}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:115 VisitorsPercentage:0.3018} Bounces:26 Duration:4732}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:140 VisitorsPercentage:0.3675} BounceRate:0.5363 Duration:4694}
+&{StatsUTMSourcesSummary:{Source: Visitors:126 VisitorsPercentage:0.3307} BounceRate:0.5363 Duration:4723}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:115 VisitorsPercentage:0.3018} BounceRate:0.5363 Duration:4732}
 
 ---
 
 [TestGetWebsiteUTMSources/UTMCampaign - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:49 VisitorsPercentage:0.4224} Bounces:12 Duration:3851}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:35 VisitorsPercentage:0.3017} Bounces:5 Duration:6888}
-&{StatsUTMSourcesSummary:{Source: Visitors:32 VisitorsPercentage:0.2759} Bounces:14 Duration:3696}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:49 VisitorsPercentage:0.4224} BounceRate:0.5439 Duration:3851}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:35 VisitorsPercentage:0.3017} BounceRate:0.5439 Duration:6888}
+&{StatsUTMSourcesSummary:{Source: Visitors:32 VisitorsPercentage:0.2759} BounceRate:0.5439 Duration:3696}
 
 ---
 
 [TestGetWebsiteUTMSources/UTMMedium - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:17 VisitorsPercentage:0.4857} Bounces:3 Duration:3389}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:10 VisitorsPercentage:0.2857} Bounces:0 Duration:9728}
-&{StatsUTMSourcesSummary:{Source: Visitors:8 VisitorsPercentage:0.2286} Bounces:3 Duration:3102}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:17 VisitorsPercentage:0.4857} BounceRate:0.4615 Duration:3389}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:10 VisitorsPercentage:0.2857} BounceRate:0.4615 Duration:9728}
+&{StatsUTMSourcesSummary:{Source: Visitors:8 VisitorsPercentage:0.2286} BounceRate:0.4615 Duration:3102}
 
 ---
 
 [TestGetWebsiteUTMSources/UTMSource - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:17 VisitorsPercentage:1} Bounces:3 Duration:3389}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
 
 ---
 

--- a/core/db/duckdb/__snapshots__/utm_test.snap
+++ b/core/db/duckdb/__snapshots__/utm_test.snap
@@ -1,33 +1,33 @@
 
 [TestGetWebsiteUTMCampaigns/Base - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:166923 VisitorsPercentage:0.3341} BounceRate:0.4996 Duration:5000}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:166654 VisitorsPercentage:0.3335} BounceRate:0.4996 Duration:5002}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:166080 VisitorsPercentage:0.3324} BounceRate:0.4996 Duration:5007}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:166923 VisitorsPercentage:0.3341} BounceRate:0.4893 Duration:5000}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:166654 VisitorsPercentage:0.3335} BounceRate:0.4908 Duration:5002}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:166080 VisitorsPercentage:0.3324} BounceRate:0.4884 Duration:5007}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Browser - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:55517 VisitorsPercentage:0.3343} BounceRate:0.5009 Duration:4977}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:55310 VisitorsPercentage:0.333} BounceRate:0.5009 Duration:4992}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:55263 VisitorsPercentage:0.3327} BounceRate:0.5009 Duration:4970}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:55517 VisitorsPercentage:0.3343} BounceRate:0.49 Duration:4977}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:55310 VisitorsPercentage:0.333} BounceRate:0.4911 Duration:4992}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:55263 VisitorsPercentage:0.3327} BounceRate:0.4921 Duration:4970}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Country - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:18468 VisitorsPercentage:0.3343} BounceRate:0.4978 Duration:5002}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:18406 VisitorsPercentage:0.3332} BounceRate:0.4978 Duration:5017}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:18369 VisitorsPercentage:0.3325} BounceRate:0.4978 Duration:4958}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:18468 VisitorsPercentage:0.3343} BounceRate:0.4885 Duration:5002}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:18406 VisitorsPercentage:0.3332} BounceRate:0.4877 Duration:5017}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:18369 VisitorsPercentage:0.3325} BounceRate:0.4898 Duration:4958}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Device - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:6260 VisitorsPercentage:0.3355} BounceRate:0.4947 Duration:5040}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:6228 VisitorsPercentage:0.3337} BounceRate:0.4947 Duration:4970}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:6173 VisitorsPercentage:0.3308} BounceRate:0.4947 Duration:4982}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:6260 VisitorsPercentage:0.3355} BounceRate:0.4798 Duration:5040}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:6228 VisitorsPercentage:0.3337} BounceRate:0.4924 Duration:4970}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:6173 VisitorsPercentage:0.3308} BounceRate:0.4836 Duration:4982}
 
 ---
 
@@ -38,33 +38,33 @@ RECORDS:
 
 [TestGetWebsiteUTMCampaigns/Language - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:3215 VisitorsPercentage:0.3389} BounceRate:0.4931 Duration:4972}
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:3150 VisitorsPercentage:0.3321} BounceRate:0.4931 Duration:5105}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:3121 VisitorsPercentage:0.329} BounceRate:0.4931 Duration:4872}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:3215 VisitorsPercentage:0.3389} BounceRate:0.4942 Duration:4972}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:3150 VisitorsPercentage:0.3321} BounceRate:0.4613 Duration:5105}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:3121 VisitorsPercentage:0.329} BounceRate:0.4917 Duration:4872}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/OS - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:1068 VisitorsPercentage:0.3427} BounceRate:0.5 Duration:4997}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:1043 VisitorsPercentage:0.3347} BounceRate:0.5 Duration:5131}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:1005 VisitorsPercentage:0.3225} BounceRate:0.5 Duration:4736}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:1068 VisitorsPercentage:0.3427} BounceRate:0.4826 Duration:4997}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:1043 VisitorsPercentage:0.3347} BounceRate:0.4746 Duration:5131}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:1005 VisitorsPercentage:0.3225} BounceRate:0.5126 Duration:4736}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Pathname - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:369 VisitorsPercentage:0.3385} BounceRate:0.4945 Duration:4948}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:361 VisitorsPercentage:0.3312} BounceRate:0.4945 Duration:5038}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:360 VisitorsPercentage:0.3303} BounceRate:0.4945 Duration:5509}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:369 VisitorsPercentage:0.3385} BounceRate:0.526 Duration:4948}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:361 VisitorsPercentage:0.3312} BounceRate:0.4716 Duration:5038}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:360 VisitorsPercentage:0.3303} BounceRate:0.4611 Duration:5509}
 
 ---
 
 [TestGetWebsiteUTMCampaigns/Referrer - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:141 VisitorsPercentage:0.3701} BounceRate:0.5363 Duration:4761}
-&{StatsUTMCampaignsSummary:{Campaign: Visitors:124 VisitorsPercentage:0.3255} BounceRate:0.5363 Duration:4700}
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:116 VisitorsPercentage:0.3045} BounceRate:0.5363 Duration:4732}
+&{StatsUTMCampaignsSummary:{Campaign:winter Visitors:141 VisitorsPercentage:0.3701} BounceRate:0.5588 Duration:4761}
+&{StatsUTMCampaignsSummary:{Campaign: Visitors:124 VisitorsPercentage:0.3255} BounceRate:0.4444 Duration:4700}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:116 VisitorsPercentage:0.3045} BounceRate:0.5439 Duration:4732}
 
 ---
 
@@ -82,7 +82,7 @@ RECORDS:
 
 [TestGetWebsiteUTMCampaigns/UTMSource - 1]
 RECORDS:
-&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
+&{StatsUTMCampaignsSummary:{Campaign:summer Visitors:17 VisitorsPercentage:1} BounceRate:0 Duration:3389}
 
 ---
 
@@ -175,33 +175,33 @@ RECORDS:
 
 [TestGetWebsiteUTMMediums/Base - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:167067 VisitorsPercentage:0.3344} BounceRate:0.4996 Duration:5008}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:166355 VisitorsPercentage:0.3329} BounceRate:0.4996 Duration:5004}
-&{StatsUTMMediumsSummary:{Medium: Visitors:166235 VisitorsPercentage:0.3327} BounceRate:0.4996 Duration:4995}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:167067 VisitorsPercentage:0.3344} BounceRate:0.4891 Duration:5008}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:166355 VisitorsPercentage:0.3329} BounceRate:0.4887 Duration:5004}
+&{StatsUTMMediumsSummary:{Medium: Visitors:166235 VisitorsPercentage:0.3327} BounceRate:0.4907 Duration:4995}
 
 ---
 
 [TestGetWebsiteUTMMediums/Browser - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:55415 VisitorsPercentage:0.3336} BounceRate:0.5009 Duration:4992}
-&{StatsUTMMediumsSummary:{Medium: Visitors:55402 VisitorsPercentage:0.3336} BounceRate:0.5009 Duration:4976}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:55273 VisitorsPercentage:0.3328} BounceRate:0.5009 Duration:4973}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:55415 VisitorsPercentage:0.3336} BounceRate:0.489 Duration:4992}
+&{StatsUTMMediumsSummary:{Medium: Visitors:55402 VisitorsPercentage:0.3336} BounceRate:0.4924 Duration:4976}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:55273 VisitorsPercentage:0.3328} BounceRate:0.4917 Duration:4973}
 
 ---
 
 [TestGetWebsiteUTMMediums/Country - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:18538 VisitorsPercentage:0.3356} BounceRate:0.4978 Duration:5006}
-&{StatsUTMMediumsSummary:{Medium: Visitors:18528 VisitorsPercentage:0.3354} BounceRate:0.4978 Duration:4995}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:18177 VisitorsPercentage:0.329} BounceRate:0.4978 Duration:4977}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:18538 VisitorsPercentage:0.3356} BounceRate:0.4884 Duration:5006}
+&{StatsUTMMediumsSummary:{Medium: Visitors:18528 VisitorsPercentage:0.3354} BounceRate:0.487 Duration:4995}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:18177 VisitorsPercentage:0.329} BounceRate:0.4906 Duration:4977}
 
 ---
 
 [TestGetWebsiteUTMMediums/Device - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:6299 VisitorsPercentage:0.3375} BounceRate:0.4947 Duration:5036}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:6293 VisitorsPercentage:0.3372} BounceRate:0.4947 Duration:4916}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:6069 VisitorsPercentage:0.3252} BounceRate:0.4947 Duration:5028}
+&{StatsUTMMediumsSummary:{Medium: Visitors:6299 VisitorsPercentage:0.3375} BounceRate:0.4766 Duration:5036}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:6293 VisitorsPercentage:0.3372} BounceRate:0.4976 Duration:4916}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:6069 VisitorsPercentage:0.3252} BounceRate:0.4815 Duration:5028}
 
 ---
 
@@ -212,41 +212,41 @@ RECORDS:
 
 [TestGetWebsiteUTMMediums/Language - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:3216 VisitorsPercentage:0.339} BounceRate:0.4931 Duration:5126}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:3193 VisitorsPercentage:0.3366} BounceRate:0.4931 Duration:4909}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:3077 VisitorsPercentage:0.3244} BounceRate:0.4931 Duration:4968}
+&{StatsUTMMediumsSummary:{Medium: Visitors:3216 VisitorsPercentage:0.339} BounceRate:0.4596 Duration:5126}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:3193 VisitorsPercentage:0.3366} BounceRate:0.4984 Duration:4909}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:3077 VisitorsPercentage:0.3244} BounceRate:0.4906 Duration:4968}
 
 ---
 
 [TestGetWebsiteUTMMediums/OS - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:1052 VisitorsPercentage:0.3376} BounceRate:0.5 Duration:4848}
-&{StatsUTMMediumsSummary:{Medium: Visitors:1043 VisitorsPercentage:0.3347} BounceRate:0.5 Duration:5072}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:1021 VisitorsPercentage:0.3277} BounceRate:0.5 Duration:4970}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:1052 VisitorsPercentage:0.3376} BounceRate:0.5066 Duration:4848}
+&{StatsUTMMediumsSummary:{Medium: Visitors:1043 VisitorsPercentage:0.3347} BounceRate:0.4585 Duration:5072}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:1021 VisitorsPercentage:0.3277} BounceRate:0.5049 Duration:4970}
 
 ---
 
 [TestGetWebsiteUTMMediums/Pathname - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium: Visitors:384 VisitorsPercentage:0.3523} BounceRate:0.4945 Duration:4950}
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:364 VisitorsPercentage:0.3339} BounceRate:0.4945 Duration:4826}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:342 VisitorsPercentage:0.3138} BounceRate:0.4945 Duration:5556}
+&{StatsUTMMediumsSummary:{Medium: Visitors:384 VisitorsPercentage:0.3523} BounceRate:0.4619 Duration:4950}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:364 VisitorsPercentage:0.3339} BounceRate:0.541 Duration:4826}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:342 VisitorsPercentage:0.3138} BounceRate:0.4506 Duration:5556}
 
 ---
 
 [TestGetWebsiteUTMMediums/Referrer - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:132 VisitorsPercentage:0.3465} BounceRate:0.5363 Duration:4180}
-&{StatsUTMMediumsSummary:{Medium: Visitors:131 VisitorsPercentage:0.3438} BounceRate:0.5363 Duration:4812}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:118 VisitorsPercentage:0.3097} BounceRate:0.5363 Duration:5558}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:132 VisitorsPercentage:0.3465} BounceRate:0.6094 Duration:4180}
+&{StatsUTMMediumsSummary:{Medium: Visitors:131 VisitorsPercentage:0.3438} BounceRate:0.5 Duration:4812}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:118 VisitorsPercentage:0.3097} BounceRate:0.4286 Duration:5558}
 
 ---
 
 [TestGetWebsiteUTMMediums/UTMCampaign - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:cpc Visitors:42 VisitorsPercentage:0.3621} BounceRate:0.5439 Duration:4395}
-&{StatsUTMMediumsSummary:{Medium: Visitors:39 VisitorsPercentage:0.3362} BounceRate:0.5439 Duration:5240}
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:35 VisitorsPercentage:0.3017} BounceRate:0.5439 Duration:6547}
+&{StatsUTMMediumsSummary:{Medium:cpc Visitors:42 VisitorsPercentage:0.3621} BounceRate:0.6154 Duration:4395}
+&{StatsUTMMediumsSummary:{Medium: Visitors:39 VisitorsPercentage:0.3362} BounceRate:0.5 Duration:5240}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:35 VisitorsPercentage:0.3017} BounceRate:0.4615 Duration:6547}
 
 ---
 
@@ -258,7 +258,7 @@ RECORDS:
 
 [TestGetWebsiteUTMMediums/UTMSource - 1]
 RECORDS:
-&{StatsUTMMediumsSummary:{Medium:organic Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
+&{StatsUTMMediumsSummary:{Medium:organic Visitors:17 VisitorsPercentage:1} BounceRate:0 Duration:3389}
 
 ---
 
@@ -353,33 +353,33 @@ RECORDS:
 
 [TestGetWebsiteUTMSources/Base - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:166720 VisitorsPercentage:0.3337} BounceRate:0.4996 Duration:5006}
-&{StatsUTMSourcesSummary:{Source:bing Visitors:166575 VisitorsPercentage:0.3334} BounceRate:0.4996 Duration:4990}
-&{StatsUTMSourcesSummary:{Source: Visitors:166362 VisitorsPercentage:0.333} BounceRate:0.4996 Duration:5013}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:166720 VisitorsPercentage:0.3337} BounceRate:0.4873 Duration:5006}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:166575 VisitorsPercentage:0.3334} BounceRate:0.4926 Duration:4990}
+&{StatsUTMSourcesSummary:{Source: Visitors:166362 VisitorsPercentage:0.333} BounceRate:0.4886 Duration:5013}
 
 ---
 
 [TestGetWebsiteUTMSources/Browser - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:55742 VisitorsPercentage:0.3356} BounceRate:0.5009 Duration:4976}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:55251 VisitorsPercentage:0.3327} BounceRate:0.5009 Duration:4978}
-&{StatsUTMSourcesSummary:{Source: Visitors:55097 VisitorsPercentage:0.3317} BounceRate:0.5009 Duration:4989}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:55742 VisitorsPercentage:0.3356} BounceRate:0.4928 Duration:4976}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:55251 VisitorsPercentage:0.3327} BounceRate:0.491 Duration:4978}
+&{StatsUTMSourcesSummary:{Source: Visitors:55097 VisitorsPercentage:0.3317} BounceRate:0.4893 Duration:4989}
 
 ---
 
 [TestGetWebsiteUTMSources/Country - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:18552 VisitorsPercentage:0.3358} BounceRate:0.4978 Duration:4993}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:18490 VisitorsPercentage:0.3347} BounceRate:0.4978 Duration:5014}
-&{StatsUTMSourcesSummary:{Source: Visitors:18201 VisitorsPercentage:0.3295} BounceRate:0.4978 Duration:4965}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:18552 VisitorsPercentage:0.3358} BounceRate:0.4892 Duration:4993}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:18490 VisitorsPercentage:0.3347} BounceRate:0.4888 Duration:5014}
+&{StatsUTMSourcesSummary:{Source: Visitors:18201 VisitorsPercentage:0.3295} BounceRate:0.488 Duration:4965}
 
 ---
 
 [TestGetWebsiteUTMSources/Device - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:6267 VisitorsPercentage:0.3358} BounceRate:0.4947 Duration:5044}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:6213 VisitorsPercentage:0.3329} BounceRate:0.4947 Duration:5031}
-&{StatsUTMSourcesSummary:{Source: Visitors:6181 VisitorsPercentage:0.3312} BounceRate:0.4947 Duration:4915}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:6267 VisitorsPercentage:0.3358} BounceRate:0.4806 Duration:5044}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:6213 VisitorsPercentage:0.3329} BounceRate:0.483 Duration:5031}
+&{StatsUTMSourcesSummary:{Source: Visitors:6181 VisitorsPercentage:0.3312} BounceRate:0.4922 Duration:4915}
 
 ---
 
@@ -390,55 +390,55 @@ RECORDS:
 
 [TestGetWebsiteUTMSources/Language - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:3206 VisitorsPercentage:0.338} BounceRate:0.4931 Duration:5120}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:3190 VisitorsPercentage:0.3363} BounceRate:0.4931 Duration:5028}
-&{StatsUTMSourcesSummary:{Source: Visitors:3090 VisitorsPercentage:0.3257} BounceRate:0.4931 Duration:4835}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:3206 VisitorsPercentage:0.338} BounceRate:0.4767 Duration:5120}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:3190 VisitorsPercentage:0.3363} BounceRate:0.4764 Duration:5028}
+&{StatsUTMSourcesSummary:{Source: Visitors:3090 VisitorsPercentage:0.3257} BounceRate:0.4948 Duration:4835}
 
 ---
 
 [TestGetWebsiteUTMSources/OS - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:1064 VisitorsPercentage:0.3415} BounceRate:0.5 Duration:5071}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:1034 VisitorsPercentage:0.3318} BounceRate:0.5 Duration:4861}
-&{StatsUTMSourcesSummary:{Source: Visitors:1018 VisitorsPercentage:0.3267} BounceRate:0.5 Duration:4954}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:1064 VisitorsPercentage:0.3415} BounceRate:0.4839 Duration:5071}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:1034 VisitorsPercentage:0.3318} BounceRate:0.4962 Duration:4861}
+&{StatsUTMSourcesSummary:{Source: Visitors:1018 VisitorsPercentage:0.3267} BounceRate:0.4892 Duration:4954}
 
 ---
 
 [TestGetWebsiteUTMSources/Pathname - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:381 VisitorsPercentage:0.3495} BounceRate:0.4945 Duration:5441}
-&{StatsUTMSourcesSummary:{Source: Visitors:365 VisitorsPercentage:0.3349} BounceRate:0.4945 Duration:5028}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:344 VisitorsPercentage:0.3156} BounceRate:0.4945 Duration:4985}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:381 VisitorsPercentage:0.3495} BounceRate:0.4497 Duration:5441}
+&{StatsUTMSourcesSummary:{Source: Visitors:365 VisitorsPercentage:0.3349} BounceRate:0.5026 Duration:5028}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:344 VisitorsPercentage:0.3156} BounceRate:0.5061 Duration:4985}
 
 ---
 
 [TestGetWebsiteUTMSources/Referrer - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:140 VisitorsPercentage:0.3675} BounceRate:0.5363 Duration:4694}
-&{StatsUTMSourcesSummary:{Source: Visitors:126 VisitorsPercentage:0.3307} BounceRate:0.5363 Duration:4723}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:115 VisitorsPercentage:0.3018} BounceRate:0.5363 Duration:4732}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:140 VisitorsPercentage:0.3675} BounceRate:0.4918 Duration:4694}
+&{StatsUTMSourcesSummary:{Source: Visitors:126 VisitorsPercentage:0.3307} BounceRate:0.5606 Duration:4723}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:115 VisitorsPercentage:0.3018} BounceRate:0.5 Duration:4732}
 
 ---
 
 [TestGetWebsiteUTMSources/UTMCampaign - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:49 VisitorsPercentage:0.4224} BounceRate:0.5439 Duration:3851}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:35 VisitorsPercentage:0.3017} BounceRate:0.5439 Duration:6888}
-&{StatsUTMSourcesSummary:{Source: Visitors:32 VisitorsPercentage:0.2759} BounceRate:0.5439 Duration:3696}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:49 VisitorsPercentage:0.4224} BounceRate:0.6667 Duration:3851}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:35 VisitorsPercentage:0.3017} BounceRate:0.2941 Duration:6888}
+&{StatsUTMSourcesSummary:{Source: Visitors:32 VisitorsPercentage:0.2759} BounceRate:0.6364 Duration:3696}
 
 ---
 
 [TestGetWebsiteUTMSources/UTMMedium - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:17 VisitorsPercentage:0.4857} BounceRate:0.4615 Duration:3389}
-&{StatsUTMSourcesSummary:{Source:twitter Visitors:10 VisitorsPercentage:0.2857} BounceRate:0.4615 Duration:9728}
-&{StatsUTMSourcesSummary:{Source: Visitors:8 VisitorsPercentage:0.2286} BounceRate:0.4615 Duration:3102}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:17 VisitorsPercentage:0.4857} BounceRate:0 Duration:3389}
+&{StatsUTMSourcesSummary:{Source:twitter Visitors:10 VisitorsPercentage:0.2857} BounceRate:0 Duration:9728}
+&{StatsUTMSourcesSummary:{Source: Visitors:8 VisitorsPercentage:0.2286} BounceRate:0 Duration:3102}
 
 ---
 
 [TestGetWebsiteUTMSources/UTMSource - 1]
 RECORDS:
-&{StatsUTMSourcesSummary:{Source:bing Visitors:17 VisitorsPercentage:1} BounceRate:0.6 Duration:3389}
+&{StatsUTMSourcesSummary:{Source:bing Visitors:17 VisitorsPercentage:1} BounceRate:0 Duration:3389}
 
 ---
 

--- a/core/db/duckdb/common.go
+++ b/core/db/duckdb/common.go
@@ -11,17 +11,32 @@ const (
 	VisitorsPercentageStmt = "ifnull(ROUND(visitors / (SELECT total_visitors FROM total), 4), 0) AS visitors_percentage"
 	// PageviewsStmt is the number of pageviews for the query.
 	PageviewsStmt = "COUNT(*) AS pageviews"
-	// BouncesStmt is the number of bounces for the query.
-	BouncesStmt = "COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms < 5000) AS bounces"
 	// DurationStmt is the median duration of the visits.
 	DurationStmt = "CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration"
+	// BouncePercentageStmt is the bounce rate of the visits.
+	// This expects a CTE named bounces with a bounce_rate column to be present.
+	BounceRateStmt = "(SELECT bounce_rate FROM bounces) AS bounce_rate"
 )
 
 // TotalVisitorsCTE declares a materialized CTE to calculate the total number of unique visitors.
-func TotalVisitorsCTE(whereClause string) *qb.QueryBuilder {
-	return qb.New().WithMaterialized("total", qb.New().
+func TotalVisitorsCTE(whereClause string) qb.CTE {
+	return qb.NewCTE("total", qb.New().
 		Select("COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors").
 		From("views").
-		Where(whereClause),
-	)
+		Where(whereClause))
+}
+
+// BounceRateCTE declares a materialized CTE to calculate the bounce rate.
+func BounceRateCTE(whereClause string) qb.CTE {
+	return qb.NewCTE("bounces", qb.New().
+		Select(
+			"COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms BETWEEN 1 AND 5000) AS count",
+			// Slightly modified to ONLY include visitors that have a duration_ms to
+			// represent bounce rates more fairly.
+			"COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms IS NOT NULL) AS total_visitors",
+			// The bounce rate is calculated as bounces / total_bounce_visitors.
+			"ifnull(ROUND(count / total_visitors, 4), 0) AS bounce_rate",
+		).
+		From("views").
+		Where(whereClause))
 }

--- a/core/db/duckdb/common.go
+++ b/core/db/duckdb/common.go
@@ -14,29 +14,20 @@ const (
 	// DurationStmt is the median duration of the visits.
 	DurationStmt = "CAST(ifnull(median(duration_ms), 0) AS INTEGER) AS duration"
 	// BouncePercentageStmt is the bounce rate of the visits.
-	// This expects a CTE named bounces with a bounce_rate column to be present.
-	BounceRateStmt = "(SELECT bounce_rate FROM bounces) AS bounce_rate"
+	// The bounce rate is calculated as bounce count / total unique visitors that have a duration_ms.
+	BounceRateStmt = `--sql
+		CASE WHEN COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms IS NOT NULL) > 5 THEN
+		ifnull(ROUND(
+            COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms BETWEEN 100 AND 5000) * 1.0 /
+            NULLIF(COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms IS NOT NULL), 0)
+        , 4), 0)
+		ELSE 0 END AS bounce_rate`
 )
 
 // TotalVisitorsCTE declares a materialized CTE to calculate the total number of unique visitors.
 func TotalVisitorsCTE(whereClause string) qb.CTE {
 	return qb.NewCTE("total", qb.New().
 		Select("COUNT(*) FILTER (WHERE is_unique_user = true) AS total_visitors").
-		From("views").
-		Where(whereClause))
-}
-
-// BounceRateCTE declares a materialized CTE to calculate the bounce rate.
-func BounceRateCTE(whereClause string) qb.CTE {
-	return qb.NewCTE("bounces", qb.New().
-		Select(
-			"COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms BETWEEN 1 AND 5000) AS count",
-			// Slightly modified to ONLY include visitors that have a duration_ms to
-			// represent bounce rates more fairly.
-			"COUNT(*) FILTER (WHERE is_unique_user = true AND duration_ms IS NOT NULL) AS total_visitors",
-			// The bounce rate is calculated as bounces / total_bounce_visitors.
-			"ifnull(ROUND(count / total_visitors, 4), 0) AS bounce_rate",
-		).
 		From("views").
 		Where(whereClause))
 }

--- a/core/db/duckdb/locale.go
+++ b/core/db/duckdb/locale.go
@@ -64,7 +64,6 @@ func (c *Client) GetWebsiteCountries(ctx context.Context, filter *db.Filters) ([
 	// VisitorsPercentage is the percentage the country contributes to the total unique visits.
 	query := qb.New().
 		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
-		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"country",
 			VisitorsStmt,
@@ -161,7 +160,6 @@ func (c *Client) GetWebsiteLanguages(ctx context.Context, isLocale bool, filter 
 	// VisitorsPercentage is the percentage the language contributes to the total unique visitors.
 	query := qb.New().
 		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
-		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			languageSelect,
 			VisitorsStmt,

--- a/core/db/duckdb/locale.go
+++ b/core/db/duckdb/locale.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-faster/errors"
 	"github.com/medama-io/medama/db"
+	qb "github.com/medama-io/medama/db/duckdb/query"
 	"github.com/medama-io/medama/model"
 )
 
@@ -19,7 +20,8 @@ func (c *Client) GetWebsiteCountriesSummary(ctx context.Context, filter *db.Filt
 	// Visitors is the number of unique visitors from the country.
 	//
 	// VisitorsPercentage is the percentage the country contributes to the total unique visits.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
 		Select(
 			"country",
 			VisitorsStmt,
@@ -60,12 +62,14 @@ func (c *Client) GetWebsiteCountries(ctx context.Context, filter *db.Filters) ([
 	// Visitors is the number of unique visitors from the country.
 	//
 	// VisitorsPercentage is the percentage the country contributes to the total unique visits.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
+		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"country",
 			VisitorsStmt,
 			VisitorsPercentageStmt,
-			BouncesStmt,
+			BounceRateStmt,
 			DurationStmt,
 		).
 		From("views").
@@ -108,7 +112,8 @@ func (c *Client) GetWebsiteLanguagesSummary(ctx context.Context, isLocale bool, 
 	// Visitors is the number of unique visitors for the language.
 	//
 	// VisitorsPercentage is the percentage the language contributes to the total unique visitors.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
 		Select(
 			languageSelect,
 			VisitorsStmt,
@@ -154,12 +159,14 @@ func (c *Client) GetWebsiteLanguages(ctx context.Context, isLocale bool, filter 
 	// Visitors is the number of unique visitors for the language.
 	//
 	// VisitorsPercentage is the percentage the language contributes to the total unique visitors.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
+		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			languageSelect,
 			VisitorsStmt,
 			VisitorsPercentageStmt,
-			BouncesStmt,
+			BounceRateStmt,
 			DurationStmt,
 		).
 		From("views").

--- a/core/db/duckdb/pages.go
+++ b/core/db/duckdb/pages.go
@@ -100,7 +100,6 @@ func (c *Client) GetWebsitePages(ctx context.Context, filter *db.Filters) ([]*mo
 	// This is ordered by the number of unique visitors in descending order.
 	query := qb.New().
 		WithMaterialized(totalPageviewsCTE(filter.WhereString())).
-		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"pathname",
 			// Different from VisitorsStmt due to is_unique_page

--- a/core/db/duckdb/query/qb.go
+++ b/core/db/duckdb/query/qb.go
@@ -21,12 +21,19 @@ type QueryBuilder struct {
 	paginationClause string
 }
 
+func NewCTE(name string, subquery *QueryBuilder) CTE {
+	return CTE{
+		Name:     name,
+		Subquery: subquery,
+	}
+}
+
 func New() *QueryBuilder {
 	return &QueryBuilder{}
 }
 
-func (qb *QueryBuilder) WithMaterialized(name string, subquery *QueryBuilder) *QueryBuilder {
-	qb.cteClauses = append(qb.cteClauses, CTE{Name: name, Subquery: subquery})
+func (qb *QueryBuilder) WithMaterialized(cte CTE) *QueryBuilder {
+	qb.cteClauses = append(qb.cteClauses, cte)
 	return qb
 }
 

--- a/core/db/duckdb/referrers.go
+++ b/core/db/duckdb/referrers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-faster/errors"
 	"github.com/medama-io/medama/db"
+	qb "github.com/medama-io/medama/db/duckdb/query"
 	"github.com/medama-io/medama/model"
 )
 
@@ -25,7 +26,8 @@ func (c *Client) GetWebsiteReferrersSummary(ctx context.Context, isGroup bool, f
 	// Visitors is the number of unique visitors for the referrer.
 	//
 	// VisitorsPercentage is the percentage the referrer contributes to the total visitors.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
 		Select(
 			referrerStmt,
 			VisitorsStmt,
@@ -76,12 +78,14 @@ func (c *Client) GetWebsiteReferrers(ctx context.Context, isGroup bool, filter *
 	// Bounces is the number of bounces for the referrer.
 	//
 	// Duration is the median duration the user spent on the page in milliseconds.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
+		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			referrerStmt,
 			VisitorsStmt,
 			VisitorsPercentageStmt,
-			BouncesStmt,
+			BounceRateStmt,
 			DurationStmt,
 		).
 		From("views").

--- a/core/db/duckdb/referrers.go
+++ b/core/db/duckdb/referrers.go
@@ -80,7 +80,6 @@ func (c *Client) GetWebsiteReferrers(ctx context.Context, isGroup bool, filter *
 	// Duration is the median duration the user spent on the page in milliseconds.
 	query := qb.New().
 		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
-		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			referrerStmt,
 			VisitorsStmt,

--- a/core/db/duckdb/summary.go
+++ b/core/db/duckdb/summary.go
@@ -27,7 +27,6 @@ func (c *Client) GetWebsiteSummary(ctx context.Context, filter *db.Filters) (*mo
 	//
 	// Active is the number of unique visitors that have visited the website in the last 5 minutes.
 	query := qb.New().
-		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			VisitorsStmt,
 			PageviewsStmt,
@@ -86,7 +85,6 @@ func (c *Client) GetWebsiteIntervals(ctx context.Context, filter *db.Filters, in
 		).
 		WithMaterialized(
 			qb.NewCTE("stats", qb.New().
-				WithMaterialized(BounceRateCTE(filter.WhereString())).
 				Select(
 					"time_bucket(CAST(:interval_query AS INTERVAL), date_created, CAST(:start_period AS TIMESTAMPTZ)) AS interval",
 					VisitorsStmt,

--- a/core/db/duckdb/summary_test.go
+++ b/core/db/duckdb/summary_test.go
@@ -31,7 +31,7 @@ func TestGetWebsiteSummaryEmpty(t *testing.T) {
 
 	assert.Equal(0, summary.Visitors)
 	assert.Equal(0, summary.Pageviews)
-	assert.Equal(0, summary.Bounces)
+	assert.Equal(float32(0), summary.BounceRate)
 	assert.Equal(0, summary.Duration)
 }
 

--- a/core/db/duckdb/types.go
+++ b/core/db/duckdb/types.go
@@ -67,7 +67,6 @@ func (c *Client) GetWebsiteBrowsers(ctx context.Context, filter *db.Filters) ([]
 	// Duration is the median duration of the page.
 	query := qb.New().
 		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
-		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"ua_browser AS browser",
 			VisitorsStmt,
@@ -153,7 +152,6 @@ func (c *Client) GetWebsiteOS(ctx context.Context, filter *db.Filters) ([]*model
 	// VisitorsPercentage is the percentage the operating contributes to the total visitors.
 	query := qb.New().
 		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
-		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"ua_os AS os",
 			VisitorsStmt,
@@ -239,7 +237,6 @@ func (c *Client) GetWebsiteDevices(ctx context.Context, filter *db.Filters) ([]*
 	// VisitorsPercentage is the percentage the device contributes to the total visitors.
 	query := qb.New().
 		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
-		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"ua_device_type AS device",
 			VisitorsStmt,

--- a/core/db/duckdb/types.go
+++ b/core/db/duckdb/types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-faster/errors"
 	"github.com/medama-io/medama/db"
+	qb "github.com/medama-io/medama/db/duckdb/query"
 	"github.com/medama-io/medama/model"
 )
 
@@ -19,7 +20,8 @@ func (c *Client) GetWebsiteBrowsersSummary(ctx context.Context, filter *db.Filte
 	// Visitors is the number of unique visitors for the browser.
 	//
 	// VisitorsPercentage is the percentage the browser contributes to the total visitors.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
 		Select(
 			"ua_browser AS browser",
 			VisitorsStmt,
@@ -63,12 +65,14 @@ func (c *Client) GetWebsiteBrowsers(ctx context.Context, filter *db.Filters) ([]
 	// Bounces is the number of unique visitors that match the pathname and have a duration of less than 5 seconds.
 	//
 	// Duration is the median duration of the page.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
+		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"ua_browser AS browser",
 			VisitorsStmt,
 			VisitorsPercentageStmt,
-			BouncesStmt,
+			BounceRateStmt,
 			DurationStmt,
 		).
 		From("views").
@@ -105,7 +109,8 @@ func (c *Client) GetWebsiteOSSummary(ctx context.Context, filter *db.Filters) ([
 	// Visitors is the number of unique visitors for the operating system.
 	//
 	// VisitorsPercentage is the percentage the operating contributes to the total visitors.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
 		Select(
 			"ua_os AS os",
 			VisitorsStmt,
@@ -146,12 +151,14 @@ func (c *Client) GetWebsiteOS(ctx context.Context, filter *db.Filters) ([]*model
 	// Visitors is the number of unique visitors for the operating system.
 	//
 	// VisitorsPercentage is the percentage the operating contributes to the total visitors.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
+		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"ua_os AS os",
 			VisitorsStmt,
 			VisitorsPercentageStmt,
-			BouncesStmt,
+			BounceRateStmt,
 			DurationStmt,
 		).
 		From("views").
@@ -188,7 +195,8 @@ func (c *Client) GetWebsiteDevicesSummary(ctx context.Context, filter *db.Filter
 	// Visitors is the number of unique visitors for the device.
 	//
 	// VisitorsPercentage is the percentage the device contributes to the total visitors.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
 		Select(
 			"ua_device_type AS device",
 			VisitorsStmt,
@@ -229,12 +237,14 @@ func (c *Client) GetWebsiteDevices(ctx context.Context, filter *db.Filters) ([]*
 	// Visitors is the number of unique visitors for the device.
 	//
 	// VisitorsPercentage is the percentage the device contributes to the total visitors.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
+		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"ua_device_type AS device",
 			VisitorsStmt,
 			VisitorsPercentageStmt,
-			BouncesStmt,
+			BounceRateStmt,
 			DurationStmt,
 		).
 		From("views").

--- a/core/db/duckdb/utm.go
+++ b/core/db/duckdb/utm.go
@@ -67,7 +67,6 @@ func (c *Client) GetWebsiteUTMSources(ctx context.Context, filter *db.Filters) (
 	// Duration is the median duration of the unique visitors for the utm source.
 	query := qb.New().
 		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
-		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"utm_source AS source",
 			VisitorsStmt,
@@ -157,7 +156,6 @@ func (c *Client) GetWebsiteUTMMediums(ctx context.Context, filter *db.Filters) (
 	// Duration is the median duration of the unique visitors for the utm medium.
 	query := qb.New().
 		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
-		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"utm_medium AS medium",
 			VisitorsStmt,
@@ -247,7 +245,6 @@ func (c *Client) GetWebsiteUTMCampaigns(ctx context.Context, filter *db.Filters)
 	// Duration is the median duration of the unique visitors for the utm campaign.
 	query := qb.New().
 		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
-		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"utm_campaign AS campaign",
 			VisitorsStmt,

--- a/core/db/duckdb/utm.go
+++ b/core/db/duckdb/utm.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-faster/errors"
 	"github.com/medama-io/medama/db"
+	qb "github.com/medama-io/medama/db/duckdb/query"
 	"github.com/medama-io/medama/model"
 )
 
@@ -18,7 +19,8 @@ func (c *Client) GetWebsiteUTMSourcesSummary(ctx context.Context, filter *db.Fil
 	// Visitors is the number of unique visitors for the utm source.
 	//
 	// VisitorsPercentage is the percentage the utm source contributes to the total unique visitors.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
 		Select(
 			"utm_source AS source",
 			VisitorsStmt,
@@ -63,12 +65,14 @@ func (c *Client) GetWebsiteUTMSources(ctx context.Context, filter *db.Filters) (
 	// Bounces is the number of unique visitors that bounced for the utm source.
 	//
 	// Duration is the median duration of the unique visitors for the utm source.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
+		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"utm_source AS source",
 			VisitorsStmt,
 			VisitorsPercentageStmt,
-			BouncesStmt,
+			BounceRateStmt,
 			DurationStmt,
 		).
 		From("views").
@@ -105,7 +109,8 @@ func (c *Client) GetWebsiteUTMMediumsSummary(ctx context.Context, filter *db.Fil
 	// Visitors is the number of unique visitors for the utm medium.
 	//
 	// VisitorsPercentage is the percentage the utm medium contributes to the total unique visitors.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
 		Select(
 			"utm_medium AS medium",
 			VisitorsStmt,
@@ -150,12 +155,14 @@ func (c *Client) GetWebsiteUTMMediums(ctx context.Context, filter *db.Filters) (
 	// Bounces is the number of unique visitors that bounced for the utm medium.
 	//
 	// Duration is the median duration of the unique visitors for the utm medium.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
+		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"utm_medium AS medium",
 			VisitorsStmt,
 			VisitorsPercentageStmt,
-			BouncesStmt,
+			BounceRateStmt,
 			DurationStmt,
 		).
 		From("views").
@@ -192,7 +199,8 @@ func (c *Client) GetWebsiteUTMCampaignsSummary(ctx context.Context, filter *db.F
 	// Visitors is the number of unique visitors for the utm campaign.
 	//
 	// VisitorsPercentage is the percentage the utm campaign contributes to the total unique visitors.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
 		Select(
 			"utm_campaign AS campaign",
 			VisitorsStmt,
@@ -237,12 +245,14 @@ func (c *Client) GetWebsiteUTMCampaigns(ctx context.Context, filter *db.Filters)
 	// Bounces is the number of unique visitors that bounced for the utm campaign.
 	//
 	// Duration is the median duration of the unique visitors for the utm campaign.
-	query := TotalVisitorsCTE(filter.WhereString()).
+	query := qb.New().
+		WithMaterialized(TotalVisitorsCTE(filter.WhereString())).
+		WithMaterialized(BounceRateCTE(filter.WhereString())).
 		Select(
 			"utm_campaign AS campaign",
 			VisitorsStmt,
 			VisitorsPercentageStmt,
-			BouncesStmt,
+			BounceRateStmt,
 			DurationStmt,
 		).
 		From("views").

--- a/core/model/stats.go
+++ b/core/model/stats.go
@@ -8,10 +8,10 @@ const (
 )
 
 type StatsSummarySingle struct {
-	Visitors  int `db:"visitors"`
-	Pageviews int `db:"pageviews"`
-	Bounces   int `db:"bounces"`
-	Duration  int `db:"duration"`
+	Visitors   int     `db:"visitors"`
+	Pageviews  int     `db:"pageviews"`
+	BounceRate float32 `db:"bounce_rate"`
+	Duration   int     `db:"duration"`
 }
 
 type StatsSummary struct {
@@ -24,11 +24,11 @@ type StatsSummaryLast24Hours struct {
 }
 
 type StatsIntervals struct {
-	Interval  string `db:"interval"`
-	Visitors  int    `db:"visitors"`
-	Pageviews int    `db:"pageviews"`
-	Bounces   int    `db:"bounces"`
-	Duration  int    `db:"duration"`
+	Interval   string  `db:"interval"`
+	Visitors   int     `db:"visitors"`
+	Pageviews  int     `db:"pageviews"`
+	BounceRate float32 `db:"bounce_rate"`
+	Duration   int     `db:"duration"`
 }
 
 type StatsPagesSummary struct {
@@ -41,7 +41,7 @@ type StatsPages struct {
 	StatsPagesSummary
 	Pageviews           int     `db:"pageviews"`
 	PageviewsPercentage float32 `db:"pageviews_percentage"`
-	Bounces             int     `db:"bounces"`
+	BounceRate          float32 `db:"bounce_rate"`
 	Duration            int     `db:"duration"`
 }
 
@@ -67,8 +67,8 @@ type StatsReferrerSummary struct {
 
 type StatsReferrers struct {
 	StatsReferrerSummary
-	Bounces  int `db:"bounces"`
-	Duration int `db:"duration"`
+	BounceRate float32 `db:"bounce_rate"`
+	Duration   int     `db:"duration"`
 }
 
 type StatsUTMSourcesSummary struct {
@@ -79,8 +79,8 @@ type StatsUTMSourcesSummary struct {
 
 type StatsUTMSources struct {
 	StatsUTMSourcesSummary
-	Bounces  int `db:"bounces"`
-	Duration int `db:"duration"`
+	BounceRate float32 `db:"bounce_rate"`
+	Duration   int     `db:"duration"`
 }
 
 type StatsUTMMediumsSummary struct {
@@ -91,8 +91,8 @@ type StatsUTMMediumsSummary struct {
 
 type StatsUTMMediums struct {
 	StatsUTMMediumsSummary
-	Bounces  int `db:"bounces"`
-	Duration int `db:"duration"`
+	BounceRate float32 `db:"bounce_rate"`
+	Duration   int     `db:"duration"`
 }
 
 type StatsUTMCampaignsSummary struct {
@@ -103,8 +103,8 @@ type StatsUTMCampaignsSummary struct {
 
 type StatsUTMCampaigns struct {
 	StatsUTMCampaignsSummary
-	Bounces  int `db:"bounces"`
-	Duration int `db:"duration"`
+	BounceRate float32 `db:"bounce_rate"`
+	Duration   int     `db:"duration"`
 }
 
 type StatsBrowsersSummary struct {
@@ -115,8 +115,8 @@ type StatsBrowsersSummary struct {
 
 type StatsBrowsers struct {
 	StatsBrowsersSummary
-	Bounces  int `db:"bounces"`
-	Duration int `db:"duration"`
+	BounceRate float32 `db:"bounce_rate"`
+	Duration   int     `db:"duration"`
 }
 
 type StatsOSSummary struct {
@@ -127,8 +127,8 @@ type StatsOSSummary struct {
 
 type StatsOS struct {
 	StatsOSSummary
-	Bounces  int `db:"bounces"`
-	Duration int `db:"duration"`
+	BounceRate float32 `db:"bounce_rate"`
+	Duration   int     `db:"duration"`
 }
 
 type StatsDevicesSummary struct {
@@ -139,8 +139,8 @@ type StatsDevicesSummary struct {
 
 type StatsDevices struct {
 	StatsDevicesSummary
-	Bounces  int `db:"bounces"`
-	Duration int `db:"duration"`
+	BounceRate float32 `db:"bounce_rate"`
+	Duration   int     `db:"duration"`
 }
 
 type StatsCountriesSummary struct {
@@ -151,8 +151,8 @@ type StatsCountriesSummary struct {
 
 type StatsCountries struct {
 	StatsCountriesSummary
-	Bounces  int `db:"bounces"`
-	Duration int `db:"duration"`
+	BounceRate float32 `db:"bounce_rate"`
+	Duration   int     `db:"duration"`
 }
 
 type StatsLanguagesSummary struct {
@@ -163,6 +163,6 @@ type StatsLanguagesSummary struct {
 
 type StatsLanguages struct {
 	StatsLanguagesSummary
-	Bounces  int `db:"bounces"`
-	Duration int `db:"duration"`
+	BounceRate float32 `db:"bounce_rate"`
+	Duration   int     `db:"duration"`
 }

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -1612,14 +1612,15 @@ components:
               type: integer
             pageviews:
               type: integer
-            bounces:
-              type: integer
+            bounce_percentage:
+              type: number
+              format: float
             duration:
               type: integer
           required:
             - visitors
             - pageviews
-            - bounces
+            - bounce_percentage
             - duration
         previous:
           type: object
@@ -1628,14 +1629,15 @@ components:
               type: integer
             pageviews:
               type: integer
-            bounces:
-              type: integer
+            bounce_percentage:
+              type: number
+              format: float
             duration:
               type: integer
           required:
             - visitors
             - pageviews
-            - bounces
+            - bounce_percentage
             - duration
         interval:
           type: array
@@ -1648,8 +1650,9 @@ components:
                 type: integer
               pageviews:
                 type: integer
-              bounces:
-                type: integer
+              bounce_percentage:
+                type: number
+                format: float
               duration:
                 type: integer
             required:
@@ -1679,9 +1682,10 @@ components:
             type: number
             description: Percentage of page views.
             format: float
-          bounces:
-            type: integer
-            description: Number of bounces.
+          bounce_percentage:
+            type: number
+            description: Bounce rate percentage.
+            format: float
           duration:
             type: integer
             description: Total time spent on page in milliseconds.
@@ -1734,9 +1738,10 @@ components:
             type: number
             description: Percentage of unique visitors from referrer.
             format: float
-          bounces:
-            type: integer
-            description: Number of bounces from referrer.
+          bounce_percentage:
+            type: number
+            description: Bounce rate percentage from referrer.
+            format: float
           duration:
             type: integer
             description: Total time spent on page from referrer in milliseconds.
@@ -1760,12 +1765,13 @@ components:
             type: number
             description: Percentage of unique visitors from UTM source.
             format: float
-          bounces:
-            type: integer
-            description: Number of bounces from referrer.
+          bounce_percentage:
+            type: number
+            description: Bounce rate percentage from UTM source.
+            format: float
           duration:
             type: integer
-            description: Total time spent on page from referrer in milliseconds.
+            description: Total time spent on page from UTM source in milliseconds.
         required:
           - source
           - visitors
@@ -1786,12 +1792,13 @@ components:
             type: number
             description: Percentage of unique visitors from UTM medium.
             format: float
-          bounces:
-            type: integer
-            description: Number of bounces from referrer.
+          bounce_percentage:
+            type: number
+            description: Bounce rate percentage from UTM medium.
+            format: float
           duration:
             type: integer
-            description: Total time spent on page from referrer in milliseconds.
+            description: Total time spent on page from UTM medium in milliseconds.
         required:
           - medium
           - visitors
@@ -1812,12 +1819,13 @@ components:
             type: number
             description: Percentage of unique visitors from UTM campaign.
             format: float
-          bounces:
-            type: integer
-            description: Number of bounces from referrer.
+          bounce_percentage:
+            type: number
+            description: Bounce rate percentage from UTM campaign.
+            format: float
           duration:
             type: integer
-            description: Total time spent on page from referrer in milliseconds.
+            description: Total time spent on page from UTM campaign in milliseconds.
         required:
           - campaign
           - visitors
@@ -1838,12 +1846,13 @@ components:
             type: number
             description: Percentage of unique visitors from browser.
             format: float
-          bounces:
-            type: integer
-            description: Number of bounces from referrer.
+          bounce_percentage:
+            type: number
+            description: Bounce rate percentage from browser.
+            format: float
           duration:
             type: integer
-            description: Total time spent on page from referrer in milliseconds.
+            description: Total time spent on page from browser in milliseconds.
         required:
           - browser
           - visitors
@@ -1864,12 +1873,13 @@ components:
             type: number
             description: Percentage of unique visitors from OS.
             format: float
-          bounces:
-            type: integer
-            description: Number of bounces from referrer.
+          bounce_percentage:
+            type: number
+            description: Bounce rate percentage from OS.
+            format: float
           duration:
             type: integer
-            description: Total time spent on page from referrer in milliseconds.
+            description: Total time spent on page from OS in milliseconds.
         required:
           - os
           - visitors
@@ -1890,12 +1900,13 @@ components:
             type: number
             description: Percentage of unique visitors from device.
             format: float
-          bounces:
-            type: integer
-            description: Number of bounces from referrer.
+          bounce_percentage:
+            type: number
+            description: Bounce rate percentage from device.
+            format: float
           duration:
             type: integer
-            description: Total time spent on page from referrer in milliseconds.
+            description: Total time spent on page from device in milliseconds.
         required:
           - device
           - visitors
@@ -1916,12 +1927,13 @@ components:
             type: number
             description: Percentage of unique visitors from country.
             format: float
-          bounces:
-            type: integer
-            description: Number of bounces from referrer.
+          bounce_percentage:
+            type: number
+            description: Bounce rate percentage from country.
+            format: float
           duration:
             type: integer
-            description: Total time spent on page from referrer in milliseconds.
+            description: Total time spent on page from country in milliseconds.
         required:
           - country
           - visitors
@@ -1944,12 +1956,13 @@ components:
             type: number
             description: Percentage of unique visitors for language.
             format: float
-          bounces:
-            type: integer
-            description: Number of bounces from referrer.
+          bounce_percentage:
+            type: number
+            description: Bounce rate percentage for language.
+            format: float
           duration:
             type: integer
-            description: Total time spent on page from referrer in milliseconds.
+            description: Total time spent on page from language in milliseconds.
         required:
           - language
           - visitors

--- a/core/services/stats.go
+++ b/core/services/stats.go
@@ -51,10 +51,10 @@ func (h *Handler) GetWebsiteIDSummary(ctx context.Context, params api.GetWebsite
 
 	resp := &api.StatsSummary{
 		Current: api.StatsSummaryCurrent{
-			Visitors:  currentSummary.Visitors,
-			Pageviews: currentSummary.Pageviews,
-			Bounces:   currentSummary.Bounces,
-			Duration:  currentSummary.Duration,
+			Visitors:         currentSummary.Visitors,
+			Pageviews:        currentSummary.Pageviews,
+			BouncePercentage: currentSummary.BounceRate,
+			Duration:         currentSummary.Duration,
 		},
 	}
 
@@ -77,10 +77,10 @@ func (h *Handler) GetWebsiteIDSummary(ctx context.Context, params api.GetWebsite
 
 		resp.Previous = api.NewOptStatsSummaryPrevious(
 			api.StatsSummaryPrevious{
-				Visitors:  previousSummary.Visitors,
-				Pageviews: previousSummary.Pageviews,
-				Bounces:   previousSummary.Bounces,
-				Duration:  previousSummary.Duration,
+				Visitors:         previousSummary.Visitors,
+				Pageviews:        previousSummary.Pageviews,
+				BouncePercentage: previousSummary.BounceRate,
+				Duration:         previousSummary.Duration,
 			},
 		)
 	}
@@ -100,11 +100,11 @@ func (h *Handler) GetWebsiteIDSummary(ctx context.Context, params api.GetWebsite
 		resp.Interval = []api.StatsSummaryIntervalItem{}
 		for _, i := range interval {
 			resp.Interval = append(resp.Interval, api.StatsSummaryIntervalItem{
-				Date:      i.Interval,
-				Visitors:  api.NewOptInt(i.Visitors),
-				Pageviews: api.NewOptInt(i.Pageviews),
-				Bounces:   api.NewOptInt(i.Bounces),
-				Duration:  api.NewOptInt(i.Duration),
+				Date:             i.Interval,
+				Visitors:         api.NewOptInt(i.Visitors),
+				Pageviews:        api.NewOptInt(i.Pageviews),
+				BouncePercentage: api.NewOptFloat32(i.BounceRate),
+				Duration:         api.NewOptInt(i.Duration),
 			})
 		}
 	}
@@ -192,7 +192,7 @@ func (h *Handler) GetWebsiteIDPages(ctx context.Context, params api.GetWebsiteID
 				VisitorsPercentage:  page.VisitorsPercentage,
 				Pageviews:           api.NewOptInt(page.Pageviews),
 				PageviewsPercentage: api.NewOptFloat32(page.PageviewsPercentage),
-				Bounces:             api.NewOptInt(page.Bounces),
+				BouncePercentage:    api.NewOptFloat32(page.BounceRate),
 				Duration:            api.NewOptInt(page.Duration),
 			})
 		}
@@ -371,7 +371,7 @@ func (h *Handler) GetWebsiteIDReferrers(ctx context.Context, params api.GetWebsi
 				Referrer:           page.Referrer,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
-				Bounces:            api.NewOptInt(page.Bounces),
+				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
 				Duration:           api.NewOptInt(page.Duration),
 			})
 		}
@@ -456,7 +456,7 @@ func (h *Handler) GetWebsiteIDSources(ctx context.Context, params api.GetWebsite
 				Source:             page.Source,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
-				Bounces:            api.NewOptInt(page.Bounces),
+				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
 				Duration:           api.NewOptInt(page.Duration),
 			})
 		}
@@ -544,7 +544,7 @@ func (h *Handler) GetWebsiteIDMediums(ctx context.Context, params api.GetWebsite
 				Medium:             page.Medium,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
-				Bounces:            api.NewOptInt(page.Bounces),
+				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
 				Duration:           api.NewOptInt(page.Duration),
 			})
 		}
@@ -632,7 +632,7 @@ func (h *Handler) GetWebsiteIDCampaigns(ctx context.Context, params api.GetWebsi
 				Campaign:           page.Campaign,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
-				Bounces:            api.NewOptInt(page.Bounces),
+				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
 				Duration:           api.NewOptInt(page.Duration),
 			})
 		}
@@ -720,7 +720,7 @@ func (h *Handler) GetWebsiteIDBrowsers(ctx context.Context, params api.GetWebsit
 				Browser:            page.Browser,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
-				Bounces:            api.NewOptInt(page.Bounces),
+				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
 				Duration:           api.NewOptInt(page.Duration),
 			})
 		}
@@ -808,7 +808,7 @@ func (h *Handler) GetWebsiteIDOs(ctx context.Context, params api.GetWebsiteIDOsP
 				Os:                 page.OS,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
-				Bounces:            api.NewOptInt(page.Bounces),
+				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
 				Duration:           api.NewOptInt(page.Duration),
 			})
 		}
@@ -896,7 +896,7 @@ func (h *Handler) GetWebsiteIDDevice(ctx context.Context, params api.GetWebsiteI
 				Device:             page.Device,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
-				Bounces:            api.NewOptInt(page.Bounces),
+				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
 				Duration:           api.NewOptInt(page.Duration),
 			})
 		}
@@ -984,7 +984,7 @@ func (h *Handler) GetWebsiteIDLanguage(ctx context.Context, params api.GetWebsit
 				Language:           page.Language,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
-				Bounces:            api.NewOptInt(page.Bounces),
+				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
 				Duration:           api.NewOptInt(page.Duration),
 			})
 		}
@@ -1072,7 +1072,7 @@ func (h *Handler) GetWebsiteIDCountry(ctx context.Context, params api.GetWebsite
 				Country:            page.Country,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
-				Bounces:            api.NewOptInt(page.Bounces),
+				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
 				Duration:           api.NewOptInt(page.Duration),
 			})
 		}

--- a/dashboard/app/api/types.d.ts
+++ b/dashboard/app/api/types.d.ts
@@ -346,20 +346,23 @@ export interface components {
       current: {
         visitors: number;
         pageviews: number;
-        bounces: number;
+        /** Format: float */
+        bounce_percentage: number;
         duration: number;
       };
       previous?: {
         visitors: number;
         pageviews: number;
-        bounces: number;
+        /** Format: float */
+        bounce_percentage: number;
         duration: number;
       };
       interval?: {
           date: string;
           visitors?: number;
           pageviews?: number;
-          bounces?: number;
+          /** Format: float */
+          bounce_percentage?: number;
           duration?: number;
         }[];
     };
@@ -381,8 +384,11 @@ export interface components {
          * @description Percentage of page views.
          */
         pageviews_percentage?: number;
-        /** @description Number of bounces. */
-        bounces?: number;
+        /**
+         * Format: float
+         * @description Bounce rate percentage.
+         */
+        bounce_percentage?: number;
         /** @description Total time spent on page in milliseconds. */
         duration?: number;
       }[];
@@ -415,8 +421,11 @@ export interface components {
          * @description Percentage of unique visitors from referrer.
          */
         visitors_percentage: number;
-        /** @description Number of bounces from referrer. */
-        bounces?: number;
+        /**
+         * Format: float
+         * @description Bounce rate percentage from referrer.
+         */
+        bounce_percentage?: number;
         /** @description Total time spent on page from referrer in milliseconds. */
         duration?: number;
       }[];
@@ -431,9 +440,12 @@ export interface components {
          * @description Percentage of unique visitors from UTM source.
          */
         visitors_percentage: number;
-        /** @description Number of bounces from referrer. */
-        bounces?: number;
-        /** @description Total time spent on page from referrer in milliseconds. */
+        /**
+         * Format: float
+         * @description Bounce rate percentage from UTM source.
+         */
+        bounce_percentage?: number;
+        /** @description Total time spent on page from UTM source in milliseconds. */
         duration?: number;
       }[];
     /** StatsUTMMediums */
@@ -447,9 +459,12 @@ export interface components {
          * @description Percentage of unique visitors from UTM medium.
          */
         visitors_percentage: number;
-        /** @description Number of bounces from referrer. */
-        bounces?: number;
-        /** @description Total time spent on page from referrer in milliseconds. */
+        /**
+         * Format: float
+         * @description Bounce rate percentage from UTM medium.
+         */
+        bounce_percentage?: number;
+        /** @description Total time spent on page from UTM medium in milliseconds. */
         duration?: number;
       }[];
     /** StatsUTMCampaigns */
@@ -463,9 +478,12 @@ export interface components {
          * @description Percentage of unique visitors from UTM campaign.
          */
         visitors_percentage: number;
-        /** @description Number of bounces from referrer. */
-        bounces?: number;
-        /** @description Total time spent on page from referrer in milliseconds. */
+        /**
+         * Format: float
+         * @description Bounce rate percentage from UTM campaign.
+         */
+        bounce_percentage?: number;
+        /** @description Total time spent on page from UTM campaign in milliseconds. */
         duration?: number;
       }[];
     /** StatsBrowsers */
@@ -479,9 +497,12 @@ export interface components {
          * @description Percentage of unique visitors from browser.
          */
         visitors_percentage: number;
-        /** @description Number of bounces from referrer. */
-        bounces?: number;
-        /** @description Total time spent on page from referrer in milliseconds. */
+        /**
+         * Format: float
+         * @description Bounce rate percentage from browser.
+         */
+        bounce_percentage?: number;
+        /** @description Total time spent on page from browser in milliseconds. */
         duration?: number;
       }[];
     /** StatsOS */
@@ -495,9 +516,12 @@ export interface components {
          * @description Percentage of unique visitors from OS.
          */
         visitors_percentage: number;
-        /** @description Number of bounces from referrer. */
-        bounces?: number;
-        /** @description Total time spent on page from referrer in milliseconds. */
+        /**
+         * Format: float
+         * @description Bounce rate percentage from OS.
+         */
+        bounce_percentage?: number;
+        /** @description Total time spent on page from OS in milliseconds. */
         duration?: number;
       }[];
     /** StatsDevices */
@@ -511,9 +535,12 @@ export interface components {
          * @description Percentage of unique visitors from device.
          */
         visitors_percentage: number;
-        /** @description Number of bounces from referrer. */
-        bounces?: number;
-        /** @description Total time spent on page from referrer in milliseconds. */
+        /**
+         * Format: float
+         * @description Bounce rate percentage from device.
+         */
+        bounce_percentage?: number;
+        /** @description Total time spent on page from device in milliseconds. */
         duration?: number;
       }[];
     /** StatsCountries */
@@ -527,9 +554,12 @@ export interface components {
          * @description Percentage of unique visitors from country.
          */
         visitors_percentage: number;
-        /** @description Number of bounces from referrer. */
-        bounces?: number;
-        /** @description Total time spent on page from referrer in milliseconds. */
+        /**
+         * Format: float
+         * @description Bounce rate percentage from country.
+         */
+        bounce_percentage?: number;
+        /** @description Total time spent on page from country in milliseconds. */
         duration?: number;
       }[];
     /**
@@ -549,9 +579,12 @@ export interface components {
          * @description Percentage of unique visitors for language.
          */
         visitors_percentage: number;
-        /** @description Number of bounces from referrer. */
-        bounces?: number;
-        /** @description Total time spent on page from referrer in milliseconds. */
+        /**
+         * Format: float
+         * @description Bounce rate percentage for language.
+         */
+        bounce_percentage?: number;
+        /** @description Total time spent on page from language in milliseconds. */
         duration?: number;
       }[];
   };

--- a/dashboard/app/components/stats/HeaderDataBox.tsx
+++ b/dashboard/app/components/stats/HeaderDataBox.tsx
@@ -60,10 +60,10 @@ const HeaderDataBox = React.memo(({ stat, isActive }: HeaderDataBoxProps) => {
 	const isPercentage = stat.chart === 'bounces';
 	const isDuration = stat.chart === 'duration';
 
-	const change = useMemo(
-		() => calculateChange(stat.current, stat.previous),
-		[stat],
-	);
+	const change = useMemo(() => {
+		if (isPercentage) return stat.current - (stat.previous ?? 0);
+		return calculateChange(stat.current, stat.previous);
+	}, [stat, isPercentage]);
 
 	const status = useMemo(() => getStatus(change), [change]);
 	const formattedValue = useMemo(
@@ -111,7 +111,7 @@ const HeaderDataBox = React.memo(({ stat, isActive }: HeaderDataBoxProps) => {
 						role="status"
 					>
 						{status === 'positive' ? '+' : ''}
-						{change}%
+						{isPercentage ? formatPercentage(change) : `${change}%`}
 					</Box>
 				</Group>
 			</UnstyledButton>

--- a/dashboard/app/components/stats/StatsTable.tsx
+++ b/dashboard/app/components/stats/StatsTable.tsx
@@ -89,7 +89,7 @@ type PresetDataKeys =
 	| 'visitors_percentage'
 	| 'pageviews'
 	| 'pageviews_percentage'
-	| 'bounce_rate'
+	| 'bounce_percentage'
 	| 'duration'
 	| 'duration_lower_quartile'
 	| 'duration_upper_quartile'
@@ -114,11 +114,10 @@ const PRESET_COLUMNS: Record<PresetDataKeys, DataTableColumn<DataRow>> = {
 		title: 'Views %',
 		render: (record) => formatPercentage(record.pageviews_percentage ?? 0),
 	},
-	bounce_rate: {
-		accessor: 'bounce_rate',
+	bounce_percentage: {
+		accessor: 'bounce_percentage',
 		title: 'Bounce %',
-		render: (record) =>
-			formatPercentage((record.bounces ?? 0) / (record.visitors ?? 1)),
+		render: (record) => formatPercentage(record.bounce_percentage ?? 0),
 	},
 	duration: {
 		accessor: 'duration',
@@ -332,7 +331,7 @@ const getColumnsForQuery = (
 				PRESET_COLUMNS.visitors_percentage,
 				PRESET_COLUMNS.pageviews,
 				PRESET_COLUMNS.pageviews_percentage,
-				PRESET_COLUMNS.bounce_rate,
+				PRESET_COLUMNS.bounce_percentage,
 				PRESET_COLUMNS.duration,
 			];
 		case 'time':
@@ -358,7 +357,7 @@ const getColumnsForQuery = (
 				},
 				PRESET_COLUMNS.visitors,
 				PRESET_COLUMNS.visitors_percentage,
-				PRESET_COLUMNS.bounce_rate,
+				PRESET_COLUMNS.bounce_percentage,
 				PRESET_COLUMNS.duration,
 			];
 		case 'browsers':
@@ -373,7 +372,7 @@ const getColumnsForQuery = (
 				},
 				PRESET_COLUMNS.visitors,
 				PRESET_COLUMNS.visitors_percentage,
-				PRESET_COLUMNS.bounce_rate,
+				PRESET_COLUMNS.bounce_percentage,
 				PRESET_COLUMNS.duration,
 			];
 		case 'languages':
@@ -387,7 +386,7 @@ const getColumnsForQuery = (
 				},
 				PRESET_COLUMNS.visitors,
 				PRESET_COLUMNS.visitors_percentage,
-				PRESET_COLUMNS.bounce_rate,
+				PRESET_COLUMNS.bounce_percentage,
 				PRESET_COLUMNS.duration,
 			];
 		case 'os':
@@ -400,7 +399,7 @@ const getColumnsForQuery = (
 				},
 				PRESET_COLUMNS.visitors,
 				PRESET_COLUMNS.visitors_percentage,
-				PRESET_COLUMNS.bounce_rate,
+				PRESET_COLUMNS.bounce_percentage,
 				PRESET_COLUMNS.duration,
 			];
 		case 'countries':
@@ -413,7 +412,7 @@ const getColumnsForQuery = (
 				},
 				PRESET_COLUMNS.visitors,
 				PRESET_COLUMNS.visitors_percentage,
-				PRESET_COLUMNS.bounce_rate,
+				PRESET_COLUMNS.bounce_percentage,
 				PRESET_COLUMNS.duration,
 			];
 		default:

--- a/dashboard/app/components/stats/types.ts
+++ b/dashboard/app/components/stats/types.ts
@@ -20,8 +20,7 @@ interface DataRow {
 	visitors_percentage?: number;
 	// Mixed
 	path?: string;
-	bounces?: number;
-	bounce_rate?: number;
+	bounce_percentage?: number;
 	duration?: number;
 	// Pages
 	pageviews?: number;

--- a/dashboard/app/routes/$hostname.tsx
+++ b/dashboard/app/routes/$hostname.tsx
@@ -76,10 +76,8 @@ export default function Index() {
 		{
 			label: 'Bounce Rate',
 			chart: 'bounces',
-			current: current.bounces / current.visitors || 0,
-			previous: previous
-				? previous.bounces / previous.visitors || 0
-				: undefined,
+			current: current.bounce_percentage,
+			previous: previous?.bounce_percentage,
 		},
 	];
 
@@ -89,7 +87,7 @@ export default function Index() {
 				const valueMap = {
 					visitors: item.visitors ?? 0,
 					pageviews: item.pageviews ?? 0,
-					bounces: (item.bounces ?? 0) / (item.visitors ?? 0) || 0,
+					bounces: item.bounce_percentage ?? 0,
 					duration: item.duration ?? 0,
 				};
 


### PR DESCRIPTION
Bounce rates were _significantly_ lower than expected. This was because while the logic `bounces / total_visitors` per page would give a percentage, not all visitors actually fired an unload event, which meant the number of visitors with no bounce data were deflating the total bounce rate. 

This filters out all visitors without any bounce data from these calculations. This also updates the API to return a percentage instead of a bounce count since it is meaningless without knowing how many total visitors actually had bounce data.