### PR TITLE
perf(core): cache ping endpoint if user is returning visitor

### DIFF
--- a/core/services/event.go
+++ b/core/services/event.go
@@ -21,7 +21,7 @@ const (
 	// OneDay is the duration of one day.
 	OneDay = 24 * time.Hour
 	// Set to no-cache to disable caching.
-	CacheControl = "no-cache"
+	NoCache = "no-cache"
 	// Unknown is the default value for unknown fields.
 	Unknown = "Unknown"
 )
@@ -42,7 +42,7 @@ func (h *Handler) GetEventPing(ctx context.Context, params api.GetEventPingParam
 
 		return &api.GetEventPingOKHeaders{
 			LastModified: lastModified,
-			CacheControl: CacheControl,
+			CacheControl: NoCache,
 			Response:     api.GetEventPingOK{Data: body},
 		}, nil
 	}
@@ -59,15 +59,12 @@ func (h *Handler) GetEventPing(ctx context.Context, params api.GetEventPingParam
 	// and mark as a unique user.
 	if lastModifiedTime.Before(currentDay) {
 		lastModifiedTime = currentDay
-
 		// Return body to activate caching.
 		body := strings.NewReader("0")
-
 		lastModified := lastModifiedTime.Format(http.TimeFormat)
-
 		return &api.GetEventPingOKHeaders{
 			LastModified: lastModified,
-			CacheControl: CacheControl,
+			CacheControl: NoCache, // Keep no-cache for unique users
 			Response:     api.GetEventPingOK{Data: body},
 		}, nil
 	}
@@ -75,10 +72,15 @@ func (h *Handler) GetEventPing(ctx context.Context, params api.GetEventPingParam
 	// Otherwise, this is not a unique user.
 	body := strings.NewReader("1")
 
+	// Calculate time until lastModifiedTime + OneDay
+	nextResetTime := lastModifiedTime.Add(OneDay)
+	secondsUntilReset := int(time.Until(nextResetTime).Seconds())
+	cacheControl := "max-age=" + strconv.Itoa(secondsUntilReset)
+
 	// Return not modified if the last modified time is today (not unique user).
 	return &api.GetEventPingOKHeaders{
 		LastModified: ifModified,
-		CacheControl: CacheControl,
+		CacheControl: cacheControl,
 		Response: api.GetEventPingOK{
 			Data: body,
 		},

--- a/core/services/event.go
+++ b/core/services/event.go
@@ -59,9 +59,11 @@ func (h *Handler) GetEventPing(ctx context.Context, params api.GetEventPingParam
 	// and mark as a unique user.
 	if lastModifiedTime.Before(currentDay) {
 		lastModifiedTime = currentDay
+
 		// Return body to activate caching.
 		body := strings.NewReader("0")
 		lastModified := lastModifiedTime.Format(http.TimeFormat)
+
 		return &api.GetEventPingOKHeaders{
 			LastModified: lastModified,
 			CacheControl: NoCache, // Keep no-cache for unique users


### PR DESCRIPTION
This PR adds `Cache-Control` headers when the ping endpoint returns true for a returning visitor. This means we can skip sending extra requests to the server for the 24h period we mark a user as a returning visitor.

This may also subsequently resolve a bug in Webkit based browsers where MPA websites might randomly "forget" it was cached due to some obscure cache race they have implemented. This was a blocker for #109 merging.