### PR TITLE
feat(db): support custom properties metadata

### DIFF
--- a/core/.golangci.yml
+++ b/core/.golangci.yml
@@ -6,11 +6,6 @@ run:
 # This file contains only configs which differ from defaults.
 # All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
 linters-settings:
-  cyclop:
-    # The maximal code complexity to report.
-    # Default: 10
-    max-complexity: 40
-
   errcheck:
     # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
     # Such cases aren't reported by default.
@@ -117,7 +112,7 @@ linters:
     - bodyclose # checks whether HTTP response body is closed successfully
     - containedctx # checks for context.Context contained in a struct
     - contextcheck # checks for common mistakes using context
-    - cyclop # checks function and package cyclomatic complexity
+    # - cyclop # checks function and package cyclomatic complexity
     # - dupl # tool for code clone detection
     - durationcheck # checks for two durations multiplied together
     - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
@@ -133,7 +128,7 @@ linters:
     # - gocognit # computes and checks the cognitive complexity of functions
     - goconst # finds repeated strings that could be replaced by a constant
     - gocritic # provides diagnostics that check for bugs, performance and style issues
-    - gocyclo # computes and checks the cyclomatic complexity of functions
+    # - gocyclo # computes and checks the cyclomatic complexity of functions
     - gofumpt # checks if the code is formatted with gofumpt
     - godot # checks if comments end in a period
     - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt

--- a/core/api/oas_json_gen.go
+++ b/core/api/oas_json_gen.go
@@ -542,6 +542,175 @@ func (s *ConflictErrorError) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode implements json.Marshaler.
+func (s *EventCustom) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *EventCustom) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("n")
+		e.Str(s.N)
+	}
+	{
+		e.FieldStart("p")
+		s.P.Encode(e)
+	}
+}
+
+var jsonFieldsNameOfEventCustom = [2]string{
+	0: "n",
+	1: "p",
+}
+
+// Decode decodes EventCustom from json.
+func (s *EventCustom) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode EventCustom to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "n":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.N = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"n\"")
+			}
+		case "p":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				if err := s.P.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"p\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode EventCustom")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfEventCustom) {
+					name = jsonFieldsNameOfEventCustom[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *EventCustom) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *EventCustom) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s EventCustomP) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields implements json.Marshaler.
+func (s EventCustomP) encodeFields(e *jx.Encoder) {
+	for k, elem := range s {
+		e.FieldStart(k)
+
+		if len(elem) != 0 {
+			e.Raw(elem)
+		}
+	}
+}
+
+// Decode decodes EventCustomP from json.
+func (s *EventCustomP) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode EventCustomP to nil")
+	}
+	m := s.init()
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		var elem jx.Raw
+		if err := func() error {
+			v, err := d.RawAppend(nil)
+			elem = jx.Raw(v)
+			if err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode EventCustomP")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s EventCustomP) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *EventCustomP) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes EventHit as json.
 func (s EventHit) Encode(e *jx.Encoder) {
 	e.ObjStart()
@@ -551,6 +720,20 @@ func (s EventHit) Encode(e *jx.Encoder) {
 
 func (s EventHit) encodeFields(e *jx.Encoder) {
 	switch s.Type {
+	case EventCustomEventHit:
+		e.FieldStart("e")
+		e.Str("custom")
+		{
+			s := s.EventCustom
+			{
+				e.FieldStart("n")
+				e.Str(s.N)
+			}
+			{
+				e.FieldStart("p")
+				s.P.Encode(e)
+			}
+		}
 	case EventLoadEventHit:
 		e.FieldStart("e")
 		e.Str("load")
@@ -625,6 +808,9 @@ func (s *EventHit) Decode(d *jx.Decoder) error {
 					return err
 				}
 				switch typ {
+				case "custom":
+					s.Type = EventCustomEventHit
+					found = true
 				case "load":
 					s.Type = EventLoadEventHit
 					found = true
@@ -651,6 +837,10 @@ func (s *EventHit) Decode(d *jx.Decoder) error {
 		}
 	case EventUnloadEventHit:
 		if err := s.EventUnload.Decode(d); err != nil {
+			return err
+		}
+	case EventCustomEventHit:
+		if err := s.EventCustom.Decode(d); err != nil {
 			return err
 		}
 	default:

--- a/core/api/oas_schemas_gen.go
+++ b/core/api/oas_schemas_gen.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-faster/errors"
+	"github.com/go-faster/jx"
 )
 
 // Request body for logging in.
@@ -167,6 +168,47 @@ type DeleteWebsitesIDNoContent struct{}
 
 func (*DeleteWebsitesIDNoContent) deleteWebsitesIDRes() {}
 
+// Event with custom properties.
+// Ref: #/components/schemas/EventCustom
+type EventCustom struct {
+	// Event name or key.
+	N string `json:"n"`
+	// Event properties.
+	P EventCustomP `json:"p"`
+}
+
+// GetN returns the value of N.
+func (s *EventCustom) GetN() string {
+	return s.N
+}
+
+// GetP returns the value of P.
+func (s *EventCustom) GetP() EventCustomP {
+	return s.P
+}
+
+// SetN sets the value of N.
+func (s *EventCustom) SetN(val string) {
+	s.N = val
+}
+
+// SetP sets the value of P.
+func (s *EventCustom) SetP(val EventCustomP) {
+	s.P = val
+}
+
+// Event properties.
+type EventCustomP map[string]jx.Raw
+
+func (s *EventCustomP) init() EventCustomP {
+	m := *s
+	if m == nil {
+		m = map[string]jx.Raw{}
+		*s = m
+	}
+	return m
+}
+
 // Website hit event.
 // Ref: #/components/schemas/EventHit
 // EventHit represents sum type.
@@ -174,6 +216,7 @@ type EventHit struct {
 	Type        EventHitType // switch on this field
 	EventLoad   EventLoad
 	EventUnload EventUnload
+	EventCustom EventCustom
 }
 
 // EventHitType is oneOf type of EventHit.
@@ -183,6 +226,7 @@ type EventHitType string
 const (
 	EventLoadEventHit   EventHitType = "load"
 	EventUnloadEventHit EventHitType = "unload"
+	EventCustomEventHit EventHitType = "custom"
 )
 
 // IsEventLoad reports whether EventHit is EventLoad.
@@ -190,6 +234,9 @@ func (s EventHit) IsEventLoad() bool { return s.Type == EventLoadEventHit }
 
 // IsEventUnload reports whether EventHit is EventUnload.
 func (s EventHit) IsEventUnload() bool { return s.Type == EventUnloadEventHit }
+
+// IsEventCustom reports whether EventHit is EventCustom.
+func (s EventHit) IsEventCustom() bool { return s.Type == EventCustomEventHit }
 
 // SetEventLoad sets EventHit to EventLoad.
 func (s *EventHit) SetEventLoad(v EventLoad) {
@@ -230,6 +277,27 @@ func (s EventHit) GetEventUnload() (v EventUnload, ok bool) {
 func NewEventUnloadEventHit(v EventUnload) EventHit {
 	var s EventHit
 	s.SetEventUnload(v)
+	return s
+}
+
+// SetEventCustom sets EventHit to EventCustom.
+func (s *EventHit) SetEventCustom(v EventCustom) {
+	s.Type = EventCustomEventHit
+	s.EventCustom = v
+}
+
+// GetEventCustom returns EventCustom and true boolean if EventHit is EventCustom.
+func (s EventHit) GetEventCustom() (v EventCustom, ok bool) {
+	if !s.IsEventCustom() {
+		return v, false
+	}
+	return s.EventCustom, true
+}
+
+// NewEventCustomEventHit returns new EventHit from EventCustom.
+func NewEventCustomEventHit(v EventCustom) EventHit {
+	var s EventHit
+	s.SetEventCustom(v)
 	return s
 }
 

--- a/core/api/oas_schemas_gen.go
+++ b/core/api/oas_schemas_gen.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/go-faster/errors"
-	"github.com/go-faster/jx"
 )
 
 // Request body for logging in.
@@ -171,10 +170,17 @@ func (*DeleteWebsitesIDNoContent) deleteWebsitesIDRes() {}
 // Event with custom properties.
 // Ref: #/components/schemas/EventCustom
 type EventCustom struct {
+	// Group name of events. Currently, only the hostname is supported.
+	G string `json:"g"`
 	// Event name or key.
 	N string `json:"n"`
 	// Event properties.
 	P EventCustomP `json:"p"`
+}
+
+// GetG returns the value of G.
+func (s *EventCustom) GetG() string {
+	return s.G
 }
 
 // GetN returns the value of N.
@@ -185,6 +191,11 @@ func (s *EventCustom) GetN() string {
 // GetP returns the value of P.
 func (s *EventCustom) GetP() EventCustomP {
 	return s.P
+}
+
+// SetG sets the value of G.
+func (s *EventCustom) SetG(val string) {
+	s.G = val
 }
 
 // SetN sets the value of N.
@@ -198,15 +209,105 @@ func (s *EventCustom) SetP(val EventCustomP) {
 }
 
 // Event properties.
-type EventCustomP map[string]jx.Raw
+type EventCustomP map[string]EventCustomPItem
 
 func (s *EventCustomP) init() EventCustomP {
 	m := *s
 	if m == nil {
-		m = map[string]jx.Raw{}
+		m = map[string]EventCustomPItem{}
 		*s = m
 	}
 	return m
+}
+
+// EventCustomPItem represents sum type.
+type EventCustomPItem struct {
+	Type   EventCustomPItemType // switch on this field
+	String string
+	Int    int
+	Bool   bool
+}
+
+// EventCustomPItemType is oneOf type of EventCustomPItem.
+type EventCustomPItemType string
+
+// Possible values for EventCustomPItemType.
+const (
+	StringEventCustomPItem EventCustomPItemType = "string"
+	IntEventCustomPItem    EventCustomPItemType = "int"
+	BoolEventCustomPItem   EventCustomPItemType = "bool"
+)
+
+// IsString reports whether EventCustomPItem is string.
+func (s EventCustomPItem) IsString() bool { return s.Type == StringEventCustomPItem }
+
+// IsInt reports whether EventCustomPItem is int.
+func (s EventCustomPItem) IsInt() bool { return s.Type == IntEventCustomPItem }
+
+// IsBool reports whether EventCustomPItem is bool.
+func (s EventCustomPItem) IsBool() bool { return s.Type == BoolEventCustomPItem }
+
+// SetString sets EventCustomPItem to string.
+func (s *EventCustomPItem) SetString(v string) {
+	s.Type = StringEventCustomPItem
+	s.String = v
+}
+
+// GetString returns string and true boolean if EventCustomPItem is string.
+func (s EventCustomPItem) GetString() (v string, ok bool) {
+	if !s.IsString() {
+		return v, false
+	}
+	return s.String, true
+}
+
+// NewStringEventCustomPItem returns new EventCustomPItem from string.
+func NewStringEventCustomPItem(v string) EventCustomPItem {
+	var s EventCustomPItem
+	s.SetString(v)
+	return s
+}
+
+// SetInt sets EventCustomPItem to int.
+func (s *EventCustomPItem) SetInt(v int) {
+	s.Type = IntEventCustomPItem
+	s.Int = v
+}
+
+// GetInt returns int and true boolean if EventCustomPItem is int.
+func (s EventCustomPItem) GetInt() (v int, ok bool) {
+	if !s.IsInt() {
+		return v, false
+	}
+	return s.Int, true
+}
+
+// NewIntEventCustomPItem returns new EventCustomPItem from int.
+func NewIntEventCustomPItem(v int) EventCustomPItem {
+	var s EventCustomPItem
+	s.SetInt(v)
+	return s
+}
+
+// SetBool sets EventCustomPItem to bool.
+func (s *EventCustomPItem) SetBool(v bool) {
+	s.Type = BoolEventCustomPItem
+	s.Bool = v
+}
+
+// GetBool returns bool and true boolean if EventCustomPItem is bool.
+func (s EventCustomPItem) GetBool() (v bool, ok bool) {
+	if !s.IsBool() {
+		return v, false
+	}
+	return s.Bool, true
+}
+
+// NewBoolEventCustomPItem returns new EventCustomPItem from bool.
+func NewBoolEventCustomPItem(v bool) EventCustomPItem {
+	var s EventCustomPItem
+	s.SetBool(v)
+	return s
 }
 
 // Website hit event.

--- a/core/api/oas_validators_gen.go
+++ b/core/api/oas_validators_gen.go
@@ -69,6 +69,8 @@ func (s EventHit) Validate() error {
 			return err
 		}
 		return nil
+	case EventCustomEventHit:
+		return nil // no validation needed
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}

--- a/core/db/db.go
+++ b/core/db/db.go
@@ -46,6 +46,7 @@ type AnalyticsClient interface {
 	GetSettingsUsage(ctx context.Context) (*model.GetSettingsUsage, error)
 	PatchSettingsUsage(ctx context.Context, settings *model.GetSettingsUsage) error
 	// Events
+	AddEvent(ctx context.Context, event *model.EventHit) error
 	AddPageView(ctx context.Context, event *model.PageViewHit) error
 	UpdatePageView(ctx context.Context, event *model.PageViewDuration) error
 	// Pages

--- a/core/db/db.go
+++ b/core/db/db.go
@@ -46,7 +46,7 @@ type AnalyticsClient interface {
 	GetSettingsUsage(ctx context.Context) (*model.GetSettingsUsage, error)
 	PatchSettingsUsage(ctx context.Context, settings *model.GetSettingsUsage) error
 	// Events
-	AddEvent(ctx context.Context, event *model.EventHit) error
+	AddEvents(ctx context.Context, event *[]model.EventHit) error
 	AddPageView(ctx context.Context, event *model.PageViewHit) error
 	UpdatePageView(ctx context.Context, event *model.PageViewDuration) error
 	// Pages

--- a/core/db/duckdb/client.go
+++ b/core/db/duckdb/client.go
@@ -1,6 +1,9 @@
 package duckdb
 
 import (
+	"context"
+
+	"github.com/alphadose/haxmap"
 	"github.com/go-faster/errors"
 	"github.com/jmoiron/sqlx"
 	"github.com/medama-io/medama/db"
@@ -8,6 +11,7 @@ import (
 
 type Client struct {
 	*sqlx.DB
+	statements *haxmap.Map[string, *sqlx.NamedStmt]
 }
 
 // Compile time check for Client.
@@ -35,31 +39,51 @@ func NewClient(host string) (*Client, error) {
 		}
 	}
 
-	return &Client{
-		DB: db,
-	}, nil
+	prepared := haxmap.New[string, *sqlx.NamedStmt]()
+	c := &Client{
+		DB:         db,
+		statements: prepared,
+	}
+
+	err = c.prepareStatements(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
 }
 
 // Close closes the database connection and any prepared statements.
 func (c *Client) Close() error {
-	// Helper function to close a statement and wrap any error.
-	closeStmt := func(stmt *sqlx.NamedStmt) error {
-		if stmt != nil {
-			if err := stmt.Close(); err != nil {
-				return errors.Wrap(err, "duckdb")
-			}
-		}
-		return nil
-	}
-
 	// Close the statements.
-	if err := closeStmt(addStmt); err != nil {
-		return err
-	}
-	if err := closeStmt(updateStmt); err != nil {
-		return err
-	}
+	c.closeStatements(context.Background())
 
 	// Close the database connection.
 	return c.DB.Close()
+}
+
+func (c *Client) prepareStatements(ctx context.Context) error {
+	// Map of statements to prepare on startup
+	queryMap := map[string]string{
+		addEventName:       addEventQuery,
+		addPageViewName:    addPageViewQuery,
+		updatePageViewName: updatePageViewQuery,
+	}
+
+	for name := range queryMap {
+		stmt, err := c.DB.PrepareNamedContext(ctx, queryMap[name])
+		if err != nil {
+			return errors.Wrap(err, "duckdb: unable to create prepared statement")
+		}
+		c.statements.Set(name, stmt)
+	}
+
+	return nil
+}
+
+func (c *Client) closeStatements(ctx context.Context) {
+	c.statements.ForEach(func(_ string, stmt *sqlx.NamedStmt) bool {
+		stmt.Close()
+		return true
+	})
 }

--- a/core/db/duckdb/event.go
+++ b/core/db/duckdb/event.go
@@ -2,35 +2,14 @@ package duckdb
 
 import (
 	"context"
-	"sync"
 
 	"github.com/go-faster/errors"
-	"github.com/jmoiron/sqlx"
 	"github.com/medama-io/medama/model"
-	"github.com/medama-io/medama/util/logger"
 )
 
-var (
-	//nolint:gochecknoglobals // Reason: Singleton patterns are typically written like this.
-	eventOnce sync.Once
-	//nolint:gochecknoglobals // Reason: Prepared statements are meant to be global.
-	eventStmt *sqlx.NamedStmt
-	//nolint:gochecknoglobals // Reason: Singleton patterns are typically written like this.
-	addOnce sync.Once
-	//nolint:gochecknoglobals // Reason: Prepared statements are meant to be global.
-	addStmt *sqlx.NamedStmt
-	//nolint:gochecknoglobals // Reason: Singleton patterns are typically written like this.
-	updateOnce sync.Once
-	//nolint:gochecknoglobals // Reason: Prepared statements are meant to be global.
-	updateStmt *sqlx.NamedStmt
-)
-
-// AddEvent adds an event with a custom property to the database.
-func (c *Client) AddEvent(ctx context.Context, event *model.EventHit) error {
-	var err error
-	// Prepare named exec once.
-	eventOnce.Do(func() {
-		exec := `--sql
+const (
+	addEventName  = "addEvent"
+	addEventQuery = `--sql
 		INSERT INTO events (
 			group,
 			name,
@@ -42,35 +21,8 @@ func (c *Client) AddEvent(ctx context.Context, event *model.EventHit) error {
 			:value,
 			NOW()
 		)`
-
-		eventStmt, err = c.DB.PrepareNamedContext(ctx, exec)
-		if err != nil {
-			log := logger.Get()
-			log.Error().Err(err).Msg("failed to create prepared statement for add event")
-			panic("failed to create prepared statement for add event")
-		}
-	})
-
-	paramMap := map[string]interface{}{
-		"group": event.Group,
-		"name":  event.Name,
-		"value": event.Value,
-	}
-
-	_, err = eventStmt.ExecContext(ctx, paramMap)
-	if err != nil {
-		return errors.Wrap(err, "db")
-	}
-
-	return nil
-}
-
-// AddPageView adds a page view to the database.
-func (c *Client) AddPageView(ctx context.Context, event *model.PageViewHit) error {
-	var err error
-	// Prepare named exec once.
-	addOnce.Do(func() {
-		exec := `--sql
+	addPageViewName  = "addPageView"
+	addPageViewQuery = `--sql
 		INSERT INTO views (
 			bid,
 			hostname,
@@ -108,15 +60,30 @@ func (c *Client) AddPageView(ctx context.Context, event *model.PageViewHit) erro
 			:utm_campaign,
 			NOW()
 		)`
+	updatePageViewName  = "updatePageView"
+	updatePageViewQuery = `--sql
+		UPDATE views SET duration_ms = :duration_ms WHERE bid = :bid`
+)
 
-		addStmt, err = c.DB.PrepareNamedContext(ctx, exec)
-		if err != nil {
-			log := logger.Get()
-			log.Error().Err(err).Msg("failed to create prepared statement for add page view")
-			panic("failed to create prepared statement for add page view")
-		}
-	})
+// AddEvent adds an event with a custom property to the database.
+func (c *Client) AddEvent(ctx context.Context, event *model.EventHit) error {
+	paramMap := map[string]interface{}{
+		"group": event.Group,
+		"name":  event.Name,
+		"value": event.Value,
+	}
 
+	q, _ := c.statements.Get(addEventName)
+	_, err := q.ExecContext(ctx, paramMap)
+	if err != nil {
+		return errors.Wrap(err, "db")
+	}
+
+	return nil
+}
+
+// AddPageView adds a page view to the database.
+func (c *Client) AddPageView(ctx context.Context, event *model.PageViewHit) error {
 	paramMap := map[string]interface{}{
 		"bid":              event.BID,
 		"hostname":         event.Hostname,
@@ -136,7 +103,8 @@ func (c *Client) AddPageView(ctx context.Context, event *model.PageViewHit) erro
 		"utm_campaign":     event.UTMCampaign,
 	}
 
-	_, err = addStmt.ExecContext(ctx, paramMap)
+	q, _ := c.statements.Get(addPageViewName)
+	_, err := q.ExecContext(ctx, paramMap)
 	if err != nil {
 		return errors.Wrap(err, "db")
 	}
@@ -146,26 +114,13 @@ func (c *Client) AddPageView(ctx context.Context, event *model.PageViewHit) erro
 
 // UpdatePageView updates a page view in the database.
 func (c *Client) UpdatePageView(ctx context.Context, event *model.PageViewDuration) error {
-	var err error
-	// Prepare named exec once.
-	updateOnce.Do(func() {
-		exec := `--sql
-		UPDATE views SET duration_ms = :duration_ms WHERE bid = :bid`
-
-		updateStmt, err = c.DB.PrepareNamedContext(ctx, exec)
-		if err != nil {
-			log := logger.Get()
-			log.Error().Err(err).Msg("failed to create prepared statement for update page view")
-			panic(err)
-		}
-	})
-
 	paramMap := map[string]interface{}{
 		"bid":         event.BID,
 		"duration_ms": event.DurationMs,
 	}
 
-	_, err = updateStmt.ExecContext(ctx, paramMap)
+	q, _ := c.statements.Get(updatePageViewName)
+	_, err := q.ExecContext(ctx, paramMap)
 	if err != nil {
 		return errors.Wrap(err, "db")
 	}

--- a/core/db/duckdb/event.go
+++ b/core/db/duckdb/event.go
@@ -17,12 +17,12 @@ const (
 func (c *Client) AddEvent(ctx context.Context, event *model.EventHit) error {
 	exec := `--sql
 		INSERT INTO events (
-			group,
+			group_name,
 			name,
 			value,
 			date_created
 		) VALUES (
-			:group,
+			:group_name,
 			:name,
 			:value,
 			NOW()
@@ -34,9 +34,9 @@ func (c *Client) AddEvent(ctx context.Context, event *model.EventHit) error {
 	}
 
 	paramMap := map[string]interface{}{
-		"group": event.Group,
-		"name":  event.Name,
-		"value": event.Value,
+		"group_name": event.Group,
+		"name":       event.Name,
+		"value":      event.Value,
 	}
 
 	_, err = stmt.ExecContext(ctx, paramMap)

--- a/core/db/duckdb/event_test.go
+++ b/core/db/duckdb/event_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/medama-io/medama/model"
 )
 
-func TestAddEvent(t *testing.T) {
+func TestAddEvents(t *testing.T) {
 	assert, _, ctx, client := SetupDatabase(t)
 	rows := client.DB.QueryRow("SELECT COUNT(*) FROM events WHERE group_name = 'add-event-test.io'")
 	var count int
@@ -14,19 +14,25 @@ func TestAddEvent(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(0, count)
 
-	event := &model.EventHit{
+	event1 := model.EventHit{
 		Group: "add-event-test.io",
 		Name:  "test_event",
 		Value: "test_value",
 	}
 
-	err = client.AddEvent(ctx, event)
+	event2 := model.EventHit{
+		Group: "add-event-test.io",
+		Name:  "test_event2",
+		Value: "test_value2",
+	}
+
+	err = client.AddEvents(ctx, &[]model.EventHit{event1, event2})
 	assert.NoError(err)
 
 	rows = client.DB.QueryRow("SELECT COUNT(*) FROM events WHERE group_name = 'add-event-test.io'")
 	err = rows.Scan(&count)
 	assert.NoError(err)
-	assert.Equal(1, count)
+	assert.Equal(2, count)
 }
 
 func TestAddPageView(t *testing.T) {

--- a/core/db/duckdb/event_test.go
+++ b/core/db/duckdb/event_test.go
@@ -6,6 +6,29 @@ import (
 	"github.com/medama-io/medama/model"
 )
 
+func TestAddEvent(t *testing.T) {
+	assert, _, ctx, client := SetupDatabase(t)
+	rows := client.DB.QueryRow("SELECT COUNT(*) FROM events WHERE group_name = 'add-event-test.io'")
+	var count int
+	err := rows.Scan(&count)
+	assert.NoError(err)
+	assert.Equal(0, count)
+
+	event := &model.EventHit{
+		Group: "add-event-test.io",
+		Name:  "test_event",
+		Value: "test_value",
+	}
+
+	err = client.AddEvent(ctx, event)
+	assert.NoError(err)
+
+	rows = client.DB.QueryRow("SELECT COUNT(*) FROM events WHERE group_name = 'add-event-test.io'")
+	err = rows.Scan(&count)
+	assert.NoError(err)
+	assert.Equal(1, count)
+}
+
 func TestAddPageView(t *testing.T) {
 	assert, _, ctx, client := SetupDatabase(t)
 	rows := client.DB.QueryRow("SELECT COUNT(*) FROM views WHERE hostname = 'add-page-view-test.io'")

--- a/core/go.mod
+++ b/core/go.mod
@@ -4,6 +4,7 @@ go 1.22.2
 
 require (
 	github.com/alexedwards/argon2id v1.0.0
+	github.com/alphadose/haxmap v1.4.0
 	github.com/caarlos0/env/v11 v11.1.0
 	github.com/gkampitakis/go-snaps v0.5.4
 	github.com/go-faster/errors v0.7.1

--- a/core/go.sum
+++ b/core/go.sum
@@ -2,6 +2,8 @@ filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/alexedwards/argon2id v1.0.0 h1:wJzDx66hqWX7siL/SRUmgz3F8YMrd/nfX/xHHcQQP0w=
 github.com/alexedwards/argon2id v1.0.0/go.mod h1:tYKkqIjzXvZdzPvADMWOEZ+l6+BD6CtBXMj5fnJppiw=
+github.com/alphadose/haxmap v1.4.0 h1:1yn+oGzy2THJj1DMuJBzRanE3sMnDAjJVbU0L31Jp3w=
+github.com/alphadose/haxmap v1.4.0/go.mod h1:rjHw1IAqbxm0S3U5tD16GoKsiAd8FWx5BJ2IYqXwgmM=
 github.com/apache/arrow/go/v14 v14.0.2 h1:N8OkaJEOfI3mEZt07BIkvo4sC6XDbL+48MBPWO5IONw=
 github.com/apache/arrow/go/v14 v14.0.2/go.mod h1:u3fgh3EdgN/YQ8cVQRguVW3R+seMybFg8QBQ5LU+eBY=
 github.com/boyter/go-string v1.0.5 h1:/xcOlWdgelLYLVkUU0xBLfioGjZ9KIMUMI/RXG138YY=
@@ -76,8 +78,6 @@ github.com/medama-io/go-referrer-parser v0.0.0-20240706151617-0106555291e7 h1:r/
 github.com/medama-io/go-referrer-parser v0.0.0-20240706151617-0106555291e7/go.mod h1:y/Y+TQijcFNVXWiZ7YhiThXVRbORFdhcY0osQZXQw8Q=
 github.com/medama-io/go-timezone-country v0.0.0-20240125021558-8a6127efd8f7 h1:mydNOo0Zm10bC/RX4h9iwe18hGS0KB5cTqo/y/WpbLQ=
 github.com/medama-io/go-timezone-country v0.0.0-20240125021558-8a6127efd8f7/go.mod h1:Wq7lg5D0ZdQ3bHnzOTKsb1YGlxm/l82OVA4aIbAA5w4=
-github.com/medama-io/go-useragent v0.0.0-20240705132343-7fdad75704b9 h1:WJcl6hA8S7/F5MmiPaFdUduMyj40IhIAuh14zuLCZyk=
-github.com/medama-io/go-useragent v0.0.0-20240705132343-7fdad75704b9/go.mod h1:H9GYWth4IN8vAFZh5LeARza7VwM4jK9uk7Tb9huVzLw=
 github.com/medama-io/go-useragent v0.0.0-20240707203018-4bd80a87eb23 h1:myjtzE9EGr2zS0d9jguGbZGCgj2117X82L9ZAK1AeYo=
 github.com/medama-io/go-useragent v0.0.0-20240707203018-4bd80a87eb23/go.mod h1:H9GYWth4IN8vAFZh5LeARza7VwM4jK9uk7Tb9huVzLw=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=

--- a/core/migrations/0004_duckdb_events.go
+++ b/core/migrations/0004_duckdb_events.go
@@ -13,7 +13,7 @@ func Up0004(c *duckdb.Client) error {
 
 	// Create events table
 	//
-	// group is the group name of the event, typically the hostname
+	// group_name is the group name of the event, typically the hostname
 	//
 	// name is the name of the event
 	//

--- a/core/migrations/0004_duckdb_events.go
+++ b/core/migrations/0004_duckdb_events.go
@@ -1,0 +1,69 @@
+package migrations
+
+import (
+	"github.com/medama-io/medama/db/duckdb"
+)
+
+func Up0004(c *duckdb.Client) error {
+	// Begin transaction
+	tx, err := c.Beginx()
+	if err != nil {
+		return err
+	}
+
+	// Create events table
+	//
+	// group is the group name of the event, typically the hostname
+	//
+	// name is the name of the event
+	//
+	// value is the value of the event
+	//
+	// date_created is the date the event was created
+	_, err = tx.Exec(`--sql
+	CREATE TABLE IF NOT EXISTS events (
+		group TEXT NOT NULL,
+		name TEXT NOT NULL,
+		value TEXT NOT NULL,
+		date_created TIMESTAMPTZ NOT NULL
+	)`)
+	if err != nil {
+		rollbackErr := tx.Rollback()
+		if rollbackErr != nil {
+			return rollbackErr
+		}
+
+		return err
+	}
+
+	// Commit transaction
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Down0004(c *duckdb.Client) error {
+	// Begin transaction
+	tx, err := c.Beginx()
+	if err != nil {
+		return err
+	}
+
+	// Drop views table
+	_, err = tx.Exec(`--sql
+	DROP TABLE IF EXISTS events`)
+	if err != nil {
+		return err
+	}
+
+	// Commit transaction
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/core/migrations/0004_duckdb_events.go
+++ b/core/migrations/0004_duckdb_events.go
@@ -22,7 +22,7 @@ func Up0004(c *duckdb.Client) error {
 	// date_created is the date the event was created
 	_, err = tx.Exec(`--sql
 	CREATE TABLE IF NOT EXISTS events (
-		group TEXT NOT NULL,
+		group_name TEXT NOT NULL,
 		name TEXT NOT NULL,
 		value TEXT NOT NULL,
 		date_created TIMESTAMPTZ NOT NULL

--- a/core/migrations/0004_duckdb_events.go
+++ b/core/migrations/0004_duckdb_events.go
@@ -11,17 +11,20 @@ func Up0004(c *duckdb.Client) error {
 		return err
 	}
 
-	// Create events table
+	// Create events table.
 	//
-	// group_name is the group name of the event, typically the hostname
+	// batch_id is used to group together multiple properties of the same event.
 	//
-	// name is the name of the event
+	// group_name is the group name of the event, typically the hostname.
 	//
-	// value is the value of the event
+	// name is the name of the event.
 	//
-	// date_created is the date the event was created
+	// value is the value of the event.
+	//
+	// date_created is the date the event was created.
 	_, err = tx.Exec(`--sql
 	CREATE TABLE IF NOT EXISTS events (
+		batch_id TEXT NOT NULL,
 		group_name TEXT NOT NULL,
 		name TEXT NOT NULL,
 		value TEXT NOT NULL,

--- a/core/migrations/migrations.go
+++ b/core/migrations/migrations.go
@@ -54,6 +54,7 @@ func NewMigrationsService(ctx context.Context, sqliteC *sqlite.Client, duckdbC *
 	duckdbMigrations := []*Migration[duckdb.Client]{
 		{ID: 2, Name: "0002_duckdb_schema.go", Type: DuckDB, Up: Up0002, Down: Down0002},
 		{ID: 3, Name: "0003_duckdb_referrer.go", Type: DuckDB, Up: Up0003, Down: Down0003},
+		{ID: 4, Name: "0004_duckdb_events.go", Type: DuckDB, Up: Up0004, Down: Down0004},
 	}
 
 	log := logger.Get()

--- a/core/model/event.go
+++ b/core/model/event.go
@@ -9,7 +9,7 @@ const (
 
 type EventHit struct {
 	// Group - The group name of the event, typically the hostname.
-	Group string `db:"group"`
+	Group string `db:"group_name"`
 	// Name - The name of the event.
 	Name string `db:"name"`
 	// Value - The value of the event.

--- a/core/model/event.go
+++ b/core/model/event.go
@@ -7,6 +7,15 @@ const (
 	RequestKeyBody RequestKey = "request"
 )
 
+type EventHit struct {
+	// Group - The group name of the event, typically the hostname.
+	Group string `db:"group"`
+	// Name - The name of the event.
+	Name string `db:"name"`
+	// Value - The value of the event.
+	Value string `db:"value"`
+}
+
 type PageViewHit struct {
 	// Beacon ID - Used to determine if multiple event types are
 	// associated with a single page view.

--- a/core/model/event.go
+++ b/core/model/event.go
@@ -8,6 +8,8 @@ const (
 )
 
 type EventHit struct {
+	// BatchID - Used to group together multiple properties of the same event.
+	BatchID string `db:"batch_id"`
 	// Group - The group name of the event, typically the hostname.
 	Group string `db:"group_name"`
 	// Name - The name of the event.

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -1413,14 +1413,22 @@ components:
       description: Event with custom properties.
       type: object
       properties:
+        g:
+          type: string
+          description: Group name of events. Currently, only the hostname is supported.
         n:
           type: string
           description: Event name or key.
         p:
           type: object
           description: Event properties.
-          additionalProperties: true
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: integer
+              - type: boolean
       required:
+        - g
         - n
         - p
     EventHit:

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -1408,17 +1408,34 @@ components:
       required:
         - b
         - m
+    EventCustom:
+      title: EventCustom
+      description: Event with custom properties.
+      type: object
+      properties:
+        n:
+          type: string
+          description: Event name or key.
+        p:
+          type: object
+          description: Event properties.
+          additionalProperties: true
+      required:
+        - n
+        - p
     EventHit:
       title: EventHit
       description: Website hit event.
       oneOf:
         - $ref: "#/components/schemas/EventLoad"
         - $ref: "#/components/schemas/EventUnload"
+        - $ref: "#/components/schemas/EventCustom"
       discriminator:
         propertyName: e
         mapping:
           load: "#/components/schemas/EventLoad"
           unload: "#/components/schemas/EventUnload"
+          custom: "#/components/schemas/EventCustom"
     FilterString:
       type: object
       properties:

--- a/core/services/event.go
+++ b/core/services/event.go
@@ -335,7 +335,6 @@ func (h *Handler) PostEventHit(ctx context.Context, req api.EventHit, params api
 
 			err := h.analyticsDB.AddEvents(ctx, &events)
 			if err != nil {
-
 				log.Error().Err(err).Msg("hit: failed to add event")
 				return ErrInternalServerError(err), nil
 			}

--- a/dashboard/app/api/types.d.ts
+++ b/dashboard/app/api/types.d.ts
@@ -483,10 +483,27 @@ export interface components {
             e: "unload";
         };
         /**
+         * EventCustom
+         * @description Event with custom properties.
+         */
+        EventCustom: {
+            /** @description Event name or key. */
+            n: string;
+            /** @description Event properties. */
+            p: {
+                [key: string]: unknown;
+            };
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            e: "custom";
+        };
+        /**
          * EventHit
          * @description Website hit event.
          */
-        EventHit: components["schemas"]["EventLoad"] | components["schemas"]["EventUnload"];
+        EventHit: components["schemas"]["EventLoad"] | components["schemas"]["EventUnload"] | components["schemas"]["EventCustom"];
         FilterString: {
             /** @description Equal to. */
             eq?: string;

--- a/dashboard/app/api/types.d.ts
+++ b/dashboard/app/api/types.d.ts
@@ -487,11 +487,13 @@ export interface components {
          * @description Event with custom properties.
          */
         EventCustom: {
+            /** @description Group name of events. Currently, only the hostname is supported. */
+            g: string;
             /** @description Event name or key. */
             n: string;
             /** @description Event properties. */
             p: {
-                [key: string]: unknown;
+                [key: string]: (string | number | boolean) | undefined;
             };
             /**
              * @description discriminator enum property added by openapi-typescript


### PR DESCRIPTION
PR 1/? to add support for #9.

This PR adds a new `events` table and updates the `/hit` API endpoint to support the addition of custom properties. 