### PR TITLE
build(dashboard): use vite plugin to inject custom media properties

### DIFF
--- a/dashboard/app/components/DatePicker.module.css
+++ b/dashboard/app/components/DatePicker.module.css
@@ -1,5 +1,3 @@
-@import "../styles/_media.css";
-
 .button {
 	composes: dropdown option from "./DropdownSelect.module.css";
 	text-align: left;

--- a/dashboard/app/components/DropdownSelect.module.css
+++ b/dashboard/app/components/DropdownSelect.module.css
@@ -1,5 +1,3 @@
-@import "../styles/_media.css";
-
 .trigger {
 	composes: button from global;
 	min-width: 192px;

--- a/dashboard/app/components/layout/Error.module.css
+++ b/dashboard/app/components/layout/Error.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .root {
 	padding-top: 30vh;
 }

--- a/dashboard/app/components/layout/Header.module.css
+++ b/dashboard/app/components/layout/Header.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .header {
 	color: var(--text-light);
 	background-color: var(--bg-dark);

--- a/dashboard/app/components/layout/InnerHeader.module.css
+++ b/dashboard/app/components/layout/InnerHeader.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .header {
 	color: var(--text-light);
 	background-color: var(--bg-dark);

--- a/dashboard/app/components/login/Login.module.css
+++ b/dashboard/app/components/login/Login.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .wrapper {
 	margin: 0 auto;
 	padding: 32px;

--- a/dashboard/app/components/settings/Code.module.css
+++ b/dashboard/app/components/settings/Code.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .root {
 	width: 100%;
 	overflow: hidden;

--- a/dashboard/app/components/settings/Layout.module.css
+++ b/dashboard/app/components/settings/Layout.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .wrapper {
 	composes: group from global;
 	width: 100%;

--- a/dashboard/app/components/settings/Section.module.css
+++ b/dashboard/app/components/settings/Section.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .wrapper {
 	width: 100%;
 	padding: 32px 24px 8px 24px;

--- a/dashboard/app/components/settings/Sidebar.module.css
+++ b/dashboard/app/components/settings/Sidebar.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .wrapper {
 	composes: flex from global;
 

--- a/dashboard/app/components/settings/WebsiteSelector.module.css
+++ b/dashboard/app/components/settings/WebsiteSelector.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .target {
 	min-width: 192px;
 	height: 40px;

--- a/dashboard/app/components/stats/Combobox.module.css
+++ b/dashboard/app/components/stats/Combobox.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .select-wrapper {
 	width: 100%;
 	padding: 12px 8px 2px 8px;

--- a/dashboard/app/components/stats/Filter.module.css
+++ b/dashboard/app/components/stats/Filter.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .popover {
 	padding: 16px 16px 12px 16px;
 	gap: 16px;

--- a/dashboard/app/components/stats/HeaderDataBox.module.css
+++ b/dashboard/app/components/stats/HeaderDataBox.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .databox {
 	height: 132px;
 	width: 192px;

--- a/dashboard/app/components/stats/StatsHeader.module.css
+++ b/dashboard/app/components/stats/StatsHeader.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .title {
 	padding: 12px 0;
 

--- a/dashboard/app/components/stats/StatsItem.module.css
+++ b/dashboard/app/components/stats/StatsItem.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .item {
 	height: 50px;
 	margin: 6px 8px;

--- a/dashboard/app/components/stats/Table.module.css
+++ b/dashboard/app/components/stats/Table.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .root {
 	background-color: var(--bg-grey);
 

--- a/dashboard/app/components/stats/Tabs.module.css
+++ b/dashboard/app/components/stats/Tabs.module.css
@@ -1,5 +1,3 @@
-@import "../../styles/_media.css";
-
 .grid {
 	width: 100%;
 	background-color: var(--bg-grey);

--- a/dashboard/app/styles/Button.css
+++ b/dashboard/app/styles/Button.css
@@ -1,5 +1,4 @@
-@import "./_media.css";
-
+@charset "UTF-8";
 .button {
 	height: 40px;
 

--- a/dashboard/app/styles/Layout.css
+++ b/dashboard/app/styles/Layout.css
@@ -1,5 +1,3 @@
-@import "./_media.css";
-
 .flex {
 	display: flex;
 	flex-direction: column;

--- a/dashboard/app/styles/global.css
+++ b/dashboard/app/styles/global.css
@@ -1,6 +1,4 @@
-@import "./_media.css";
-
-:root  {
+:root {
 	/* Text Colors */
 	--text-light: #fcfcfc;
 	--text-dark: #111111;

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,12 +1,15 @@
 import { vitePlugin as remix } from '@remix-run/dev';
 import browserslist from 'browserslist';
 import { browserslistToTargets } from 'lightningcss';
+import fs from 'node:fs';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 const targets = browserslistToTargets(
 	browserslist('defaults and fully supports es6-module'),
 );
+
+const customMedia = fs.readFileSync('./app/styles/_media.css', 'utf-8');
 
 export default defineConfig({
 	build: {
@@ -22,6 +25,15 @@ export default defineConfig({
 		},
 	},
 	plugins: [
+		{
+			name: 'css-additional-data',
+			enforce: 'pre',
+			transform(code, id) {
+				if (id.endsWith('.css')) {
+					return `${customMedia}\n${code}`;
+				}
+			},
+		},
 		remix({
 			ssr: false,
 		}),

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,7 +1,7 @@
+import fs from 'node:fs';
 import { vitePlugin as remix } from '@remix-run/dev';
 import browserslist from 'browserslist';
 import { browserslistToTargets } from 'lightningcss';
-import fs from 'node:fs';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 


### PR DESCRIPTION
This replaces the `@custom-media` workaround in using `@import` rules with a Vite plugin instead to import the global `@custom-media` rules programatically.

Reference: https://github.com/vitejs/vite/issues/17724