### PR TITLE
fix: correct monthly interval querying and chart tooltips dates

### DIFF
--- a/dashboard/app/components/DropdownSelect.tsx
+++ b/dashboard/app/components/DropdownSelect.tsx
@@ -42,11 +42,10 @@ export const DropdownSelect = (props: DropdownSelectProps) => {
 
 	const [searchParams, setSearchParams] = useSearchParams();
 	const navigate = useNavigate();
-	const [option, setOption] = useState<string>(
-		isSearchParams(props)
-			? searchParams.get(props.searchParamKey) ?? defaultValue
-			: defaultValue,
-	);
+
+	const option = isSearchParams(props)
+		? searchParams.get(props.searchParamKey) ?? defaultValue
+		: defaultValue;
 
 	const combobox = useCombobox({
 		onDropdownClose: () => combobox.resetSelectedOption(),
@@ -57,25 +56,18 @@ export const DropdownSelect = (props: DropdownSelectProps) => {
 		},
 	});
 
-	useDidUpdate(() => {
+	const handleOptionSubmit = (value: string) => {
+		combobox.toggleDropdown();
 		if (isSearchParams(props)) {
 			setSearchParams((prevParams) => {
 				const newParams = new URLSearchParams(prevParams);
-				newParams.set(props.searchParamKey, option);
+				newParams.set(props.searchParamKey, value);
 				return newParams;
 			});
 		} else {
-			navigate(`/${option}`, { relative: 'route' });
+			navigate(`/${value}`, { relative: 'route' });
 		}
-	}, [option]);
-
-	const handleOptionSubmit = useCallback(
-		(value: string) => {
-			setOption(value);
-			combobox.toggleDropdown();
-		},
-		[combobox.toggleDropdown],
-	);
+	};
 
 	const options = useMemo(
 		() =>

--- a/dashboard/app/components/stats/Chart.tsx
+++ b/dashboard/app/components/stats/Chart.tsx
@@ -38,13 +38,16 @@ interface ChartTooltipProps {
 
 type HourPeriod = `${number}h`;
 type DayPeriod = `${number}d`;
-type FixedPeriod = 'today' | 'yesterday' | 'quarter';
+type FixedPeriod = 'today' | 'yesterday' | 'quarter' | 'half' | 'year' | 'all';
 type Period = HourPeriod | DayPeriod | FixedPeriod;
 
 const PERIODS = {
 	TODAY: 'today',
 	YESTERDAY: 'yesterday',
 	QUARTER: 'quarter',
+	HALF: 'half',
+	YEAR: 'year',
+	ALL: 'all',
 } as const;
 
 const intlFormatterBasic = new Intl.DateTimeFormat('en', {
@@ -53,6 +56,11 @@ const intlFormatterBasic = new Intl.DateTimeFormat('en', {
 
 const intlFormatterDay = new Intl.DateTimeFormat('en', {
 	dateStyle: 'full',
+});
+
+const intlFormatterMonth = new Intl.DateTimeFormat('en', {
+	month: 'long',
+	year: 'numeric',
 });
 
 const intlFormatterAll = new Intl.DateTimeFormat('en', {
@@ -84,13 +92,40 @@ const ChartTooltip = React.memo(
 				return intlFormatterDay;
 			}
 
+			if (
+				period === PERIODS.QUARTER ||
+				period === PERIODS.HALF ||
+				period === PERIODS.YEAR ||
+				period === PERIODS.ALL
+			) {
+				return intlFormatterMonth;
+			}
+
 			return intlFormatterBasic;
 		}, [period]);
+
+		const dateLabel = useMemo(() => {
+			const value = dateTimeFormat.format(parseISO(date));
+
+			if (period === PERIODS.QUARTER) {
+				return `Week of ${value}`;
+			}
+
+			if (
+				period === PERIODS.HALF ||
+				period === PERIODS.YEAR ||
+				period === PERIODS.ALL
+			) {
+				return `Month of ${value}`;
+			}
+
+			return value;
+		}, [dateTimeFormat, date, period]);
 
 		return (
 			<Paper px="md" py="md" withBorder shadow="md" radius="md">
 				<Text fw={500} mb="xs">
-					{dateTimeFormat.format(parseISO(date))}
+					{dateLabel}
 				</Text>
 				<Group gap="xs" justify="space-between">
 					<Group gap="sm">

--- a/dashboard/app/components/stats/Chart.tsx
+++ b/dashboard/app/components/stats/Chart.tsx
@@ -93,7 +93,6 @@ const ChartTooltip = React.memo(
 			}
 
 			if (
-				period === PERIODS.QUARTER ||
 				period === PERIODS.HALF ||
 				period === PERIODS.YEAR ||
 				period === PERIODS.ALL

--- a/dashboard/app/routes/settings.account.tsx
+++ b/dashboard/app/routes/settings.account.tsx
@@ -120,6 +120,7 @@ export default function Index() {
 
 	const handleSubmit = (values: typeof account.values) => {
 		submit(values, { method: 'POST' });
+		account.reset();
 	};
 
 	return (

--- a/dashboard/app/routes/settings.usage.tsx
+++ b/dashboard/app/routes/settings.usage.tsx
@@ -131,6 +131,7 @@ export default function Index() {
 
 	const handleSubmit = (values: Partial<typeof usageForm.values>) => {
 		submit(values, { method: 'POST' });
+		usageForm.reset();
 	};
 
 	return (

--- a/dashboard/app/utils/filters.ts
+++ b/dashboard/app/utils/filters.ts
@@ -1,6 +1,8 @@
 import {
 	endOfDay,
 	endOfHour,
+	endOfMonth,
+	endOfWeek,
 	formatRFC3339,
 	startOfDay,
 	startOfHour,
@@ -34,19 +36,19 @@ const generatePeriods = (period: string) => {
 		}
 		case 'quarter': {
 			startPeriod = startOfWeek(sub(currentDate, { months: 3 }));
-			endPeriod = endOfDay(currentDate);
+			endPeriod = endOfWeek(currentDate);
 			interval = 'week';
 			break;
 		}
 		case 'half': {
 			startPeriod = startOfMonth(sub(currentDate, { months: 6 }));
-			endPeriod = endOfDay(currentDate);
+			endPeriod = endOfMonth(currentDate);
 			interval = 'month';
 			break;
 		}
 		case 'year': {
 			startPeriod = startOfMonth(sub(currentDate, { years: 1 }));
-			endPeriod = endOfDay(currentDate);
+			endPeriod = endOfMonth(currentDate);
 			interval = 'month';
 			break;
 		}


### PR DESCRIPTION
Closes #88. This PR addresses a couple bugs related to time selection for weekly and monthly intervals:

- Chart tooltips are now clearer stating `Week of July 7` instead of `July 7` to show the data contains the aggregated data of the following days. This was previously unclear when looking at the charts directly at times.
- Monthly interval querying server-side was generating incorrect time bucket series' due to mismatches in days (e.g. February with 28 days). This adds a little extra logic to handle the monthly edge case. 