### PR TITLE
ci(docker): remove node and reduce layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,34 +3,26 @@
 FROM jdxcode/mise:latest AS build
 
 # Install unzip dependency for bun
-RUN apt-get update && apt-get install -y unzip
-
-# Install runtimes - Temporarily include node for google-closure-compiler for tracker
-RUN mise use -g node@20
-RUN mise use -g bun@latest
-RUN mise use -g go@1.22
-
-# Install Taskfile
-RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/bin
+# Also combine RUN commands to reduce layers
+RUN apt-get update && apt-get install -y unzip && \
+	mise use -g bun@latest && \
+	mise use -g go@1.22 && \
+	sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/bin
 
 # Cache build dependencies
 ENV GOCACHE=/root/.cache/go-build
 
 # Cache Go modules
 WORKDIR /app
-COPY /core/go.mod /core/go.sum ./core/
-
-WORKDIR /app/core
-RUN --mount=type=cache,target=/root/.cache/go-build \
-	--mount=type=cache,target=/go/pkg/mod \
-	go mod download
-
-# Go back to root directory and install JavaScript dependencies
-WORKDIR /app
+COPY core/go.mod core/go.sum ./core/
 COPY package.json bun.lockb ./
 COPY dashboard/package.json ./dashboard/
 COPY tracker/package.json ./tracker/
-RUN bun install --frozen-lockfile
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+	--mount=type=cache,target=/go/pkg/mod \
+	cd core && go mod download && cd .. && \
+	bun install --frozen-lockfile
 
 # Copy the rest of the source code
 COPY . .
@@ -39,13 +31,13 @@ RUN --mount=type=cache,target="/root/.cache/go-build" ~/bin/task core:release
 # Build the final image
 FROM gcr.io/distroless/cc-debian12
 
-LABEL org.opencontainers.image.source=https://github.com/medama-io/medama
-LABEL org.opencontainers.image.description="Cookie-free, privacy-focused website analytics."
-LABEL org.opencontainers.image.licenses=Apache-2.0
+LABEL org.opencontainers.image.source=https://github.com/medama-io/medama \
+	org.opencontainers.image.description="Cookie-free, privacy-focused website analytics." \
+	org.opencontainers.image.licenses=Apache-2.0
 
-ENV PORT=8080
-ENV ANALYTICS_DATABASE_HOST=/app/data/me_analytics.db
-ENV APP_DATABASE_HOST=/app/data/me_app.db
+ENV PORT=8080 \
+	ANALYTICS_DATABASE_HOST=/app/data/me_analytics.db \
+	APP_DATABASE_HOST=/app/data/me_app.db
 
 WORKDIR /app
 


### PR DESCRIPTION
Since #91 removed `google-closure-compiler` from the build process, we can remove Node from the build image. The compiler was the only dependency that could not run using Bun. 

The `Dockerfile` has also been optimised a little to reduce layers for better caching.