### PR TITLE
ci: skip using qemu for building arm images

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -1,5 +1,6 @@
 name: Docker Edge Publish # Publish Docker images under `edge` and commit SHA tags
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: [Tests]
     types: [completed]
@@ -22,9 +23,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -21,9 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/tracker/Taskfile.yaml
+++ b/tracker/Taskfile.yaml
@@ -16,7 +16,6 @@ tasks:
       - ./dist/default.js
 
   embed:
-    deps: [build:default]
     cmds:
       - mkdir -p ../core/client
       - cp ./dist/default.js ../core/client/script.js


### PR DESCRIPTION
Follow up PR to #90. Closes #89. 

- QEMU is extremely slow. `buildx` apparently supports building for ARM without using QEMU.
- google-closure-compiler doesn't support ARM, so this PR removes that from the build task since we already pre-build the scripts.