### PR TITLE
fix(core): get settings should return default values for null settings

### DIFF
--- a/core/db/sqlite/settings.go
+++ b/core/db/sqlite/settings.go
@@ -38,8 +38,8 @@ func (c *Client) GetSetting(ctx context.Context, key model.SettingsKey) (string,
 func (c *Client) GetSettings(ctx context.Context) (*model.UserSettings, error) {
 	query := `--sql
 	SELECT
-		JSON_EXTRACT(settings, '$.language') AS language,
-		JSON_EXTRACT(settings, '$.script_type') AS script_type
+		COALESCE(JSON_EXTRACT(settings, '$.language'), 'en') AS language,
+		COALESCE(JSON_EXTRACT(settings, '$.script_type'), 'default') AS script_type
 	FROM users LIMIT 1`
 
 	settings := model.NewDefaultSettings()

--- a/core/migrations/0001_sqlite_schema.go
+++ b/core/migrations/0001_sqlite_schema.go
@@ -55,8 +55,6 @@ func Up0001(c *sqlite.Client) error {
 		return err
 	}
 
-	// Moved user creation to 0006_sqlite_settings.go
-
 	return nil
 }
 

--- a/core/migrations/migrations.go
+++ b/core/migrations/migrations.go
@@ -182,7 +182,7 @@ func (s *Service) AutoMigrate(ctx context.Context) error {
 	id := typeid.String()
 
 	// Hash default password
-	auth, err := util.NewAuthService(context.Background(), false)
+	auth, err := util.NewAuthService(ctx, false)
 	if err != nil {
 		return err
 	}
@@ -193,7 +193,7 @@ func (s *Service) AutoMigrate(ctx context.Context) error {
 
 	dateCreated := time.Now().Unix()
 	dateUpdated := dateCreated
-	err = s.sqlite.CreateUser(context.Background(), model.NewUser(id, "admin", pwdHash, model.NewDefaultSettings(), dateCreated, dateUpdated))
+	err = s.sqlite.CreateUser(ctx, model.NewUser(id, "admin", pwdHash, model.NewDefaultSettings(), dateCreated, dateUpdated))
 	if err != nil {
 		return err
 	}

--- a/core/model/settings.go
+++ b/core/model/settings.go
@@ -18,3 +18,11 @@ type UserSettings struct {
 }
 
 type WebsiteSettings struct{}
+
+// NewSettings returns a new instance of Settings with default values.
+func NewDefaultSettings() *UserSettings {
+	return &UserSettings{
+		Language:   "en",
+		ScriptType: "default",
+	}
+}

--- a/core/model/user.go
+++ b/core/model/user.go
@@ -22,11 +22,3 @@ func NewUser(id string, username string, password string, settings *UserSettings
 		DateUpdated: dateUpdated,
 	}
 }
-
-// NewSettings returns a new instance of Settings with default values.
-func NewDefaultSettings() *UserSettings {
-	return &UserSettings{
-		Language:   "en",
-		ScriptType: "default",
-	}
-}


### PR DESCRIPTION
Minor bug fix from #113 that handles NULL values in settings with default values.