### PR TITLE
perf(core): preallocate stat responses and reduce branching

### DIFF
--- a/core/services/stats.go
+++ b/core/services/stats.go
@@ -78,7 +78,7 @@ func (h *Handler) GetWebsiteIDSummary(ctx context.Context, params api.GetWebsite
 			return ErrInternalServerError(err), nil
 		}
 
-		resp.Interval = []api.StatsSummaryIntervalItem{}
+		resp.Interval = make([]api.StatsSummaryIntervalItem, 0, len(interval))
 		for _, i := range interval {
 			resp.Interval = append(resp.Interval, api.StatsSummaryIntervalItem{
 				Date:             i.Interval,
@@ -119,17 +119,16 @@ func (h *Handler) GetWebsiteIDPages(ctx context.Context, params api.GetWebsiteID
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response.
-		res := api.StatsPages{}
+		resp := make(api.StatsPages, 0, len(pages))
 		for _, page := range pages {
-			res = append(res, api.StatsPagesItem{
+			resp = append(resp, api.StatsPagesItem{
 				Path:               page.Pathname,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	case false:
 		// Get pages
 		pages, err := h.analyticsDB.GetWebsitePages(ctx, filters)
@@ -141,10 +140,9 @@ func (h *Handler) GetWebsiteIDPages(ctx context.Context, params api.GetWebsiteID
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsPages{}
+		resp := make(api.StatsPages, 0, len(pages))
 		for _, page := range pages {
-			res = append(res, api.StatsPagesItem{
+			resp = append(resp, api.StatsPagesItem{
 				Path:                page.Pathname,
 				Visitors:            page.Visitors,
 				VisitorsPercentage:  page.VisitorsPercentage,
@@ -155,7 +153,7 @@ func (h *Handler) GetWebsiteIDPages(ctx context.Context, params api.GetWebsiteID
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	default:
 		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
@@ -187,17 +185,16 @@ func (h *Handler) GetWebsiteIDTime(ctx context.Context, params api.GetWebsiteIDT
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsTime{}
+		resp := make(api.StatsTime, 0, len(times))
 		for _, page := range times {
-			res = append(res, api.StatsTimeItem{
+			resp = append(resp, api.StatsTimeItem{
 				Path:               page.Pathname,
 				Duration:           page.Duration,
 				DurationPercentage: page.DurationPercentage,
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	case false:
 		// Get time
 		times, err := h.analyticsDB.GetWebsiteTime(ctx, filters)
@@ -209,10 +206,9 @@ func (h *Handler) GetWebsiteIDTime(ctx context.Context, params api.GetWebsiteIDT
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsTime{}
+		resp := make(api.StatsTime, 0, len(times))
 		for _, page := range times {
-			res = append(res, api.StatsTimeItem{
+			resp = append(resp, api.StatsTimeItem{
 				Path:                  page.Pathname,
 				Duration:              page.Duration,
 				DurationPercentage:    page.DurationPercentage,
@@ -222,7 +218,7 @@ func (h *Handler) GetWebsiteIDTime(ctx context.Context, params api.GetWebsiteIDT
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	default:
 		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
@@ -254,17 +250,16 @@ func (h *Handler) GetWebsiteIDReferrers(ctx context.Context, params api.GetWebsi
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsReferrers{}
+		resp := make(api.StatsReferrers, 0, len(referrers))
 		for _, page := range referrers {
-			res = append(res, api.StatsReferrersItem{
+			resp = append(resp, api.StatsReferrersItem{
 				Referrer:           page.Referrer,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	case false:
 		// Get referrers
 		referrers, err := h.analyticsDB.GetWebsiteReferrers(ctx, params.Grouped.Value, filters)
@@ -276,10 +271,9 @@ func (h *Handler) GetWebsiteIDReferrers(ctx context.Context, params api.GetWebsi
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsReferrers{}
+		resp := make(api.StatsReferrers, 0, len(referrers))
 		for _, page := range referrers {
-			res = append(res, api.StatsReferrersItem{
+			resp = append(resp, api.StatsReferrersItem{
 				Referrer:           page.Referrer,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
@@ -288,7 +282,7 @@ func (h *Handler) GetWebsiteIDReferrers(ctx context.Context, params api.GetWebsi
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	default:
 		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
@@ -319,17 +313,16 @@ func (h *Handler) GetWebsiteIDSources(ctx context.Context, params api.GetWebsite
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsUTMSources{}
+		resp := make(api.StatsUTMSources, 0, len(sources))
 		for _, page := range sources {
-			res = append(res, api.StatsUTMSourcesItem{
+			resp = append(resp, api.StatsUTMSourcesItem{
 				Source:             page.Source,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	case false:
 		// Get sources
 		sources, err := h.analyticsDB.GetWebsiteUTMSources(ctx, filters)
@@ -338,10 +331,9 @@ func (h *Handler) GetWebsiteIDSources(ctx context.Context, params api.GetWebsite
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsUTMSources{}
+		resp := make(api.StatsUTMSources, 0, len(sources))
 		for _, page := range sources {
-			res = append(res, api.StatsUTMSourcesItem{
+			resp = append(resp, api.StatsUTMSourcesItem{
 				Source:             page.Source,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
@@ -350,7 +342,7 @@ func (h *Handler) GetWebsiteIDSources(ctx context.Context, params api.GetWebsite
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	default:
 		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
@@ -381,17 +373,16 @@ func (h *Handler) GetWebsiteIDMediums(ctx context.Context, params api.GetWebsite
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsUTMMediums{}
+		resp := make(api.StatsUTMMediums, 0, len(mediums))
 		for _, page := range mediums {
-			res = append(res, api.StatsUTMMediumsItem{
+			resp = append(resp, api.StatsUTMMediumsItem{
 				Medium:             page.Medium,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	case false:
 		// Get mediums
 		mediums, err := h.analyticsDB.GetWebsiteUTMMediums(ctx, filters)
@@ -403,10 +394,9 @@ func (h *Handler) GetWebsiteIDMediums(ctx context.Context, params api.GetWebsite
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsUTMMediums{}
+		resp := make(api.StatsUTMMediums, 0, len(mediums))
 		for _, page := range mediums {
-			res = append(res, api.StatsUTMMediumsItem{
+			resp = append(resp, api.StatsUTMMediumsItem{
 				Medium:             page.Medium,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
@@ -415,7 +405,7 @@ func (h *Handler) GetWebsiteIDMediums(ctx context.Context, params api.GetWebsite
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	default:
 		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
@@ -446,17 +436,16 @@ func (h *Handler) GetWebsiteIDCampaigns(ctx context.Context, params api.GetWebsi
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsUTMCampaigns{}
+		resp := make(api.StatsUTMCampaigns, 0, len(campaigns))
 		for _, page := range campaigns {
-			res = append(res, api.StatsUTMCampaignsItem{
+			resp = append(resp, api.StatsUTMCampaignsItem{
 				Campaign:           page.Campaign,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	case false:
 		// Get campaigns
 		campaigns, err := h.analyticsDB.GetWebsiteUTMCampaigns(ctx, filters)
@@ -468,10 +457,9 @@ func (h *Handler) GetWebsiteIDCampaigns(ctx context.Context, params api.GetWebsi
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsUTMCampaigns{}
+		resp := make(api.StatsUTMCampaigns, 0, len(campaigns))
 		for _, page := range campaigns {
-			res = append(res, api.StatsUTMCampaignsItem{
+			resp = append(resp, api.StatsUTMCampaignsItem{
 				Campaign:           page.Campaign,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
@@ -480,7 +468,7 @@ func (h *Handler) GetWebsiteIDCampaigns(ctx context.Context, params api.GetWebsi
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	default:
 		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
@@ -511,17 +499,16 @@ func (h *Handler) GetWebsiteIDBrowsers(ctx context.Context, params api.GetWebsit
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsBrowsers{}
+		resp := make(api.StatsBrowsers, 0, len(browsers))
 		for _, page := range browsers {
-			res = append(res, api.StatsBrowsersItem{
+			resp = append(resp, api.StatsBrowsersItem{
 				Browser:            page.Browser,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	case false:
 		// Get browsers
 		browsers, err := h.analyticsDB.GetWebsiteBrowsers(ctx, filters)
@@ -533,10 +520,9 @@ func (h *Handler) GetWebsiteIDBrowsers(ctx context.Context, params api.GetWebsit
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsBrowsers{}
+		resp := make(api.StatsBrowsers, 0, len(browsers))
 		for _, page := range browsers {
-			res = append(res, api.StatsBrowsersItem{
+			resp = append(resp, api.StatsBrowsersItem{
 				Browser:            page.Browser,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
@@ -545,7 +531,7 @@ func (h *Handler) GetWebsiteIDBrowsers(ctx context.Context, params api.GetWebsit
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	default:
 		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
@@ -576,17 +562,16 @@ func (h *Handler) GetWebsiteIDOs(ctx context.Context, params api.GetWebsiteIDOsP
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsOS{}
+		resp := make(api.StatsOS, 0, len(os))
 		for _, page := range os {
-			res = append(res, api.StatsOSItem{
+			resp = append(resp, api.StatsOSItem{
 				Os:                 page.OS,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	case false:
 		// Get OS
 		os, err := h.analyticsDB.GetWebsiteOS(ctx, filters)
@@ -598,10 +583,9 @@ func (h *Handler) GetWebsiteIDOs(ctx context.Context, params api.GetWebsiteIDOsP
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsOS{}
+		resp := make(api.StatsOS, 0, len(os))
 		for _, page := range os {
-			res = append(res, api.StatsOSItem{
+			resp = append(resp, api.StatsOSItem{
 				Os:                 page.OS,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
@@ -610,7 +594,7 @@ func (h *Handler) GetWebsiteIDOs(ctx context.Context, params api.GetWebsiteIDOsP
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	default:
 		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
@@ -641,17 +625,16 @@ func (h *Handler) GetWebsiteIDDevice(ctx context.Context, params api.GetWebsiteI
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsDevices{}
+		resp := make(api.StatsDevices, 0, len(devices))
 		for _, page := range devices {
-			res = append(res, api.StatsDevicesItem{
+			resp = append(resp, api.StatsDevicesItem{
 				Device:             page.Device,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	case false:
 		// Get devices
 		devices, err := h.analyticsDB.GetWebsiteDevices(ctx, filters)
@@ -663,10 +646,9 @@ func (h *Handler) GetWebsiteIDDevice(ctx context.Context, params api.GetWebsiteI
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsDevices{}
+		resp := make(api.StatsDevices, 0, len(devices))
 		for _, page := range devices {
-			res = append(res, api.StatsDevicesItem{
+			resp = append(resp, api.StatsDevicesItem{
 				Device:             page.Device,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
@@ -675,7 +657,7 @@ func (h *Handler) GetWebsiteIDDevice(ctx context.Context, params api.GetWebsiteI
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	default:
 		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
@@ -706,17 +688,16 @@ func (h *Handler) GetWebsiteIDLanguage(ctx context.Context, params api.GetWebsit
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsLanguages{}
+		resp := make(api.StatsLanguages, 0, len(languages))
 		for _, page := range languages {
-			res = append(res, api.StatsLanguagesItem{
+			resp = append(resp, api.StatsLanguagesItem{
 				Language:           page.Language,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	case false:
 		// Get languages
 		languages, err := h.analyticsDB.GetWebsiteLanguages(ctx, params.Locale.Value, filters)
@@ -728,10 +709,9 @@ func (h *Handler) GetWebsiteIDLanguage(ctx context.Context, params api.GetWebsit
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsLanguages{}
+		resp := make(api.StatsLanguages, 0, len(languages))
 		for _, page := range languages {
-			res = append(res, api.StatsLanguagesItem{
+			resp = append(resp, api.StatsLanguagesItem{
 				Language:           page.Language,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
@@ -740,7 +720,7 @@ func (h *Handler) GetWebsiteIDLanguage(ctx context.Context, params api.GetWebsit
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	default:
 		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
@@ -771,17 +751,16 @@ func (h *Handler) GetWebsiteIDCountry(ctx context.Context, params api.GetWebsite
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsCountries{}
+		resp := make(api.StatsCountries, 0, len(countries))
 		for _, page := range countries {
-			res = append(res, api.StatsCountriesItem{
+			resp = append(resp, api.StatsCountriesItem{
 				Country:            page.Country,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	case false:
 		// Get countries
 		countries, err := h.analyticsDB.GetWebsiteCountries(ctx, filters)
@@ -793,10 +772,9 @@ func (h *Handler) GetWebsiteIDCountry(ctx context.Context, params api.GetWebsite
 			return ErrInternalServerError(err), nil
 		}
 
-		// Create API response
-		res := api.StatsCountries{}
+		resp := make(api.StatsCountries, 0, len(countries))
 		for _, page := range countries {
-			res = append(res, api.StatsCountriesItem{
+			resp = append(resp, api.StatsCountriesItem{
 				Country:            page.Country,
 				Visitors:           page.Visitors,
 				VisitorsPercentage: page.VisitorsPercentage,
@@ -805,7 +783,7 @@ func (h *Handler) GetWebsiteIDCountry(ctx context.Context, params api.GetWebsite
 			})
 		}
 
-		return &res, nil
+		return &resp, nil
 	default:
 		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}

--- a/core/services/stats.go
+++ b/core/services/stats.go
@@ -107,8 +107,7 @@ func (h *Handler) GetWebsiteIDPages(ctx context.Context, params api.GetWebsiteID
 	filters := db.CreateFilters(params, params.Hostname)
 
 	// Check parameter if it is asking for summary.
-	switch params.Summary.Value {
-	case true:
+	if params.Summary.Value {
 		// Get summary.
 		pages, err := h.analyticsDB.GetWebsitePagesSummary(ctx, filters)
 		if err != nil {
@@ -129,34 +128,32 @@ func (h *Handler) GetWebsiteIDPages(ctx context.Context, params api.GetWebsiteID
 		}
 
 		return &resp, nil
-	case false:
-		// Get pages
-		pages, err := h.analyticsDB.GetWebsitePages(ctx, filters)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Bool("summary", params.Summary.Value).
-				Msg("failed to get website pages")
-			return ErrInternalServerError(err), nil
-		}
-
-		resp := make(api.StatsPages, 0, len(pages))
-		for _, page := range pages {
-			resp = append(resp, api.StatsPagesItem{
-				Path:                page.Pathname,
-				Visitors:            page.Visitors,
-				VisitorsPercentage:  page.VisitorsPercentage,
-				Pageviews:           api.NewOptInt(page.Pageviews),
-				PageviewsPercentage: api.NewOptFloat32(page.PageviewsPercentage),
-				BouncePercentage:    api.NewOptFloat32(page.BounceRate),
-				Duration:            api.NewOptInt(page.Duration),
-			})
-		}
-
-		return &resp, nil
-	default:
-		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
+
+	// Get pages
+	pages, err := h.analyticsDB.GetWebsitePages(ctx, filters)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Bool("summary", params.Summary.Value).
+			Msg("failed to get website pages")
+		return ErrInternalServerError(err), nil
+	}
+
+	resp := make(api.StatsPages, 0, len(pages))
+	for _, page := range pages {
+		resp = append(resp, api.StatsPagesItem{
+			Path:                page.Pathname,
+			Visitors:            page.Visitors,
+			VisitorsPercentage:  page.VisitorsPercentage,
+			Pageviews:           api.NewOptInt(page.Pageviews),
+			PageviewsPercentage: api.NewOptFloat32(page.PageviewsPercentage),
+			BouncePercentage:    api.NewOptFloat32(page.BounceRate),
+			Duration:            api.NewOptInt(page.Duration),
+		})
+	}
+
+	return &resp, nil
 }
 
 func (h *Handler) GetWebsiteIDTime(ctx context.Context, params api.GetWebsiteIDTimeParams) (api.GetWebsiteIDTimeRes, error) {
@@ -173,8 +170,7 @@ func (h *Handler) GetWebsiteIDTime(ctx context.Context, params api.GetWebsiteIDT
 	filters := db.CreateFilters(params, params.Hostname)
 
 	// Check parameter if it is asking for summary
-	switch params.Summary.Value {
-	case true:
+	if params.Summary.Value {
 		// Get summary
 		times, err := h.analyticsDB.GetWebsiteTimeSummary(ctx, filters)
 		if err != nil {
@@ -195,33 +191,31 @@ func (h *Handler) GetWebsiteIDTime(ctx context.Context, params api.GetWebsiteIDT
 		}
 
 		return &resp, nil
-	case false:
-		// Get time
-		times, err := h.analyticsDB.GetWebsiteTime(ctx, filters)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Bool("summary", params.Summary.Value).
-				Msg("failed to get website time")
-			return ErrInternalServerError(err), nil
-		}
-
-		resp := make(api.StatsTime, 0, len(times))
-		for _, page := range times {
-			resp = append(resp, api.StatsTimeItem{
-				Path:                  page.Pathname,
-				Duration:              page.Duration,
-				DurationPercentage:    page.DurationPercentage,
-				DurationUpperQuartile: api.NewOptInt(page.DurationUpperQuartile),
-				DurationLowerQuartile: api.NewOptInt(page.DurationLowerQuartile),
-				Visitors:              api.NewOptInt(page.Visitors),
-			})
-		}
-
-		return &resp, nil
-	default:
-		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
+
+	// Get time
+	times, err := h.analyticsDB.GetWebsiteTime(ctx, filters)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Bool("summary", params.Summary.Value).
+			Msg("failed to get website time")
+		return ErrInternalServerError(err), nil
+	}
+
+	resp := make(api.StatsTime, 0, len(times))
+	for _, page := range times {
+		resp = append(resp, api.StatsTimeItem{
+			Path:                  page.Pathname,
+			Duration:              page.Duration,
+			DurationPercentage:    page.DurationPercentage,
+			DurationUpperQuartile: api.NewOptInt(page.DurationUpperQuartile),
+			DurationLowerQuartile: api.NewOptInt(page.DurationLowerQuartile),
+			Visitors:              api.NewOptInt(page.Visitors),
+		})
+	}
+
+	return &resp, nil
 }
 
 func (h *Handler) GetWebsiteIDReferrers(ctx context.Context, params api.GetWebsiteIDReferrersParams) (api.GetWebsiteIDReferrersRes, error) {
@@ -238,8 +232,7 @@ func (h *Handler) GetWebsiteIDReferrers(ctx context.Context, params api.GetWebsi
 	filters := db.CreateFilters(params, params.Hostname)
 
 	// Check parameter if it is asking for summary
-	switch params.Summary.Value {
-	case true:
+	if params.Summary.Value {
 		// Get summary
 		referrers, err := h.analyticsDB.GetWebsiteReferrersSummary(ctx, params.Grouped.Value, filters)
 		if err != nil {
@@ -260,32 +253,30 @@ func (h *Handler) GetWebsiteIDReferrers(ctx context.Context, params api.GetWebsi
 		}
 
 		return &resp, nil
-	case false:
-		// Get referrers
-		referrers, err := h.analyticsDB.GetWebsiteReferrers(ctx, params.Grouped.Value, filters)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Bool("summary", params.Summary.Value).
-				Msg("failed to get website referrers")
-			return ErrInternalServerError(err), nil
-		}
-
-		resp := make(api.StatsReferrers, 0, len(referrers))
-		for _, page := range referrers {
-			resp = append(resp, api.StatsReferrersItem{
-				Referrer:           page.Referrer,
-				Visitors:           page.Visitors,
-				VisitorsPercentage: page.VisitorsPercentage,
-				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
-				Duration:           api.NewOptInt(page.Duration),
-			})
-		}
-
-		return &resp, nil
-	default:
-		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
+
+	// Get referrers
+	referrers, err := h.analyticsDB.GetWebsiteReferrers(ctx, params.Grouped.Value, filters)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Bool("summary", params.Summary.Value).
+			Msg("failed to get website referrers")
+		return ErrInternalServerError(err), nil
+	}
+
+	resp := make(api.StatsReferrers, 0, len(referrers))
+	for _, page := range referrers {
+		resp = append(resp, api.StatsReferrersItem{
+			Referrer:           page.Referrer,
+			Visitors:           page.Visitors,
+			VisitorsPercentage: page.VisitorsPercentage,
+			BouncePercentage:   api.NewOptFloat32(page.BounceRate),
+			Duration:           api.NewOptInt(page.Duration),
+		})
+	}
+
+	return &resp, nil
 }
 
 func (h *Handler) GetWebsiteIDSources(ctx context.Context, params api.GetWebsiteIDSourcesParams) (api.GetWebsiteIDSourcesRes, error) {
@@ -301,8 +292,7 @@ func (h *Handler) GetWebsiteIDSources(ctx context.Context, params api.GetWebsite
 	// Create filter for database query
 	filters := db.CreateFilters(params, params.Hostname)
 
-	switch params.Summary.Value {
-	case true:
+	if params.Summary.Value {
 		// Get summary
 		sources, err := h.analyticsDB.GetWebsiteUTMSourcesSummary(ctx, filters)
 		if err != nil {
@@ -323,29 +313,27 @@ func (h *Handler) GetWebsiteIDSources(ctx context.Context, params api.GetWebsite
 		}
 
 		return &resp, nil
-	case false:
-		// Get sources
-		sources, err := h.analyticsDB.GetWebsiteUTMSources(ctx, filters)
-		if err != nil {
-			log.Error().Err(err).Msg("failed to get website utm sources")
-			return ErrInternalServerError(err), nil
-		}
-
-		resp := make(api.StatsUTMSources, 0, len(sources))
-		for _, page := range sources {
-			resp = append(resp, api.StatsUTMSourcesItem{
-				Source:             page.Source,
-				Visitors:           page.Visitors,
-				VisitorsPercentage: page.VisitorsPercentage,
-				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
-				Duration:           api.NewOptInt(page.Duration),
-			})
-		}
-
-		return &resp, nil
-	default:
-		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
+
+	// Get sources
+	sources, err := h.analyticsDB.GetWebsiteUTMSources(ctx, filters)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to get website utm sources")
+		return ErrInternalServerError(err), nil
+	}
+
+	resp := make(api.StatsUTMSources, 0, len(sources))
+	for _, page := range sources {
+		resp = append(resp, api.StatsUTMSourcesItem{
+			Source:             page.Source,
+			Visitors:           page.Visitors,
+			VisitorsPercentage: page.VisitorsPercentage,
+			BouncePercentage:   api.NewOptFloat32(page.BounceRate),
+			Duration:           api.NewOptInt(page.Duration),
+		})
+	}
+
+	return &resp, nil
 }
 
 func (h *Handler) GetWebsiteIDMediums(ctx context.Context, params api.GetWebsiteIDMediumsParams) (api.GetWebsiteIDMediumsRes, error) {
@@ -361,8 +349,7 @@ func (h *Handler) GetWebsiteIDMediums(ctx context.Context, params api.GetWebsite
 	// Create filter for database query
 	filters := db.CreateFilters(params, params.Hostname)
 
-	switch params.Summary.Value {
-	case true:
+	if params.Summary.Value {
 		// Get summary
 		mediums, err := h.analyticsDB.GetWebsiteUTMMediumsSummary(ctx, filters)
 		if err != nil {
@@ -383,32 +370,30 @@ func (h *Handler) GetWebsiteIDMediums(ctx context.Context, params api.GetWebsite
 		}
 
 		return &resp, nil
-	case false:
-		// Get mediums
-		mediums, err := h.analyticsDB.GetWebsiteUTMMediums(ctx, filters)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Bool("summary", params.Summary.Value).
-				Msg("failed to get website utm mediums")
-			return ErrInternalServerError(err), nil
-		}
-
-		resp := make(api.StatsUTMMediums, 0, len(mediums))
-		for _, page := range mediums {
-			resp = append(resp, api.StatsUTMMediumsItem{
-				Medium:             page.Medium,
-				Visitors:           page.Visitors,
-				VisitorsPercentage: page.VisitorsPercentage,
-				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
-				Duration:           api.NewOptInt(page.Duration),
-			})
-		}
-
-		return &resp, nil
-	default:
-		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
+
+	// Get mediums
+	mediums, err := h.analyticsDB.GetWebsiteUTMMediums(ctx, filters)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Bool("summary", params.Summary.Value).
+			Msg("failed to get website utm mediums")
+		return ErrInternalServerError(err), nil
+	}
+
+	resp := make(api.StatsUTMMediums, 0, len(mediums))
+	for _, page := range mediums {
+		resp = append(resp, api.StatsUTMMediumsItem{
+			Medium:             page.Medium,
+			Visitors:           page.Visitors,
+			VisitorsPercentage: page.VisitorsPercentage,
+			BouncePercentage:   api.NewOptFloat32(page.BounceRate),
+			Duration:           api.NewOptInt(page.Duration),
+		})
+	}
+
+	return &resp, nil
 }
 
 func (h *Handler) GetWebsiteIDCampaigns(ctx context.Context, params api.GetWebsiteIDCampaignsParams) (api.GetWebsiteIDCampaignsRes, error) {
@@ -424,8 +409,7 @@ func (h *Handler) GetWebsiteIDCampaigns(ctx context.Context, params api.GetWebsi
 	// Create filter for database query
 	filters := db.CreateFilters(params, params.Hostname)
 
-	switch params.Summary.Value {
-	case true:
+	if params.Summary.Value {
 		// Get summary
 		campaigns, err := h.analyticsDB.GetWebsiteUTMCampaignsSummary(ctx, filters)
 		if err != nil {
@@ -446,32 +430,30 @@ func (h *Handler) GetWebsiteIDCampaigns(ctx context.Context, params api.GetWebsi
 		}
 
 		return &resp, nil
-	case false:
-		// Get campaigns
-		campaigns, err := h.analyticsDB.GetWebsiteUTMCampaigns(ctx, filters)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Bool("summary", params.Summary.Value).
-				Msg("failed to get website utm campaigns")
-			return ErrInternalServerError(err), nil
-		}
-
-		resp := make(api.StatsUTMCampaigns, 0, len(campaigns))
-		for _, page := range campaigns {
-			resp = append(resp, api.StatsUTMCampaignsItem{
-				Campaign:           page.Campaign,
-				Visitors:           page.Visitors,
-				VisitorsPercentage: page.VisitorsPercentage,
-				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
-				Duration:           api.NewOptInt(page.Duration),
-			})
-		}
-
-		return &resp, nil
-	default:
-		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
+
+	// Get campaigns
+	campaigns, err := h.analyticsDB.GetWebsiteUTMCampaigns(ctx, filters)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Bool("summary", params.Summary.Value).
+			Msg("failed to get website utm campaigns")
+		return ErrInternalServerError(err), nil
+	}
+
+	resp := make(api.StatsUTMCampaigns, 0, len(campaigns))
+	for _, page := range campaigns {
+		resp = append(resp, api.StatsUTMCampaignsItem{
+			Campaign:           page.Campaign,
+			Visitors:           page.Visitors,
+			VisitorsPercentage: page.VisitorsPercentage,
+			BouncePercentage:   api.NewOptFloat32(page.BounceRate),
+			Duration:           api.NewOptInt(page.Duration),
+		})
+	}
+
+	return &resp, nil
 }
 
 func (h *Handler) GetWebsiteIDBrowsers(ctx context.Context, params api.GetWebsiteIDBrowsersParams) (api.GetWebsiteIDBrowsersRes, error) {
@@ -487,8 +469,7 @@ func (h *Handler) GetWebsiteIDBrowsers(ctx context.Context, params api.GetWebsit
 	// Create filter for database query
 	filters := db.CreateFilters(params, params.Hostname)
 
-	switch params.Summary.Value {
-	case true:
+	if params.Summary.Value {
 		// Get summary
 		browsers, err := h.analyticsDB.GetWebsiteBrowsersSummary(ctx, filters)
 		if err != nil {
@@ -509,32 +490,30 @@ func (h *Handler) GetWebsiteIDBrowsers(ctx context.Context, params api.GetWebsit
 		}
 
 		return &resp, nil
-	case false:
-		// Get browsers
-		browsers, err := h.analyticsDB.GetWebsiteBrowsers(ctx, filters)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Bool("summary", params.Summary.Value).
-				Msg("failed to get website browsers")
-			return ErrInternalServerError(err), nil
-		}
-
-		resp := make(api.StatsBrowsers, 0, len(browsers))
-		for _, page := range browsers {
-			resp = append(resp, api.StatsBrowsersItem{
-				Browser:            page.Browser,
-				Visitors:           page.Visitors,
-				VisitorsPercentage: page.VisitorsPercentage,
-				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
-				Duration:           api.NewOptInt(page.Duration),
-			})
-		}
-
-		return &resp, nil
-	default:
-		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
+
+	// Get browsers
+	browsers, err := h.analyticsDB.GetWebsiteBrowsers(ctx, filters)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Bool("summary", params.Summary.Value).
+			Msg("failed to get website browsers")
+		return ErrInternalServerError(err), nil
+	}
+
+	resp := make(api.StatsBrowsers, 0, len(browsers))
+	for _, page := range browsers {
+		resp = append(resp, api.StatsBrowsersItem{
+			Browser:            page.Browser,
+			Visitors:           page.Visitors,
+			VisitorsPercentage: page.VisitorsPercentage,
+			BouncePercentage:   api.NewOptFloat32(page.BounceRate),
+			Duration:           api.NewOptInt(page.Duration),
+		})
+	}
+
+	return &resp, nil
 }
 
 func (h *Handler) GetWebsiteIDOs(ctx context.Context, params api.GetWebsiteIDOsParams) (api.GetWebsiteIDOsRes, error) {
@@ -550,8 +529,7 @@ func (h *Handler) GetWebsiteIDOs(ctx context.Context, params api.GetWebsiteIDOsP
 	// Create filter for database query
 	filters := db.CreateFilters(params, params.Hostname)
 
-	switch params.Summary.Value {
-	case true:
+	if params.Summary.Value {
 		// Get summary
 		os, err := h.analyticsDB.GetWebsiteOSSummary(ctx, filters)
 		if err != nil {
@@ -572,32 +550,30 @@ func (h *Handler) GetWebsiteIDOs(ctx context.Context, params api.GetWebsiteIDOsP
 		}
 
 		return &resp, nil
-	case false:
-		// Get OS
-		os, err := h.analyticsDB.GetWebsiteOS(ctx, filters)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Bool("summary", params.Summary.Value).
-				Msg("failed to get website os")
-			return ErrInternalServerError(err), nil
-		}
-
-		resp := make(api.StatsOS, 0, len(os))
-		for _, page := range os {
-			resp = append(resp, api.StatsOSItem{
-				Os:                 page.OS,
-				Visitors:           page.Visitors,
-				VisitorsPercentage: page.VisitorsPercentage,
-				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
-				Duration:           api.NewOptInt(page.Duration),
-			})
-		}
-
-		return &resp, nil
-	default:
-		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
+
+	// Get OS
+	os, err := h.analyticsDB.GetWebsiteOS(ctx, filters)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Bool("summary", params.Summary.Value).
+			Msg("failed to get website os")
+		return ErrInternalServerError(err), nil
+	}
+
+	resp := make(api.StatsOS, 0, len(os))
+	for _, page := range os {
+		resp = append(resp, api.StatsOSItem{
+			Os:                 page.OS,
+			Visitors:           page.Visitors,
+			VisitorsPercentage: page.VisitorsPercentage,
+			BouncePercentage:   api.NewOptFloat32(page.BounceRate),
+			Duration:           api.NewOptInt(page.Duration),
+		})
+	}
+
+	return &resp, nil
 }
 
 func (h *Handler) GetWebsiteIDDevice(ctx context.Context, params api.GetWebsiteIDDeviceParams) (api.GetWebsiteIDDeviceRes, error) {
@@ -613,8 +589,7 @@ func (h *Handler) GetWebsiteIDDevice(ctx context.Context, params api.GetWebsiteI
 	// Create filter for database query
 	filters := db.CreateFilters(params, params.Hostname)
 
-	switch params.Summary.Value {
-	case true:
+	if params.Summary.Value {
 		// Get summary
 		devices, err := h.analyticsDB.GetWebsiteDevicesSummary(ctx, filters)
 		if err != nil {
@@ -635,32 +610,30 @@ func (h *Handler) GetWebsiteIDDevice(ctx context.Context, params api.GetWebsiteI
 		}
 
 		return &resp, nil
-	case false:
-		// Get devices
-		devices, err := h.analyticsDB.GetWebsiteDevices(ctx, filters)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Bool("summary", params.Summary.Value).
-				Msg("failed to get website devices")
-			return ErrInternalServerError(err), nil
-		}
-
-		resp := make(api.StatsDevices, 0, len(devices))
-		for _, page := range devices {
-			resp = append(resp, api.StatsDevicesItem{
-				Device:             page.Device,
-				Visitors:           page.Visitors,
-				VisitorsPercentage: page.VisitorsPercentage,
-				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
-				Duration:           api.NewOptInt(page.Duration),
-			})
-		}
-
-		return &resp, nil
-	default:
-		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
+
+	// Get devices
+	devices, err := h.analyticsDB.GetWebsiteDevices(ctx, filters)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Bool("summary", params.Summary.Value).
+			Msg("failed to get website devices")
+		return ErrInternalServerError(err), nil
+	}
+
+	resp := make(api.StatsDevices, 0, len(devices))
+	for _, page := range devices {
+		resp = append(resp, api.StatsDevicesItem{
+			Device:             page.Device,
+			Visitors:           page.Visitors,
+			VisitorsPercentage: page.VisitorsPercentage,
+			BouncePercentage:   api.NewOptFloat32(page.BounceRate),
+			Duration:           api.NewOptInt(page.Duration),
+		})
+	}
+
+	return &resp, nil
 }
 
 func (h *Handler) GetWebsiteIDLanguage(ctx context.Context, params api.GetWebsiteIDLanguageParams) (api.GetWebsiteIDLanguageRes, error) {
@@ -676,8 +649,7 @@ func (h *Handler) GetWebsiteIDLanguage(ctx context.Context, params api.GetWebsit
 	// Create filter for database query
 	filters := db.CreateFilters(params, params.Hostname)
 
-	switch params.Summary.Value {
-	case true:
+	if params.Summary.Value {
 		// Get summary
 		languages, err := h.analyticsDB.GetWebsiteLanguagesSummary(ctx, params.Locale.Value, filters)
 		if err != nil {
@@ -698,32 +670,30 @@ func (h *Handler) GetWebsiteIDLanguage(ctx context.Context, params api.GetWebsit
 		}
 
 		return &resp, nil
-	case false:
-		// Get languages
-		languages, err := h.analyticsDB.GetWebsiteLanguages(ctx, params.Locale.Value, filters)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Bool("summary", params.Summary.Value).
-				Msg("failed to get website languages")
-			return ErrInternalServerError(err), nil
-		}
-
-		resp := make(api.StatsLanguages, 0, len(languages))
-		for _, page := range languages {
-			resp = append(resp, api.StatsLanguagesItem{
-				Language:           page.Language,
-				Visitors:           page.Visitors,
-				VisitorsPercentage: page.VisitorsPercentage,
-				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
-				Duration:           api.NewOptInt(page.Duration),
-			})
-		}
-
-		return &resp, nil
-	default:
-		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
+
+	// Get languages
+	languages, err := h.analyticsDB.GetWebsiteLanguages(ctx, params.Locale.Value, filters)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Bool("summary", params.Summary.Value).
+			Msg("failed to get website languages")
+		return ErrInternalServerError(err), nil
+	}
+
+	resp := make(api.StatsLanguages, 0, len(languages))
+	for _, page := range languages {
+		resp = append(resp, api.StatsLanguagesItem{
+			Language:           page.Language,
+			Visitors:           page.Visitors,
+			VisitorsPercentage: page.VisitorsPercentage,
+			BouncePercentage:   api.NewOptFloat32(page.BounceRate),
+			Duration:           api.NewOptInt(page.Duration),
+		})
+	}
+
+	return &resp, nil
 }
 
 func (h *Handler) GetWebsiteIDCountry(ctx context.Context, params api.GetWebsiteIDCountryParams) (api.GetWebsiteIDCountryRes, error) {
@@ -739,8 +709,7 @@ func (h *Handler) GetWebsiteIDCountry(ctx context.Context, params api.GetWebsite
 	// Create filter for database query
 	filters := db.CreateFilters(params, params.Hostname)
 
-	switch params.Summary.Value {
-	case true:
+	if params.Summary.Value {
 		// Get summary
 		countries, err := h.analyticsDB.GetWebsiteCountriesSummary(ctx, filters)
 		if err != nil {
@@ -761,30 +730,28 @@ func (h *Handler) GetWebsiteIDCountry(ctx context.Context, params api.GetWebsite
 		}
 
 		return &resp, nil
-	case false:
-		// Get countries
-		countries, err := h.analyticsDB.GetWebsiteCountries(ctx, filters)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Bool("summary", params.Summary.Value).
-				Msg("failed to get website countries")
-			return ErrInternalServerError(err), nil
-		}
-
-		resp := make(api.StatsCountries, 0, len(countries))
-		for _, page := range countries {
-			resp = append(resp, api.StatsCountriesItem{
-				Country:            page.Country,
-				Visitors:           page.Visitors,
-				VisitorsPercentage: page.VisitorsPercentage,
-				BouncePercentage:   api.NewOptFloat32(page.BounceRate),
-				Duration:           api.NewOptInt(page.Duration),
-			})
-		}
-
-		return &resp, nil
-	default:
-		return ErrBadRequest(model.ErrInvalidParameter), nil
 	}
+
+	// Get countries
+	countries, err := h.analyticsDB.GetWebsiteCountries(ctx, filters)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Bool("summary", params.Summary.Value).
+			Msg("failed to get website countries")
+		return ErrInternalServerError(err), nil
+	}
+
+	resp := make(api.StatsCountries, 0, len(countries))
+	for _, page := range countries {
+		resp = append(resp, api.StatsCountriesItem{
+			Country:            page.Country,
+			Visitors:           page.Visitors,
+			VisitorsPercentage: page.VisitorsPercentage,
+			BouncePercentage:   api.NewOptFloat32(page.BounceRate),
+			Duration:           api.NewOptInt(page.Duration),
+		})
+	}
+
+	return &resp, nil
 }


### PR DESCRIPTION
Small performance improvement and refactor to pre-allocate response arrays as we already know the length of results.

Additionally, remove the switch case branch with a simple if statement for each response with a summary parameter. This makes the code a little cleaner and has a very negligible improvement in branching performance (although the compiler optimiser does benefit from this).