### PR TITLE
feat: include x-api-commit header for client cahe busting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Save GitHub tag and commit sha to environment
         run: |
           echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Install ARM64 toolchain
         if: matrix.os == 'ubuntu-latest' && matrix.arch == 'arm64'

--- a/core/api/oas_json_gen.go
+++ b/core/api/oas_json_gen.go
@@ -1578,56 +1578,6 @@ func (s *ForbiddenErrorError) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
-// Encode encodes GetWebsitesOKApplicationJSON as json.
-func (s GetWebsitesOKApplicationJSON) Encode(e *jx.Encoder) {
-	unwrapped := []WebsiteGet(s)
-
-	e.ArrStart()
-	for _, elem := range unwrapped {
-		elem.Encode(e)
-	}
-	e.ArrEnd()
-}
-
-// Decode decodes GetWebsitesOKApplicationJSON from json.
-func (s *GetWebsitesOKApplicationJSON) Decode(d *jx.Decoder) error {
-	if s == nil {
-		return errors.New("invalid: unable to decode GetWebsitesOKApplicationJSON to nil")
-	}
-	var unwrapped []WebsiteGet
-	if err := func() error {
-		unwrapped = make([]WebsiteGet, 0)
-		if err := d.Arr(func(d *jx.Decoder) error {
-			var elem WebsiteGet
-			if err := elem.Decode(d); err != nil {
-				return err
-			}
-			unwrapped = append(unwrapped, elem)
-			return nil
-		}); err != nil {
-			return err
-		}
-		return nil
-	}(); err != nil {
-		return errors.Wrap(err, "alias")
-	}
-	*s = GetWebsitesOKApplicationJSON(unwrapped)
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s GetWebsitesOKApplicationJSON) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *GetWebsitesOKApplicationJSON) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
 // Encode implements json.Marshaler.
 func (s *InternalServerError) Encode(e *jx.Encoder) {
 	e.ObjStart()

--- a/core/api/oas_response_encoders_gen.go
+++ b/core/api/oas_response_encoders_gen.go
@@ -16,64 +16,178 @@ import (
 func encodeDeleteUserResponse(response DeleteUserRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
 	case *DeleteUserNoContent:
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(204)
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -88,64 +202,178 @@ func encodeDeleteUserResponse(response DeleteUserRes, w http.ResponseWriter) err
 func encodeDeleteWebsitesIDResponse(response DeleteWebsitesIDRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
 	case *DeleteWebsitesIDNoContent:
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(204)
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -198,24 +426,62 @@ func encodeGetEventPingResponse(response GetEventPingRes, w http.ResponseWriter)
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -229,60 +495,155 @@ func encodeGetEventPingResponse(response GetEventPingRes, w http.ResponseWriter)
 
 func encodeGetUserResponse(response GetUserRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *UserGet:
+	case *UserGetHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -296,36 +657,93 @@ func encodeGetUserResponse(response GetUserRes, w http.ResponseWriter) error {
 
 func encodeGetUserUsageResponse(response GetUserUsageRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *UserUsageGet:
+	case *UserUsageGetHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -339,72 +757,186 @@ func encodeGetUserUsageResponse(response GetUserUsageRes, w http.ResponseWriter)
 
 func encodeGetWebsiteIDBrowsersResponse(response GetWebsiteIDBrowsersRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsBrowsers:
+	case *StatsBrowsersHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -418,72 +950,186 @@ func encodeGetWebsiteIDBrowsersResponse(response GetWebsiteIDBrowsersRes, w http
 
 func encodeGetWebsiteIDCampaignsResponse(response GetWebsiteIDCampaignsRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsUTMCampaigns:
+	case *StatsUTMCampaignsHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -497,72 +1143,186 @@ func encodeGetWebsiteIDCampaignsResponse(response GetWebsiteIDCampaignsRes, w ht
 
 func encodeGetWebsiteIDCountryResponse(response GetWebsiteIDCountryRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsCountries:
+	case *StatsCountriesHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -576,72 +1336,186 @@ func encodeGetWebsiteIDCountryResponse(response GetWebsiteIDCountryRes, w http.R
 
 func encodeGetWebsiteIDDeviceResponse(response GetWebsiteIDDeviceRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsDevices:
+	case *StatsDevicesHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -655,72 +1529,186 @@ func encodeGetWebsiteIDDeviceResponse(response GetWebsiteIDDeviceRes, w http.Res
 
 func encodeGetWebsiteIDLanguageResponse(response GetWebsiteIDLanguageRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsLanguages:
+	case *StatsLanguagesHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -734,72 +1722,186 @@ func encodeGetWebsiteIDLanguageResponse(response GetWebsiteIDLanguageRes, w http
 
 func encodeGetWebsiteIDMediumsResponse(response GetWebsiteIDMediumsRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsUTMMediums:
+	case *StatsUTMMediumsHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -813,72 +1915,186 @@ func encodeGetWebsiteIDMediumsResponse(response GetWebsiteIDMediumsRes, w http.R
 
 func encodeGetWebsiteIDOsResponse(response GetWebsiteIDOsRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsOS:
+	case *StatsOSHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -892,60 +2108,155 @@ func encodeGetWebsiteIDOsResponse(response GetWebsiteIDOsRes, w http.ResponseWri
 
 func encodeGetWebsiteIDPagesResponse(response GetWebsiteIDPagesRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsPages:
+	case *StatsPagesHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -959,72 +2270,186 @@ func encodeGetWebsiteIDPagesResponse(response GetWebsiteIDPagesRes, w http.Respo
 
 func encodeGetWebsiteIDPropertiesResponse(response GetWebsiteIDPropertiesRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsProperties:
+	case *StatsPropertiesHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -1038,72 +2463,186 @@ func encodeGetWebsiteIDPropertiesResponse(response GetWebsiteIDPropertiesRes, w 
 
 func encodeGetWebsiteIDReferrersResponse(response GetWebsiteIDReferrersRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsReferrers:
+	case *StatsReferrersHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -1117,72 +2656,186 @@ func encodeGetWebsiteIDReferrersResponse(response GetWebsiteIDReferrersRes, w ht
 
 func encodeGetWebsiteIDSourcesResponse(response GetWebsiteIDSourcesRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsUTMSources:
+	case *StatsUTMSourcesHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -1196,60 +2849,155 @@ func encodeGetWebsiteIDSourcesResponse(response GetWebsiteIDSourcesRes, w http.R
 
 func encodeGetWebsiteIDSummaryResponse(response GetWebsiteIDSummaryRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsSummary:
+	case *StatsSummaryHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -1263,60 +3011,155 @@ func encodeGetWebsiteIDSummaryResponse(response GetWebsiteIDSummaryRes, w http.R
 
 func encodeGetWebsiteIDTimeResponse(response GetWebsiteIDTimeRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *StatsTime:
+	case *StatsTimeHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -1330,60 +3173,159 @@ func encodeGetWebsiteIDTimeResponse(response GetWebsiteIDTimeRes, w http.Respons
 
 func encodeGetWebsitesResponse(response GetWebsitesRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *GetWebsitesOKApplicationJSON:
+	case *GetWebsitesOKHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		e.ArrStart()
+		for _, elem := range response.Response {
+			elem.Encode(e)
+		}
+		e.ArrEnd()
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -1397,60 +3339,155 @@ func encodeGetWebsitesResponse(response GetWebsitesRes, w http.ResponseWriter) e
 
 func encodeGetWebsitesIDResponse(response GetWebsitesIDRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *WebsiteGet:
+	case *WebsiteGetHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -1464,84 +3501,217 @@ func encodeGetWebsitesIDResponse(response GetWebsitesIDRes, w http.ResponseWrite
 
 func encodePatchUserResponse(response PatchUserRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *UserGet:
+	case *UserGetHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ConflictError:
+	case *ConflictErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(409)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -1555,72 +3725,186 @@ func encodePatchUserResponse(response PatchUserRes, w http.ResponseWriter) error
 
 func encodePatchWebsitesIDResponse(response PatchWebsitesIDRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *WebsiteGet:
+	case *WebsiteGetHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(200)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -1650,41 +3934,113 @@ func encodePostAuthLoginResponse(response PostAuthLoginRes, w http.ResponseWrite
 					return errors.Wrap(err, "encode Set-Cookie header")
 				}
 			}
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
 		}
 		w.WriteHeader(200)
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -1714,29 +4070,82 @@ func encodePostAuthLogoutResponse(response PostAuthLogoutRes, w http.ResponseWri
 					return errors.Wrap(err, "encode Set-Cookie header")
 				}
 			}
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
 		}
 		w.WriteHeader(204)
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -1755,36 +4164,93 @@ func encodePostEventHitResponse(response PostEventHitRes, w http.ResponseWriter)
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *NotFoundError:
+	case *NotFoundErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(404)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
@@ -1798,72 +4264,186 @@ func encodePostEventHitResponse(response PostEventHitRes, w http.ResponseWriter)
 
 func encodePostWebsitesResponse(response PostWebsitesRes, w http.ResponseWriter) error {
 	switch response := response.(type) {
-	case *WebsiteGet:
+	case *WebsiteGetHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(201)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *BadRequestError:
+	case *BadRequestErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(400)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *UnauthorisedError:
+	case *UnauthorisedErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(401)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ForbiddenError:
+	case *ForbiddenErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(403)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *ConflictError:
+	case *ConflictErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(409)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}
 
 		return nil
 
-	case *InternalServerError:
+	case *InternalServerErrorHeaders:
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Encoding response headers.
+		{
+			h := uri.NewHeaderEncoder(w.Header())
+			// Encode "X-API-Commit" header.
+			{
+				cfg := uri.HeaderParameterEncodingConfig{
+					Name:    "X-API-Commit",
+					Explode: false,
+				}
+				if err := h.EncodeParam(cfg, func(e uri.Encoder) error {
+					if val, ok := response.XAPICommit.Get(); ok {
+						return e.EncodeValue(conv.StringToString(val))
+					}
+					return nil
+				}); err != nil {
+					return errors.Wrap(err, "encode X-API-Commit header")
+				}
+			}
+		}
 		w.WriteHeader(500)
 
 		e := new(jx.Encoder)
-		response.Encode(e)
+		response.Response.Encode(e)
 		if _, err := e.WriteTo(w); err != nil {
 			return errors.Wrap(err, "write")
 		}

--- a/core/api/oas_schemas_gen.go
+++ b/core/api/oas_schemas_gen.go
@@ -51,31 +51,6 @@ func (s *BadRequestError) SetError(val BadRequestErrorError) {
 	s.Error = val
 }
 
-func (*BadRequestError) deleteUserRes()             {}
-func (*BadRequestError) deleteWebsitesIDRes()       {}
-func (*BadRequestError) getEventPingRes()           {}
-func (*BadRequestError) getUserRes()                {}
-func (*BadRequestError) getWebsiteIDBrowsersRes()   {}
-func (*BadRequestError) getWebsiteIDCampaignsRes()  {}
-func (*BadRequestError) getWebsiteIDCountryRes()    {}
-func (*BadRequestError) getWebsiteIDDeviceRes()     {}
-func (*BadRequestError) getWebsiteIDLanguageRes()   {}
-func (*BadRequestError) getWebsiteIDMediumsRes()    {}
-func (*BadRequestError) getWebsiteIDOsRes()         {}
-func (*BadRequestError) getWebsiteIDPagesRes()      {}
-func (*BadRequestError) getWebsiteIDPropertiesRes() {}
-func (*BadRequestError) getWebsiteIDReferrersRes()  {}
-func (*BadRequestError) getWebsiteIDSourcesRes()    {}
-func (*BadRequestError) getWebsiteIDSummaryRes()    {}
-func (*BadRequestError) getWebsiteIDTimeRes()       {}
-func (*BadRequestError) getWebsitesIDRes()          {}
-func (*BadRequestError) getWebsitesRes()            {}
-func (*BadRequestError) patchUserRes()              {}
-func (*BadRequestError) patchWebsitesIDRes()        {}
-func (*BadRequestError) postAuthLoginRes()          {}
-func (*BadRequestError) postEventHitRes()           {}
-func (*BadRequestError) postWebsitesRes()           {}
-
 type BadRequestErrorError struct {
 	Code    int32  `json:"code"`
 	Message string `json:"message"`
@@ -101,6 +76,57 @@ func (s *BadRequestErrorError) SetMessage(val string) {
 	s.Message = val
 }
 
+// BadRequestErrorHeaders wraps BadRequestError with response headers.
+type BadRequestErrorHeaders struct {
+	XAPICommit OptString
+	Response   BadRequestError
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *BadRequestErrorHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *BadRequestErrorHeaders) GetResponse() BadRequestError {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *BadRequestErrorHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *BadRequestErrorHeaders) SetResponse(val BadRequestError) {
+	s.Response = val
+}
+
+func (*BadRequestErrorHeaders) deleteUserRes()             {}
+func (*BadRequestErrorHeaders) deleteWebsitesIDRes()       {}
+func (*BadRequestErrorHeaders) getEventPingRes()           {}
+func (*BadRequestErrorHeaders) getUserRes()                {}
+func (*BadRequestErrorHeaders) getWebsiteIDBrowsersRes()   {}
+func (*BadRequestErrorHeaders) getWebsiteIDCampaignsRes()  {}
+func (*BadRequestErrorHeaders) getWebsiteIDCountryRes()    {}
+func (*BadRequestErrorHeaders) getWebsiteIDDeviceRes()     {}
+func (*BadRequestErrorHeaders) getWebsiteIDLanguageRes()   {}
+func (*BadRequestErrorHeaders) getWebsiteIDMediumsRes()    {}
+func (*BadRequestErrorHeaders) getWebsiteIDOsRes()         {}
+func (*BadRequestErrorHeaders) getWebsiteIDPagesRes()      {}
+func (*BadRequestErrorHeaders) getWebsiteIDPropertiesRes() {}
+func (*BadRequestErrorHeaders) getWebsiteIDReferrersRes()  {}
+func (*BadRequestErrorHeaders) getWebsiteIDSourcesRes()    {}
+func (*BadRequestErrorHeaders) getWebsiteIDSummaryRes()    {}
+func (*BadRequestErrorHeaders) getWebsiteIDTimeRes()       {}
+func (*BadRequestErrorHeaders) getWebsitesIDRes()          {}
+func (*BadRequestErrorHeaders) getWebsitesRes()            {}
+func (*BadRequestErrorHeaders) patchUserRes()              {}
+func (*BadRequestErrorHeaders) patchWebsitesIDRes()        {}
+func (*BadRequestErrorHeaders) postAuthLoginRes()          {}
+func (*BadRequestErrorHeaders) postEventHitRes()           {}
+func (*BadRequestErrorHeaders) postWebsitesRes()           {}
+
 type ConflictError struct {
 	Error ConflictErrorError `json:"error"`
 }
@@ -114,9 +140,6 @@ func (s *ConflictError) GetError() ConflictErrorError {
 func (s *ConflictError) SetError(val ConflictErrorError) {
 	s.Error = val
 }
-
-func (*ConflictError) patchUserRes()    {}
-func (*ConflictError) postWebsitesRes() {}
 
 type ConflictErrorError struct {
 	Code    int32  `json:"code"`
@@ -143,6 +166,35 @@ func (s *ConflictErrorError) SetMessage(val string) {
 	s.Message = val
 }
 
+// ConflictErrorHeaders wraps ConflictError with response headers.
+type ConflictErrorHeaders struct {
+	XAPICommit OptString
+	Response   ConflictError
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *ConflictErrorHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *ConflictErrorHeaders) GetResponse() ConflictError {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *ConflictErrorHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *ConflictErrorHeaders) SetResponse(val ConflictError) {
+	s.Response = val
+}
+
+func (*ConflictErrorHeaders) patchUserRes()    {}
+func (*ConflictErrorHeaders) postWebsitesRes() {}
+
 type CookieAuth struct {
 	APIKey string
 }
@@ -158,12 +210,36 @@ func (s *CookieAuth) SetAPIKey(val string) {
 }
 
 // DeleteUserNoContent is response for DeleteUser operation.
-type DeleteUserNoContent struct{}
+type DeleteUserNoContent struct {
+	XAPICommit OptString
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *DeleteUserNoContent) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *DeleteUserNoContent) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
 
 func (*DeleteUserNoContent) deleteUserRes() {}
 
 // DeleteWebsitesIDNoContent is response for DeleteWebsitesID operation.
-type DeleteWebsitesIDNoContent struct{}
+type DeleteWebsitesIDNoContent struct {
+	XAPICommit OptString
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *DeleteWebsitesIDNoContent) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *DeleteWebsitesIDNoContent) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
 
 func (*DeleteWebsitesIDNoContent) deleteWebsitesIDRes() {}
 
@@ -760,22 +836,6 @@ func (s *ForbiddenError) SetError(val ForbiddenErrorError) {
 	s.Error = val
 }
 
-func (*ForbiddenError) deleteUserRes()             {}
-func (*ForbiddenError) deleteWebsitesIDRes()       {}
-func (*ForbiddenError) getWebsiteIDBrowsersRes()   {}
-func (*ForbiddenError) getWebsiteIDCampaignsRes()  {}
-func (*ForbiddenError) getWebsiteIDCountryRes()    {}
-func (*ForbiddenError) getWebsiteIDDeviceRes()     {}
-func (*ForbiddenError) getWebsiteIDLanguageRes()   {}
-func (*ForbiddenError) getWebsiteIDMediumsRes()    {}
-func (*ForbiddenError) getWebsiteIDOsRes()         {}
-func (*ForbiddenError) getWebsiteIDPropertiesRes() {}
-func (*ForbiddenError) getWebsiteIDReferrersRes()  {}
-func (*ForbiddenError) getWebsiteIDSourcesRes()    {}
-func (*ForbiddenError) patchUserRes()              {}
-func (*ForbiddenError) patchWebsitesIDRes()        {}
-func (*ForbiddenError) postWebsitesRes()           {}
-
 type ForbiddenErrorError struct {
 	Code    int32  `json:"code"`
 	Message string `json:"message"`
@@ -800,6 +860,48 @@ func (s *ForbiddenErrorError) SetCode(val int32) {
 func (s *ForbiddenErrorError) SetMessage(val string) {
 	s.Message = val
 }
+
+// ForbiddenErrorHeaders wraps ForbiddenError with response headers.
+type ForbiddenErrorHeaders struct {
+	XAPICommit OptString
+	Response   ForbiddenError
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *ForbiddenErrorHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *ForbiddenErrorHeaders) GetResponse() ForbiddenError {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *ForbiddenErrorHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *ForbiddenErrorHeaders) SetResponse(val ForbiddenError) {
+	s.Response = val
+}
+
+func (*ForbiddenErrorHeaders) deleteUserRes()             {}
+func (*ForbiddenErrorHeaders) deleteWebsitesIDRes()       {}
+func (*ForbiddenErrorHeaders) getWebsiteIDBrowsersRes()   {}
+func (*ForbiddenErrorHeaders) getWebsiteIDCampaignsRes()  {}
+func (*ForbiddenErrorHeaders) getWebsiteIDCountryRes()    {}
+func (*ForbiddenErrorHeaders) getWebsiteIDDeviceRes()     {}
+func (*ForbiddenErrorHeaders) getWebsiteIDLanguageRes()   {}
+func (*ForbiddenErrorHeaders) getWebsiteIDMediumsRes()    {}
+func (*ForbiddenErrorHeaders) getWebsiteIDOsRes()         {}
+func (*ForbiddenErrorHeaders) getWebsiteIDPropertiesRes() {}
+func (*ForbiddenErrorHeaders) getWebsiteIDReferrersRes()  {}
+func (*ForbiddenErrorHeaders) getWebsiteIDSourcesRes()    {}
+func (*ForbiddenErrorHeaders) patchUserRes()              {}
+func (*ForbiddenErrorHeaders) patchWebsitesIDRes()        {}
+func (*ForbiddenErrorHeaders) postWebsitesRes()           {}
 
 // This is set to 0 if the user is a unique user, otherwise 1.
 type GetEventPingOK struct {
@@ -917,9 +1019,33 @@ func (s *GetWebsiteIDSummaryInterval) UnmarshalText(data []byte) error {
 	}
 }
 
-type GetWebsitesOKApplicationJSON []WebsiteGet
+// GetWebsitesOKHeaders wraps []WebsiteGet with response headers.
+type GetWebsitesOKHeaders struct {
+	XAPICommit OptString
+	Response   []WebsiteGet
+}
 
-func (*GetWebsitesOKApplicationJSON) getWebsitesRes() {}
+// GetXAPICommit returns the value of XAPICommit.
+func (s *GetWebsitesOKHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *GetWebsitesOKHeaders) GetResponse() []WebsiteGet {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *GetWebsitesOKHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *GetWebsitesOKHeaders) SetResponse(val []WebsiteGet) {
+	s.Response = val
+}
+
+func (*GetWebsitesOKHeaders) getWebsitesRes() {}
 
 type InternalServerError struct {
 	Error InternalServerErrorError `json:"error"`
@@ -934,33 +1060,6 @@ func (s *InternalServerError) GetError() InternalServerErrorError {
 func (s *InternalServerError) SetError(val InternalServerErrorError) {
 	s.Error = val
 }
-
-func (*InternalServerError) deleteUserRes()             {}
-func (*InternalServerError) deleteWebsitesIDRes()       {}
-func (*InternalServerError) getEventPingRes()           {}
-func (*InternalServerError) getUserRes()                {}
-func (*InternalServerError) getUserUsageRes()           {}
-func (*InternalServerError) getWebsiteIDBrowsersRes()   {}
-func (*InternalServerError) getWebsiteIDCampaignsRes()  {}
-func (*InternalServerError) getWebsiteIDCountryRes()    {}
-func (*InternalServerError) getWebsiteIDDeviceRes()     {}
-func (*InternalServerError) getWebsiteIDLanguageRes()   {}
-func (*InternalServerError) getWebsiteIDMediumsRes()    {}
-func (*InternalServerError) getWebsiteIDOsRes()         {}
-func (*InternalServerError) getWebsiteIDPagesRes()      {}
-func (*InternalServerError) getWebsiteIDPropertiesRes() {}
-func (*InternalServerError) getWebsiteIDReferrersRes()  {}
-func (*InternalServerError) getWebsiteIDSourcesRes()    {}
-func (*InternalServerError) getWebsiteIDSummaryRes()    {}
-func (*InternalServerError) getWebsiteIDTimeRes()       {}
-func (*InternalServerError) getWebsitesIDRes()          {}
-func (*InternalServerError) getWebsitesRes()            {}
-func (*InternalServerError) patchUserRes()              {}
-func (*InternalServerError) patchWebsitesIDRes()        {}
-func (*InternalServerError) postAuthLoginRes()          {}
-func (*InternalServerError) postAuthLogoutRes()         {}
-func (*InternalServerError) postEventHitRes()           {}
-func (*InternalServerError) postWebsitesRes()           {}
 
 type InternalServerErrorError struct {
 	Code    int32  `json:"code"`
@@ -987,6 +1086,59 @@ func (s *InternalServerErrorError) SetMessage(val string) {
 	s.Message = val
 }
 
+// InternalServerErrorHeaders wraps InternalServerError with response headers.
+type InternalServerErrorHeaders struct {
+	XAPICommit OptString
+	Response   InternalServerError
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *InternalServerErrorHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *InternalServerErrorHeaders) GetResponse() InternalServerError {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *InternalServerErrorHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *InternalServerErrorHeaders) SetResponse(val InternalServerError) {
+	s.Response = val
+}
+
+func (*InternalServerErrorHeaders) deleteUserRes()             {}
+func (*InternalServerErrorHeaders) deleteWebsitesIDRes()       {}
+func (*InternalServerErrorHeaders) getEventPingRes()           {}
+func (*InternalServerErrorHeaders) getUserRes()                {}
+func (*InternalServerErrorHeaders) getUserUsageRes()           {}
+func (*InternalServerErrorHeaders) getWebsiteIDBrowsersRes()   {}
+func (*InternalServerErrorHeaders) getWebsiteIDCampaignsRes()  {}
+func (*InternalServerErrorHeaders) getWebsiteIDCountryRes()    {}
+func (*InternalServerErrorHeaders) getWebsiteIDDeviceRes()     {}
+func (*InternalServerErrorHeaders) getWebsiteIDLanguageRes()   {}
+func (*InternalServerErrorHeaders) getWebsiteIDMediumsRes()    {}
+func (*InternalServerErrorHeaders) getWebsiteIDOsRes()         {}
+func (*InternalServerErrorHeaders) getWebsiteIDPagesRes()      {}
+func (*InternalServerErrorHeaders) getWebsiteIDPropertiesRes() {}
+func (*InternalServerErrorHeaders) getWebsiteIDReferrersRes()  {}
+func (*InternalServerErrorHeaders) getWebsiteIDSourcesRes()    {}
+func (*InternalServerErrorHeaders) getWebsiteIDSummaryRes()    {}
+func (*InternalServerErrorHeaders) getWebsiteIDTimeRes()       {}
+func (*InternalServerErrorHeaders) getWebsitesIDRes()          {}
+func (*InternalServerErrorHeaders) getWebsitesRes()            {}
+func (*InternalServerErrorHeaders) patchUserRes()              {}
+func (*InternalServerErrorHeaders) patchWebsitesIDRes()        {}
+func (*InternalServerErrorHeaders) postAuthLoginRes()          {}
+func (*InternalServerErrorHeaders) postAuthLogoutRes()         {}
+func (*InternalServerErrorHeaders) postEventHitRes()           {}
+func (*InternalServerErrorHeaders) postWebsitesRes()           {}
+
 type NotFoundError struct {
 	Error NotFoundErrorError `json:"error"`
 }
@@ -1000,28 +1152,6 @@ func (s *NotFoundError) GetError() NotFoundErrorError {
 func (s *NotFoundError) SetError(val NotFoundErrorError) {
 	s.Error = val
 }
-
-func (*NotFoundError) deleteUserRes()             {}
-func (*NotFoundError) deleteWebsitesIDRes()       {}
-func (*NotFoundError) getUserRes()                {}
-func (*NotFoundError) getWebsiteIDBrowsersRes()   {}
-func (*NotFoundError) getWebsiteIDCampaignsRes()  {}
-func (*NotFoundError) getWebsiteIDCountryRes()    {}
-func (*NotFoundError) getWebsiteIDDeviceRes()     {}
-func (*NotFoundError) getWebsiteIDLanguageRes()   {}
-func (*NotFoundError) getWebsiteIDMediumsRes()    {}
-func (*NotFoundError) getWebsiteIDOsRes()         {}
-func (*NotFoundError) getWebsiteIDPagesRes()      {}
-func (*NotFoundError) getWebsiteIDPropertiesRes() {}
-func (*NotFoundError) getWebsiteIDReferrersRes()  {}
-func (*NotFoundError) getWebsiteIDSourcesRes()    {}
-func (*NotFoundError) getWebsiteIDSummaryRes()    {}
-func (*NotFoundError) getWebsiteIDTimeRes()       {}
-func (*NotFoundError) getWebsitesIDRes()          {}
-func (*NotFoundError) getWebsitesRes()            {}
-func (*NotFoundError) patchUserRes()              {}
-func (*NotFoundError) patchWebsitesIDRes()        {}
-func (*NotFoundError) postEventHitRes()           {}
 
 type NotFoundErrorError struct {
 	Code    int32  `json:"code"`
@@ -1047,6 +1177,54 @@ func (s *NotFoundErrorError) SetCode(val int32) {
 func (s *NotFoundErrorError) SetMessage(val string) {
 	s.Message = val
 }
+
+// NotFoundErrorHeaders wraps NotFoundError with response headers.
+type NotFoundErrorHeaders struct {
+	XAPICommit OptString
+	Response   NotFoundError
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *NotFoundErrorHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *NotFoundErrorHeaders) GetResponse() NotFoundError {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *NotFoundErrorHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *NotFoundErrorHeaders) SetResponse(val NotFoundError) {
+	s.Response = val
+}
+
+func (*NotFoundErrorHeaders) deleteUserRes()             {}
+func (*NotFoundErrorHeaders) deleteWebsitesIDRes()       {}
+func (*NotFoundErrorHeaders) getUserRes()                {}
+func (*NotFoundErrorHeaders) getWebsiteIDBrowsersRes()   {}
+func (*NotFoundErrorHeaders) getWebsiteIDCampaignsRes()  {}
+func (*NotFoundErrorHeaders) getWebsiteIDCountryRes()    {}
+func (*NotFoundErrorHeaders) getWebsiteIDDeviceRes()     {}
+func (*NotFoundErrorHeaders) getWebsiteIDLanguageRes()   {}
+func (*NotFoundErrorHeaders) getWebsiteIDMediumsRes()    {}
+func (*NotFoundErrorHeaders) getWebsiteIDOsRes()         {}
+func (*NotFoundErrorHeaders) getWebsiteIDPagesRes()      {}
+func (*NotFoundErrorHeaders) getWebsiteIDPropertiesRes() {}
+func (*NotFoundErrorHeaders) getWebsiteIDReferrersRes()  {}
+func (*NotFoundErrorHeaders) getWebsiteIDSourcesRes()    {}
+func (*NotFoundErrorHeaders) getWebsiteIDSummaryRes()    {}
+func (*NotFoundErrorHeaders) getWebsiteIDTimeRes()       {}
+func (*NotFoundErrorHeaders) getWebsitesIDRes()          {}
+func (*NotFoundErrorHeaders) getWebsitesRes()            {}
+func (*NotFoundErrorHeaders) patchUserRes()              {}
+func (*NotFoundErrorHeaders) patchWebsitesIDRes()        {}
+func (*NotFoundErrorHeaders) postEventHitRes()           {}
 
 // NewOptBool returns new OptBool with value set to v.
 func NewOptBool(v bool) OptBool {
@@ -1602,7 +1780,8 @@ func (o OptWebsiteGetSummary) Or(d WebsiteGetSummary) WebsiteGetSummary {
 
 // PostAuthLoginOK is response for PostAuthLogin operation.
 type PostAuthLoginOK struct {
-	SetCookie string
+	SetCookie  string
+	XAPICommit OptString
 }
 
 // GetSetCookie returns the value of SetCookie.
@@ -1610,16 +1789,27 @@ func (s *PostAuthLoginOK) GetSetCookie() string {
 	return s.SetCookie
 }
 
+// GetXAPICommit returns the value of XAPICommit.
+func (s *PostAuthLoginOK) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
 // SetSetCookie sets the value of SetCookie.
 func (s *PostAuthLoginOK) SetSetCookie(val string) {
 	s.SetCookie = val
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *PostAuthLoginOK) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
 }
 
 func (*PostAuthLoginOK) postAuthLoginRes() {}
 
 // PostAuthLogoutNoContent is response for PostAuthLogout operation.
 type PostAuthLogoutNoContent struct {
-	SetCookie string
+	SetCookie  string
+	XAPICommit OptString
 }
 
 // GetSetCookie returns the value of SetCookie.
@@ -1627,9 +1817,19 @@ func (s *PostAuthLogoutNoContent) GetSetCookie() string {
 	return s.SetCookie
 }
 
+// GetXAPICommit returns the value of XAPICommit.
+func (s *PostAuthLogoutNoContent) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
 // SetSetCookie sets the value of SetCookie.
 func (s *PostAuthLogoutNoContent) SetSetCookie(val string) {
 	s.SetCookie = val
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *PostAuthLogoutNoContent) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
 }
 
 func (*PostAuthLogoutNoContent) postAuthLogoutRes() {}
@@ -1641,7 +1841,33 @@ func (*PostEventHitNoContent) postEventHitRes() {}
 
 type StatsBrowsers []StatsBrowsersItem
 
-func (*StatsBrowsers) getWebsiteIDBrowsersRes() {}
+// StatsBrowsersHeaders wraps StatsBrowsers with response headers.
+type StatsBrowsersHeaders struct {
+	XAPICommit OptString
+	Response   StatsBrowsers
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsBrowsersHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsBrowsersHeaders) GetResponse() StatsBrowsers {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsBrowsersHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsBrowsersHeaders) SetResponse(val StatsBrowsers) {
+	s.Response = val
+}
+
+func (*StatsBrowsersHeaders) getWebsiteIDBrowsersRes() {}
 
 type StatsBrowsersItem struct {
 	// Browser name.
@@ -1708,7 +1934,33 @@ func (s *StatsBrowsersItem) SetDuration(val OptInt) {
 
 type StatsCountries []StatsCountriesItem
 
-func (*StatsCountries) getWebsiteIDCountryRes() {}
+// StatsCountriesHeaders wraps StatsCountries with response headers.
+type StatsCountriesHeaders struct {
+	XAPICommit OptString
+	Response   StatsCountries
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsCountriesHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsCountriesHeaders) GetResponse() StatsCountries {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsCountriesHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsCountriesHeaders) SetResponse(val StatsCountries) {
+	s.Response = val
+}
+
+func (*StatsCountriesHeaders) getWebsiteIDCountryRes() {}
 
 type StatsCountriesItem struct {
 	// Country name.
@@ -1775,7 +2027,33 @@ func (s *StatsCountriesItem) SetDuration(val OptInt) {
 
 type StatsDevices []StatsDevicesItem
 
-func (*StatsDevices) getWebsiteIDDeviceRes() {}
+// StatsDevicesHeaders wraps StatsDevices with response headers.
+type StatsDevicesHeaders struct {
+	XAPICommit OptString
+	Response   StatsDevices
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsDevicesHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsDevicesHeaders) GetResponse() StatsDevices {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsDevicesHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsDevicesHeaders) SetResponse(val StatsDevices) {
+	s.Response = val
+}
+
+func (*StatsDevicesHeaders) getWebsiteIDDeviceRes() {}
 
 type StatsDevicesItem struct {
 	// Device name.
@@ -1842,7 +2120,33 @@ func (s *StatsDevicesItem) SetDuration(val OptInt) {
 
 type StatsLanguages []StatsLanguagesItem
 
-func (*StatsLanguages) getWebsiteIDLanguageRes() {}
+// StatsLanguagesHeaders wraps StatsLanguages with response headers.
+type StatsLanguagesHeaders struct {
+	XAPICommit OptString
+	Response   StatsLanguages
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsLanguagesHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsLanguagesHeaders) GetResponse() StatsLanguages {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsLanguagesHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsLanguagesHeaders) SetResponse(val StatsLanguages) {
+	s.Response = val
+}
+
+func (*StatsLanguagesHeaders) getWebsiteIDLanguageRes() {}
 
 type StatsLanguagesItem struct {
 	// Language name.
@@ -1909,7 +2213,33 @@ func (s *StatsLanguagesItem) SetDuration(val OptInt) {
 
 type StatsOS []StatsOSItem
 
-func (*StatsOS) getWebsiteIDOsRes() {}
+// StatsOSHeaders wraps StatsOS with response headers.
+type StatsOSHeaders struct {
+	XAPICommit OptString
+	Response   StatsOS
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsOSHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsOSHeaders) GetResponse() StatsOS {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsOSHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsOSHeaders) SetResponse(val StatsOS) {
+	s.Response = val
+}
+
+func (*StatsOSHeaders) getWebsiteIDOsRes() {}
 
 type StatsOSItem struct {
 	// OS name.
@@ -1976,7 +2306,33 @@ func (s *StatsOSItem) SetDuration(val OptInt) {
 
 type StatsPages []StatsPagesItem
 
-func (*StatsPages) getWebsiteIDPagesRes() {}
+// StatsPagesHeaders wraps StatsPages with response headers.
+type StatsPagesHeaders struct {
+	XAPICommit OptString
+	Response   StatsPages
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsPagesHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsPagesHeaders) GetResponse() StatsPages {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsPagesHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsPagesHeaders) SetResponse(val StatsPages) {
+	s.Response = val
+}
+
+func (*StatsPagesHeaders) getWebsiteIDPagesRes() {}
 
 type StatsPagesItem struct {
 	// Pathname of the page.
@@ -2067,7 +2423,33 @@ func (s *StatsPagesItem) SetDuration(val OptInt) {
 
 type StatsProperties []StatsPropertiesItem
 
-func (*StatsProperties) getWebsiteIDPropertiesRes() {}
+// StatsPropertiesHeaders wraps StatsProperties with response headers.
+type StatsPropertiesHeaders struct {
+	XAPICommit OptString
+	Response   StatsProperties
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsPropertiesHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsPropertiesHeaders) GetResponse() StatsProperties {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsPropertiesHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsPropertiesHeaders) SetResponse(val StatsProperties) {
+	s.Response = val
+}
+
+func (*StatsPropertiesHeaders) getWebsiteIDPropertiesRes() {}
 
 type StatsPropertiesItem struct {
 	// Custom property name.
@@ -2122,7 +2504,33 @@ func (s *StatsPropertiesItem) SetEventsPercentage(val float32) {
 
 type StatsReferrers []StatsReferrersItem
 
-func (*StatsReferrers) getWebsiteIDReferrersRes() {}
+// StatsReferrersHeaders wraps StatsReferrers with response headers.
+type StatsReferrersHeaders struct {
+	XAPICommit OptString
+	Response   StatsReferrers
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsReferrersHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsReferrersHeaders) GetResponse() StatsReferrers {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsReferrersHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsReferrersHeaders) SetResponse(val StatsReferrers) {
+	s.Response = val
+}
+
+func (*StatsReferrersHeaders) getWebsiteIDReferrersRes() {}
 
 type StatsReferrersItem struct {
 	// Referrer URL.
@@ -2224,8 +2632,6 @@ func (s *StatsSummary) SetInterval(val []StatsSummaryIntervalItem) {
 	s.Interval = val
 }
 
-func (*StatsSummary) getWebsiteIDSummaryRes() {}
-
 type StatsSummaryCurrent struct {
 	Visitors         int     `json:"visitors"`
 	Pageviews        int     `json:"pageviews"`
@@ -2272,6 +2678,34 @@ func (s *StatsSummaryCurrent) SetBouncePercentage(val float32) {
 func (s *StatsSummaryCurrent) SetDuration(val int) {
 	s.Duration = val
 }
+
+// StatsSummaryHeaders wraps StatsSummary with response headers.
+type StatsSummaryHeaders struct {
+	XAPICommit OptString
+	Response   StatsSummary
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsSummaryHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsSummaryHeaders) GetResponse() StatsSummary {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsSummaryHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsSummaryHeaders) SetResponse(val StatsSummary) {
+	s.Response = val
+}
+
+func (*StatsSummaryHeaders) getWebsiteIDSummaryRes() {}
 
 type StatsSummaryIntervalItem struct {
 	Date             string     `json:"date"`
@@ -2380,7 +2814,33 @@ func (s *StatsSummaryPrevious) SetDuration(val int) {
 
 type StatsTime []StatsTimeItem
 
-func (*StatsTime) getWebsiteIDTimeRes() {}
+// StatsTimeHeaders wraps StatsTime with response headers.
+type StatsTimeHeaders struct {
+	XAPICommit OptString
+	Response   StatsTime
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsTimeHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsTimeHeaders) GetResponse() StatsTime {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsTimeHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsTimeHeaders) SetResponse(val StatsTime) {
+	s.Response = val
+}
+
+func (*StatsTimeHeaders) getWebsiteIDTimeRes() {}
 
 type StatsTimeItem struct {
 	// Pathname of the page.
@@ -2459,7 +2919,33 @@ func (s *StatsTimeItem) SetDurationPercentage(val float32) {
 
 type StatsUTMCampaigns []StatsUTMCampaignsItem
 
-func (*StatsUTMCampaigns) getWebsiteIDCampaignsRes() {}
+// StatsUTMCampaignsHeaders wraps StatsUTMCampaigns with response headers.
+type StatsUTMCampaignsHeaders struct {
+	XAPICommit OptString
+	Response   StatsUTMCampaigns
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsUTMCampaignsHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsUTMCampaignsHeaders) GetResponse() StatsUTMCampaigns {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsUTMCampaignsHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsUTMCampaignsHeaders) SetResponse(val StatsUTMCampaigns) {
+	s.Response = val
+}
+
+func (*StatsUTMCampaignsHeaders) getWebsiteIDCampaignsRes() {}
 
 type StatsUTMCampaignsItem struct {
 	// UTM campaign.
@@ -2526,7 +3012,33 @@ func (s *StatsUTMCampaignsItem) SetDuration(val OptInt) {
 
 type StatsUTMMediums []StatsUTMMediumsItem
 
-func (*StatsUTMMediums) getWebsiteIDMediumsRes() {}
+// StatsUTMMediumsHeaders wraps StatsUTMMediums with response headers.
+type StatsUTMMediumsHeaders struct {
+	XAPICommit OptString
+	Response   StatsUTMMediums
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsUTMMediumsHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsUTMMediumsHeaders) GetResponse() StatsUTMMediums {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsUTMMediumsHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsUTMMediumsHeaders) SetResponse(val StatsUTMMediums) {
+	s.Response = val
+}
+
+func (*StatsUTMMediumsHeaders) getWebsiteIDMediumsRes() {}
 
 type StatsUTMMediumsItem struct {
 	// UTM medium.
@@ -2593,7 +3105,33 @@ func (s *StatsUTMMediumsItem) SetDuration(val OptInt) {
 
 type StatsUTMSources []StatsUTMSourcesItem
 
-func (*StatsUTMSources) getWebsiteIDSourcesRes() {}
+// StatsUTMSourcesHeaders wraps StatsUTMSources with response headers.
+type StatsUTMSourcesHeaders struct {
+	XAPICommit OptString
+	Response   StatsUTMSources
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *StatsUTMSourcesHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *StatsUTMSourcesHeaders) GetResponse() StatsUTMSources {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *StatsUTMSourcesHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *StatsUTMSourcesHeaders) SetResponse(val StatsUTMSources) {
+	s.Response = val
+}
+
+func (*StatsUTMSourcesHeaders) getWebsiteIDSourcesRes() {}
 
 type StatsUTMSourcesItem struct {
 	// UTM source.
@@ -2672,31 +3210,6 @@ func (s *UnauthorisedError) SetError(val UnauthorisedErrorError) {
 	s.Error = val
 }
 
-func (*UnauthorisedError) deleteUserRes()             {}
-func (*UnauthorisedError) deleteWebsitesIDRes()       {}
-func (*UnauthorisedError) getUserRes()                {}
-func (*UnauthorisedError) getUserUsageRes()           {}
-func (*UnauthorisedError) getWebsiteIDBrowsersRes()   {}
-func (*UnauthorisedError) getWebsiteIDCampaignsRes()  {}
-func (*UnauthorisedError) getWebsiteIDCountryRes()    {}
-func (*UnauthorisedError) getWebsiteIDDeviceRes()     {}
-func (*UnauthorisedError) getWebsiteIDLanguageRes()   {}
-func (*UnauthorisedError) getWebsiteIDMediumsRes()    {}
-func (*UnauthorisedError) getWebsiteIDOsRes()         {}
-func (*UnauthorisedError) getWebsiteIDPagesRes()      {}
-func (*UnauthorisedError) getWebsiteIDPropertiesRes() {}
-func (*UnauthorisedError) getWebsiteIDReferrersRes()  {}
-func (*UnauthorisedError) getWebsiteIDSourcesRes()    {}
-func (*UnauthorisedError) getWebsiteIDSummaryRes()    {}
-func (*UnauthorisedError) getWebsiteIDTimeRes()       {}
-func (*UnauthorisedError) getWebsitesIDRes()          {}
-func (*UnauthorisedError) getWebsitesRes()            {}
-func (*UnauthorisedError) patchUserRes()              {}
-func (*UnauthorisedError) patchWebsitesIDRes()        {}
-func (*UnauthorisedError) postAuthLoginRes()          {}
-func (*UnauthorisedError) postAuthLogoutRes()         {}
-func (*UnauthorisedError) postWebsitesRes()           {}
-
 type UnauthorisedErrorError struct {
 	Code    int32  `json:"code"`
 	Message string `json:"message"`
@@ -2721,6 +3234,57 @@ func (s *UnauthorisedErrorError) SetCode(val int32) {
 func (s *UnauthorisedErrorError) SetMessage(val string) {
 	s.Message = val
 }
+
+// UnauthorisedErrorHeaders wraps UnauthorisedError with response headers.
+type UnauthorisedErrorHeaders struct {
+	XAPICommit OptString
+	Response   UnauthorisedError
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *UnauthorisedErrorHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *UnauthorisedErrorHeaders) GetResponse() UnauthorisedError {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *UnauthorisedErrorHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *UnauthorisedErrorHeaders) SetResponse(val UnauthorisedError) {
+	s.Response = val
+}
+
+func (*UnauthorisedErrorHeaders) deleteUserRes()             {}
+func (*UnauthorisedErrorHeaders) deleteWebsitesIDRes()       {}
+func (*UnauthorisedErrorHeaders) getUserRes()                {}
+func (*UnauthorisedErrorHeaders) getUserUsageRes()           {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDBrowsersRes()   {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDCampaignsRes()  {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDCountryRes()    {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDDeviceRes()     {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDLanguageRes()   {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDMediumsRes()    {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDOsRes()         {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDPagesRes()      {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDPropertiesRes() {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDReferrersRes()  {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDSourcesRes()    {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDSummaryRes()    {}
+func (*UnauthorisedErrorHeaders) getWebsiteIDTimeRes()       {}
+func (*UnauthorisedErrorHeaders) getWebsitesIDRes()          {}
+func (*UnauthorisedErrorHeaders) getWebsitesRes()            {}
+func (*UnauthorisedErrorHeaders) patchUserRes()              {}
+func (*UnauthorisedErrorHeaders) patchWebsitesIDRes()        {}
+func (*UnauthorisedErrorHeaders) postAuthLoginRes()          {}
+func (*UnauthorisedErrorHeaders) postAuthLogoutRes()         {}
+func (*UnauthorisedErrorHeaders) postWebsitesRes()           {}
 
 // Response body for getting a user.
 // Ref: #/components/schemas/UserGet
@@ -2771,8 +3335,34 @@ func (s *UserGet) SetDateUpdated(val int64) {
 	s.DateUpdated = val
 }
 
-func (*UserGet) getUserRes()   {}
-func (*UserGet) patchUserRes() {}
+// UserGetHeaders wraps UserGet with response headers.
+type UserGetHeaders struct {
+	XAPICommit OptString
+	Response   UserGet
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *UserGetHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *UserGetHeaders) GetResponse() UserGet {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *UserGetHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *UserGetHeaders) SetResponse(val UserGet) {
+	s.Response = val
+}
+
+func (*UserGetHeaders) getUserRes()   {}
+func (*UserGetHeaders) patchUserRes() {}
 
 // Request body for updating a user.
 // Ref: #/components/schemas/UserPatch
@@ -2959,8 +3549,6 @@ func (s *UserUsageGet) SetDisk(val UserUsageGetDisk) {
 	s.Disk = val
 }
 
-func (*UserUsageGet) getUserUsageRes() {}
-
 type UserUsageGetCPU struct {
 	Usage   float32 `json:"usage"`
 	Cores   int     `json:"cores"`
@@ -3021,6 +3609,34 @@ func (s *UserUsageGetDisk) SetUsed(val int64) {
 func (s *UserUsageGetDisk) SetTotal(val int64) {
 	s.Total = val
 }
+
+// UserUsageGetHeaders wraps UserUsageGet with response headers.
+type UserUsageGetHeaders struct {
+	XAPICommit OptString
+	Response   UserUsageGet
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *UserUsageGetHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *UserUsageGetHeaders) GetResponse() UserUsageGet {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *UserUsageGetHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *UserUsageGetHeaders) SetResponse(val UserUsageGet) {
+	s.Response = val
+}
+
+func (*UserUsageGetHeaders) getUserUsageRes() {}
 
 type UserUsageGetMemory struct {
 	Used  int64 `json:"used"`
@@ -3090,9 +3706,35 @@ func (s *WebsiteGet) SetSummary(val OptWebsiteGetSummary) {
 	s.Summary = val
 }
 
-func (*WebsiteGet) getWebsitesIDRes()   {}
-func (*WebsiteGet) patchWebsitesIDRes() {}
-func (*WebsiteGet) postWebsitesRes()    {}
+// WebsiteGetHeaders wraps WebsiteGet with response headers.
+type WebsiteGetHeaders struct {
+	XAPICommit OptString
+	Response   WebsiteGet
+}
+
+// GetXAPICommit returns the value of XAPICommit.
+func (s *WebsiteGetHeaders) GetXAPICommit() OptString {
+	return s.XAPICommit
+}
+
+// GetResponse returns the value of Response.
+func (s *WebsiteGetHeaders) GetResponse() WebsiteGet {
+	return s.Response
+}
+
+// SetXAPICommit sets the value of XAPICommit.
+func (s *WebsiteGetHeaders) SetXAPICommit(val OptString) {
+	s.XAPICommit = val
+}
+
+// SetResponse sets the value of Response.
+func (s *WebsiteGetHeaders) SetResponse(val WebsiteGet) {
+	s.Response = val
+}
+
+func (*WebsiteGetHeaders) getWebsitesIDRes()   {}
+func (*WebsiteGetHeaders) patchWebsitesIDRes() {}
+func (*WebsiteGetHeaders) postWebsitesRes()    {}
 
 type WebsiteGetSummary struct {
 	Visitors int `json:"visitors"`

--- a/core/api/oas_validators_gen.go
+++ b/core/api/oas_validators_gen.go
@@ -125,24 +125,39 @@ func (s GetWebsiteIDSummaryInterval) Validate() error {
 	}
 }
 
-func (s GetWebsitesOKApplicationJSON) Validate() error {
-	alias := ([]WebsiteGet)(s)
-	if alias == nil {
-		return errors.New("nil is invalid value")
+func (s *GetWebsitesOKHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
 	}
+
 	var failures []validate.FieldError
-	for i, elem := range alias {
-		if err := func() error {
-			if err := elem.Validate(); err != nil {
-				return err
-			}
-			return nil
-		}(); err != nil {
-			failures = append(failures, validate.FieldError{
-				Name:  fmt.Sprintf("[%d]", i),
-				Error: err,
-			})
+	if err := func() error {
+		if s.Response == nil {
+			return errors.New("nil is invalid value")
 		}
+		var failures []validate.FieldError
+		for i, elem := range s.Response {
+			if err := func() error {
+				if err := elem.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				failures = append(failures, validate.FieldError{
+					Name:  fmt.Sprintf("[%d]", i),
+					Error: err,
+				})
+			}
+		}
+		if len(failures) > 0 {
+			return &validate.Error{Fields: failures}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
 	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
@@ -168,6 +183,29 @@ func (s StatsBrowsers) Validate() error {
 				Error: err,
 			})
 		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *StatsBrowsersHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
 	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
@@ -241,6 +279,29 @@ func (s StatsCountries) Validate() error {
 	return nil
 }
 
+func (s *StatsCountriesHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *StatsCountriesItem) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -300,6 +361,29 @@ func (s StatsDevices) Validate() error {
 				Error: err,
 			})
 		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *StatsDevicesHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
 	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
@@ -373,6 +457,29 @@ func (s StatsLanguages) Validate() error {
 	return nil
 }
 
+func (s *StatsLanguagesHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *StatsLanguagesItem) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -439,6 +546,29 @@ func (s StatsOS) Validate() error {
 	return nil
 }
 
+func (s *StatsOSHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *StatsOSItem) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -498,6 +628,29 @@ func (s StatsPages) Validate() error {
 				Error: err,
 			})
 		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *StatsPagesHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
 	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
@@ -589,6 +742,29 @@ func (s StatsProperties) Validate() error {
 	return nil
 }
 
+func (s *StatsPropertiesHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *StatsPropertiesItem) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -630,6 +806,29 @@ func (s StatsReferrers) Validate() error {
 				Error: err,
 			})
 		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *StatsReferrersHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
 	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
@@ -767,6 +966,29 @@ func (s *StatsSummaryCurrent) Validate() error {
 	return nil
 }
 
+func (s *StatsSummaryHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *StatsSummaryIntervalItem) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -845,6 +1067,29 @@ func (s StatsTime) Validate() error {
 	return nil
 }
 
+func (s *StatsTimeHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *StatsTimeItem) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -886,6 +1131,29 @@ func (s StatsUTMCampaigns) Validate() error {
 				Error: err,
 			})
 		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *StatsUTMCampaignsHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
 	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
@@ -959,6 +1227,29 @@ func (s StatsUTMMediums) Validate() error {
 	return nil
 }
 
+func (s *StatsUTMMediumsHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *StatsUTMMediumsItem) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -1018,6 +1309,29 @@ func (s StatsUTMSources) Validate() error {
 				Error: err,
 			})
 		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *StatsUTMSourcesHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
 	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
@@ -1099,6 +1413,29 @@ func (s *UserGet) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "settings",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *UserGetHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
 			Error: err,
 		})
 	}
@@ -1324,6 +1661,29 @@ func (s *UserUsageGetCPU) Validate() error {
 	return nil
 }
 
+func (s *UserUsageGetHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *WebsiteCreate) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -1377,6 +1737,29 @@ func (s *WebsiteGet) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "hostname",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *WebsiteGetHeaders) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Response.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "Response",
 			Error: err,
 		})
 	}

--- a/core/cmd/config.go
+++ b/core/cmd/config.go
@@ -28,6 +28,11 @@ type ServerConfig struct {
 	// Misc settings.
 	UseEnvironment bool
 	DemoMode       bool `env:"DEMO_MODE"`
+
+	// Short Git commit SHA. Used when returning the version of the server in
+	// X-API-Commit header for client-side cache busting.
+	Commit  string
+	Version string
 }
 
 type AppDBConfig struct {
@@ -63,7 +68,14 @@ const (
 )
 
 // NewServerConfig creates a new server config.
-func NewServerConfig(useEnv bool) (*ServerConfig, error) {
+func NewServerConfig(useEnv bool, version string, commit string) (*ServerConfig, error) {
+	if version == "" {
+		version = "development"
+	}
+	if commit == "" {
+		commit = "development"
+	}
+
 	config := &ServerConfig{
 		Port:                 DefaultPort,
 		CacheCleanupInterval: DefaultCacheCleanupInterval,
@@ -74,6 +86,8 @@ func NewServerConfig(useEnv bool) (*ServerConfig, error) {
 		TimeoutIdle:          DefaultTimeoutIdle,
 		UseEnvironment:       useEnv,
 		DemoMode:             DefaultDemoMode,
+		Version:              version,
+		Commit:               commit,
 	}
 
 	// Load config from environment variables.

--- a/core/cmd/main.go
+++ b/core/cmd/main.go
@@ -62,7 +62,7 @@ func run(ctx context.Context, args []string) error {
 		}
 
 		// Create start command
-		s, err := NewStartCommand(useEnv)
+		s, err := NewStartCommand(useEnv, Version, Commit)
 		if err != nil {
 			return err
 		}

--- a/core/middlewares/commit.go
+++ b/core/middlewares/commit.go
@@ -12,7 +12,7 @@ func XAPICommitMiddleware(commit string) func(http.Handler) http.Handler {
 			// Include all routes except for /event routes.
 			// Only apply to GET requests.
 			if r.Method == http.MethodGet && !strings.HasPrefix(r.URL.Path, "/api/event") {
-				w.Header().Set("x-api-commit", commit)
+				w.Header().Set("X-Api-Commit", commit)
 			}
 
 			next.ServeHTTP(w, r)

--- a/core/middlewares/commit.go
+++ b/core/middlewares/commit.go
@@ -1,0 +1,20 @@
+package middlewares
+
+import (
+	"net/http"
+	"strings"
+)
+
+// XAPICommitMiddleware creates a middleware to apply the X-API-Commit header to all routes.
+func XAPICommitMiddleware(commit string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Include all routes except for /event routes.
+			if !strings.HasPrefix(r.URL.Path, "/api/event") {
+				w.Header().Set("x-api-commit", commit)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/core/middlewares/commit.go
+++ b/core/middlewares/commit.go
@@ -10,7 +10,8 @@ func XAPICommitMiddleware(commit string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Include all routes except for /event routes.
-			if !strings.HasPrefix(r.URL.Path, "/api/event") {
+			// Only apply to GET requests.
+			if r.Method == http.MethodGet && !strings.HasPrefix(r.URL.Path, "/api/event") {
 				w.Header().Set("x-api-commit", commit)
 			}
 

--- a/core/middlewares/cors.go
+++ b/core/middlewares/cors.go
@@ -17,6 +17,8 @@ func CORSAllowedOriginsMiddleware(allowedOrigins []string) func(http.Handler) ht
 		AllowedOrigins:   allowedOrigins,
 		AllowCredentials: true,
 		AllowedMethods:   []string{"GET", "POST", "PATCH", "DELETE"},
+		// CORS blocks the custom headers by default, so we need to allow them explicitly
+		ExposedHeaders: []string{"x-api-commit"},
 	})
 
 	// Create a default CORS handler

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -49,6 +49,8 @@ paths:
                 type: string
               description: Set the cookie for the session.
               required: true
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
         "400":
           $ref: "#/components/responses/BadRequestError"
         "401":
@@ -73,6 +75,8 @@ paths:
                 type: string
               description: Destroy the cookie for the session.
               required: true
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
         "401":
           $ref: "#/components/responses/UnauthorisedError"
         "500":
@@ -167,6 +171,9 @@ paths:
       responses:
         "200":
           description: User Found
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -199,6 +206,9 @@ paths:
       responses:
         "200":
           description: Success
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -228,6 +238,9 @@ paths:
       responses:
         "204":
           description: Success No Content
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
         "400":
           $ref: "#/components/responses/BadRequestError"
         "401":
@@ -252,6 +265,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -275,6 +291,9 @@ paths:
       responses:
         "200":
           description: Returns a list of websites.
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -306,6 +325,9 @@ paths:
       responses:
         "201":
           description: Created
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -348,6 +370,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -381,6 +406,9 @@ paths:
       responses:
         "200":
           description: Success
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -409,6 +437,9 @@ paths:
       responses:
         "204":
           description: Success No Content
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
         "400":
           $ref: "#/components/responses/BadRequestError"
         "401":
@@ -465,6 +496,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -509,6 +543,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -553,6 +590,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -603,6 +643,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -649,6 +692,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -695,6 +741,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -741,6 +790,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -787,6 +839,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -833,6 +888,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -879,6 +937,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -925,6 +986,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -977,6 +1041,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -1022,6 +1089,9 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-API-Commit:
+              $ref: "#/components/headers/X-API-Commit"
           content:
             application/json:
               schema:
@@ -1043,6 +1113,12 @@ components:
       in: cookie
       type: apiKey
       description: Session token for authentication.
+  headers:
+    X-API-Commit:
+      description: A custom header used to identify the commit of the API. This can be used to force reload the client if the API has been updated.
+      schema:
+        type: string
+        example: "97dd2ae"
   parameters:
     # Authentication
     SessionAuth:
@@ -1227,6 +1303,9 @@ components:
   responses:
     BadRequestError:
       description: 400 Bad Request.
+      headers:
+        X-API-Commit:
+          $ref: "#/components/headers/X-API-Commit"
       content:
         application/json:
           schema:
@@ -1249,6 +1328,9 @@ components:
               - error
     UnauthorisedError:
       description: 401 Unauthorised.
+      headers:
+        X-API-Commit:
+          $ref: "#/components/headers/X-API-Commit"
       content:
         application/json:
           schema:
@@ -1271,6 +1353,9 @@ components:
               - error
     ForbiddenError:
       description: 403 Forbidden.
+      headers:
+        X-API-Commit:
+          $ref: "#/components/headers/X-API-Commit"
       content:
         application/json:
           schema:
@@ -1293,6 +1378,9 @@ components:
               - error
     NotFoundError:
       description: 404 Not Found.
+      headers:
+        X-API-Commit:
+          $ref: "#/components/headers/X-API-Commit"
       content:
         application/json:
           schema:
@@ -1316,6 +1404,9 @@ components:
               - error
     ConflictError:
       description: 409 Conflict Found.
+      headers:
+        X-API-Commit:
+          $ref: "#/components/headers/X-API-Commit"
       content:
         application/json:
           schema:
@@ -1338,6 +1429,9 @@ components:
               - error
     InternalServerError:
       description: 500 Unexpected Internal Server Error.
+      headers:
+        X-API-Commit:
+          $ref: "#/components/headers/X-API-Commit"
       content:
         application/json:
           schema:

--- a/core/services/errors.go
+++ b/core/services/errors.go
@@ -7,61 +7,73 @@ import (
 )
 
 // ErrBadRequest returns an API specific BadRequestError pointer.
-func ErrBadRequest(err error) *api.BadRequestError {
-	return &api.BadRequestError{
-		Error: api.BadRequestErrorError{
-			Code:    http.StatusBadRequest,
-			Message: err.Error(),
+func ErrBadRequest(err error) *api.BadRequestErrorHeaders {
+	return &api.BadRequestErrorHeaders{
+		Response: api.BadRequestError{
+			Error: api.BadRequestErrorError{
+				Code:    http.StatusBadRequest,
+				Message: err.Error(),
+			},
 		},
 	}
 }
 
 // ErrConflict returns an API specific ConflictError pointer.
-func ErrConflict(err error) *api.ConflictError {
-	return &api.ConflictError{
-		Error: api.ConflictErrorError{
-			Code:    http.StatusConflict,
-			Message: err.Error(),
+func ErrConflict(err error) *api.ConflictErrorHeaders {
+	return &api.ConflictErrorHeaders{
+		Response: api.ConflictError{
+			Error: api.ConflictErrorError{
+				Code:    http.StatusConflict,
+				Message: err.Error(),
+			},
 		},
 	}
 }
 
 // ErrForbidden returns an API specific ForbiddenError pointer.
-func ErrForbidden(err error) *api.ForbiddenError {
-	return &api.ForbiddenError{
-		Error: api.ForbiddenErrorError{
-			Code:    http.StatusForbidden,
-			Message: err.Error(),
+func ErrForbidden(err error) *api.ForbiddenErrorHeaders {
+	return &api.ForbiddenErrorHeaders{
+		Response: api.ForbiddenError{
+			Error: api.ForbiddenErrorError{
+				Code:    http.StatusForbidden,
+				Message: err.Error(),
+			},
 		},
 	}
 }
 
 // ErrNotFound returns an API specific NotFoundError pointer.
-func ErrNotFound(err error) *api.NotFoundError {
-	return &api.NotFoundError{
-		Error: api.NotFoundErrorError{
-			Code:    http.StatusNotFound,
-			Message: err.Error(),
+func ErrNotFound(err error) *api.NotFoundErrorHeaders {
+	return &api.NotFoundErrorHeaders{
+		Response: api.NotFoundError{
+			Error: api.NotFoundErrorError{
+				Code:    http.StatusNotFound,
+				Message: err.Error(),
+			},
 		},
 	}
 }
 
 // ErrInternalServerError returns an API specific InternalServerError pointer.
-func ErrInternalServerError(err error) *api.InternalServerError {
-	return &api.InternalServerError{
-		Error: api.InternalServerErrorError{
-			Code:    http.StatusInternalServerError,
-			Message: err.Error(),
+func ErrInternalServerError(err error) *api.InternalServerErrorHeaders {
+	return &api.InternalServerErrorHeaders{
+		Response: api.InternalServerError{
+			Error: api.InternalServerErrorError{
+				Code:    http.StatusInternalServerError,
+				Message: err.Error(),
+			},
 		},
 	}
 }
 
 // ErrUnauthorised returns an API specific UnauthorisedError pointer.
-func ErrUnauthorised(err error) *api.UnauthorisedError {
-	return &api.UnauthorisedError{
-		Error: api.UnauthorisedErrorError{
-			Code:    http.StatusUnauthorized,
-			Message: err.Error(),
+func ErrUnauthorised(err error) *api.UnauthorisedErrorHeaders {
+	return &api.UnauthorisedErrorHeaders{
+		Response: api.UnauthorisedError{
+			Error: api.UnauthorisedErrorError{
+				Code:    http.StatusUnauthorized,
+				Message: err.Error(),
+			},
 		},
 	}
 }

--- a/core/services/properties.go
+++ b/core/services/properties.go
@@ -48,5 +48,7 @@ func (h *Handler) GetWebsiteIDProperties(ctx context.Context, params api.GetWebs
 		resp = append(resp, item)
 	}
 
-	return &resp, nil
+	return &api.StatsPropertiesHeaders{
+		Response: resp,
+	}, nil
 }

--- a/core/services/stats.go
+++ b/core/services/stats.go
@@ -30,7 +30,7 @@ func (h *Handler) GetWebsiteIDSummary(ctx context.Context, params api.GetWebsite
 		return ErrInternalServerError(err), nil
 	}
 
-	resp := &api.StatsSummary{
+	resp := api.StatsSummary{
 		Current: api.StatsSummaryCurrent{
 			Visitors:         currentSummary.Visitors,
 			Pageviews:        currentSummary.Pageviews,
@@ -90,7 +90,9 @@ func (h *Handler) GetWebsiteIDSummary(ctx context.Context, params api.GetWebsite
 		}
 	}
 
-	return resp, nil
+	return &api.StatsSummaryHeaders{
+		Response: resp,
+	}, nil
 }
 
 func (h *Handler) GetWebsiteIDPages(ctx context.Context, params api.GetWebsiteIDPagesParams) (api.GetWebsiteIDPagesRes, error) {
@@ -127,7 +129,9 @@ func (h *Handler) GetWebsiteIDPages(ctx context.Context, params api.GetWebsiteID
 			})
 		}
 
-		return &resp, nil
+		return &api.StatsPagesHeaders{
+			Response: resp,
+		}, nil
 	}
 
 	// Get pages
@@ -153,7 +157,9 @@ func (h *Handler) GetWebsiteIDPages(ctx context.Context, params api.GetWebsiteID
 		})
 	}
 
-	return &resp, nil
+	return &api.StatsPagesHeaders{
+		Response: resp,
+	}, nil
 }
 
 func (h *Handler) GetWebsiteIDTime(ctx context.Context, params api.GetWebsiteIDTimeParams) (api.GetWebsiteIDTimeRes, error) {
@@ -190,7 +196,9 @@ func (h *Handler) GetWebsiteIDTime(ctx context.Context, params api.GetWebsiteIDT
 			})
 		}
 
-		return &resp, nil
+		return &api.StatsTimeHeaders{
+			Response: resp,
+		}, nil
 	}
 
 	// Get time
@@ -215,7 +223,9 @@ func (h *Handler) GetWebsiteIDTime(ctx context.Context, params api.GetWebsiteIDT
 		})
 	}
 
-	return &resp, nil
+	return &api.StatsTimeHeaders{
+		Response: resp,
+	}, nil
 }
 
 func (h *Handler) GetWebsiteIDReferrers(ctx context.Context, params api.GetWebsiteIDReferrersParams) (api.GetWebsiteIDReferrersRes, error) {
@@ -252,7 +262,9 @@ func (h *Handler) GetWebsiteIDReferrers(ctx context.Context, params api.GetWebsi
 			})
 		}
 
-		return &resp, nil
+		return &api.StatsReferrersHeaders{
+			Response: resp,
+		}, nil
 	}
 
 	// Get referrers
@@ -276,7 +288,9 @@ func (h *Handler) GetWebsiteIDReferrers(ctx context.Context, params api.GetWebsi
 		})
 	}
 
-	return &resp, nil
+	return &api.StatsReferrersHeaders{
+		Response: resp,
+	}, nil
 }
 
 func (h *Handler) GetWebsiteIDSources(ctx context.Context, params api.GetWebsiteIDSourcesParams) (api.GetWebsiteIDSourcesRes, error) {
@@ -312,7 +326,9 @@ func (h *Handler) GetWebsiteIDSources(ctx context.Context, params api.GetWebsite
 			})
 		}
 
-		return &resp, nil
+		return &api.StatsUTMSourcesHeaders{
+			Response: resp,
+		}, nil
 	}
 
 	// Get sources
@@ -333,7 +349,9 @@ func (h *Handler) GetWebsiteIDSources(ctx context.Context, params api.GetWebsite
 		})
 	}
 
-	return &resp, nil
+	return &api.StatsUTMSourcesHeaders{
+		Response: resp,
+	}, nil
 }
 
 func (h *Handler) GetWebsiteIDMediums(ctx context.Context, params api.GetWebsiteIDMediumsParams) (api.GetWebsiteIDMediumsRes, error) {
@@ -369,7 +387,9 @@ func (h *Handler) GetWebsiteIDMediums(ctx context.Context, params api.GetWebsite
 			})
 		}
 
-		return &resp, nil
+		return &api.StatsUTMMediumsHeaders{
+			Response: resp,
+		}, nil
 	}
 
 	// Get mediums
@@ -393,7 +413,9 @@ func (h *Handler) GetWebsiteIDMediums(ctx context.Context, params api.GetWebsite
 		})
 	}
 
-	return &resp, nil
+	return &api.StatsUTMMediumsHeaders{
+		Response: resp,
+	}, nil
 }
 
 func (h *Handler) GetWebsiteIDCampaigns(ctx context.Context, params api.GetWebsiteIDCampaignsParams) (api.GetWebsiteIDCampaignsRes, error) {
@@ -429,7 +451,9 @@ func (h *Handler) GetWebsiteIDCampaigns(ctx context.Context, params api.GetWebsi
 			})
 		}
 
-		return &resp, nil
+		return &api.StatsUTMCampaignsHeaders{
+			Response: resp,
+		}, nil
 	}
 
 	// Get campaigns
@@ -453,7 +477,9 @@ func (h *Handler) GetWebsiteIDCampaigns(ctx context.Context, params api.GetWebsi
 		})
 	}
 
-	return &resp, nil
+	return &api.StatsUTMCampaignsHeaders{
+		Response: resp,
+	}, nil
 }
 
 func (h *Handler) GetWebsiteIDBrowsers(ctx context.Context, params api.GetWebsiteIDBrowsersParams) (api.GetWebsiteIDBrowsersRes, error) {
@@ -489,7 +515,9 @@ func (h *Handler) GetWebsiteIDBrowsers(ctx context.Context, params api.GetWebsit
 			})
 		}
 
-		return &resp, nil
+		return &api.StatsBrowsersHeaders{
+			Response: resp,
+		}, nil
 	}
 
 	// Get browsers
@@ -513,7 +541,9 @@ func (h *Handler) GetWebsiteIDBrowsers(ctx context.Context, params api.GetWebsit
 		})
 	}
 
-	return &resp, nil
+	return &api.StatsBrowsersHeaders{
+		Response: resp,
+	}, nil
 }
 
 func (h *Handler) GetWebsiteIDOs(ctx context.Context, params api.GetWebsiteIDOsParams) (api.GetWebsiteIDOsRes, error) {
@@ -549,7 +579,9 @@ func (h *Handler) GetWebsiteIDOs(ctx context.Context, params api.GetWebsiteIDOsP
 			})
 		}
 
-		return &resp, nil
+		return &api.StatsOSHeaders{
+			Response: resp,
+		}, nil
 	}
 
 	// Get OS
@@ -573,7 +605,9 @@ func (h *Handler) GetWebsiteIDOs(ctx context.Context, params api.GetWebsiteIDOsP
 		})
 	}
 
-	return &resp, nil
+	return &api.StatsOSHeaders{
+		Response: resp,
+	}, nil
 }
 
 func (h *Handler) GetWebsiteIDDevice(ctx context.Context, params api.GetWebsiteIDDeviceParams) (api.GetWebsiteIDDeviceRes, error) {
@@ -609,7 +643,9 @@ func (h *Handler) GetWebsiteIDDevice(ctx context.Context, params api.GetWebsiteI
 			})
 		}
 
-		return &resp, nil
+		return &api.StatsDevicesHeaders{
+			Response: resp,
+		}, nil
 	}
 
 	// Get devices
@@ -633,7 +669,9 @@ func (h *Handler) GetWebsiteIDDevice(ctx context.Context, params api.GetWebsiteI
 		})
 	}
 
-	return &resp, nil
+	return &api.StatsDevicesHeaders{
+		Response: resp,
+	}, nil
 }
 
 func (h *Handler) GetWebsiteIDLanguage(ctx context.Context, params api.GetWebsiteIDLanguageParams) (api.GetWebsiteIDLanguageRes, error) {
@@ -669,7 +707,9 @@ func (h *Handler) GetWebsiteIDLanguage(ctx context.Context, params api.GetWebsit
 			})
 		}
 
-		return &resp, nil
+		return &api.StatsLanguagesHeaders{
+			Response: resp,
+		}, nil
 	}
 
 	// Get languages
@@ -693,7 +733,9 @@ func (h *Handler) GetWebsiteIDLanguage(ctx context.Context, params api.GetWebsit
 		})
 	}
 
-	return &resp, nil
+	return &api.StatsLanguagesHeaders{
+		Response: resp,
+	}, nil
 }
 
 func (h *Handler) GetWebsiteIDCountry(ctx context.Context, params api.GetWebsiteIDCountryParams) (api.GetWebsiteIDCountryRes, error) {
@@ -729,7 +771,9 @@ func (h *Handler) GetWebsiteIDCountry(ctx context.Context, params api.GetWebsite
 			})
 		}
 
-		return &resp, nil
+		return &api.StatsCountriesHeaders{
+			Response: resp,
+		}, nil
 	}
 
 	// Get countries
@@ -753,5 +797,7 @@ func (h *Handler) GetWebsiteIDCountry(ctx context.Context, params api.GetWebsite
 		})
 	}
 
-	return &resp, nil
+	return &api.StatsCountriesHeaders{
+		Response: resp,
+	}, nil
 }

--- a/core/services/users.go
+++ b/core/services/users.go
@@ -40,14 +40,16 @@ func (h *Handler) GetUser(ctx context.Context, _params api.GetUserParams) (api.G
 		scriptFeatures = append(scriptFeatures, api.UserSettingsScriptTypeItem(v))
 	}
 
-	return &api.UserGet{
-		Username: user.Username,
-		Settings: api.UserSettings{
-			Language:   api.NewOptUserSettingsLanguage(api.UserSettingsLanguage(user.Settings.Language)),
-			ScriptType: scriptFeatures,
+	return &api.UserGetHeaders{
+		Response: api.UserGet{
+			Username: user.Username,
+			Settings: api.UserSettings{
+				Language:   api.NewOptUserSettingsLanguage(api.UserSettingsLanguage(user.Settings.Language)),
+				ScriptType: scriptFeatures,
+			},
+			DateCreated: user.DateCreated,
+			DateUpdated: user.DateUpdated,
 		},
-		DateCreated: user.DateCreated,
-		DateUpdated: user.DateUpdated,
 	}, nil
 }
 
@@ -85,19 +87,21 @@ func (h *Handler) GetUserUsage(ctx context.Context, _params api.GetUserUsagePara
 		return nil, err
 	}
 
-	return &api.UserUsageGet{
-		CPU: api.UserUsageGetCPU{
-			Usage:   float32(cpuUsage),
-			Cores:   cpuCores,
-			Threads: cpuThreads,
-		},
-		Memory: api.UserUsageGetMemory{
-			Used:  safeConvertUint64ToInt64(vmStat.Used),
-			Total: safeConvertUint64ToInt64(vmStat.Total),
-		},
-		Disk: api.UserUsageGetDisk{
-			Used:  safeConvertUint64ToInt64(diskStat.Used),
-			Total: safeConvertUint64ToInt64(diskStat.Total),
+	return &api.UserUsageGetHeaders{
+		Response: api.UserUsageGet{
+			CPU: api.UserUsageGetCPU{
+				Usage:   float32(cpuUsage),
+				Cores:   cpuCores,
+				Threads: cpuThreads,
+			},
+			Memory: api.UserUsageGetMemory{
+				Used:  safeConvertUint64ToInt64(vmStat.Used),
+				Total: safeConvertUint64ToInt64(vmStat.Total),
+			},
+			Disk: api.UserUsageGetDisk{
+				Used:  safeConvertUint64ToInt64(diskStat.Used),
+				Total: safeConvertUint64ToInt64(diskStat.Total),
+			},
 		},
 	}, nil
 }
@@ -210,14 +214,16 @@ func (h *Handler) PatchUser(ctx context.Context, req *api.UserPatch, _params api
 		scriptFeatures = append(scriptFeatures, api.UserSettingsScriptTypeItem(v))
 	}
 
-	return &api.UserGet{
-		Username: user.Username,
-		Settings: api.UserSettings{
-			Language:   api.NewOptUserSettingsLanguage(api.UserSettingsLanguage(user.Settings.Language)),
-			ScriptType: scriptFeatures,
+	return &api.UserGetHeaders{
+		Response: api.UserGet{
+			Username: user.Username,
+			Settings: api.UserSettings{
+				Language:   api.NewOptUserSettingsLanguage(api.UserSettingsLanguage(user.Settings.Language)),
+				ScriptType: scriptFeatures,
+			},
+			DateCreated: user.DateCreated,
+			DateUpdated: user.DateUpdated,
 		},
-		DateCreated: user.DateCreated,
-		DateUpdated: user.DateUpdated,
 	}, nil
 }
 

--- a/core/services/websites.go
+++ b/core/services/websites.go
@@ -86,7 +86,7 @@ func (h *Handler) GetWebsites(ctx context.Context, params api.GetWebsitesParams)
 	}
 
 	// Map to API response
-	websitesGet := &api.GetWebsitesOKApplicationJSON{}
+	websitesGet := make([]api.WebsiteGet, 0, len(websites))
 
 	// If summary is requested, include visitors per website
 	if ok := params.Summary.Or(false); ok {
@@ -100,7 +100,7 @@ func (h *Handler) GetWebsites(ctx context.Context, params api.GetWebsitesParams)
 				return nil, errors.Wrap(err, w.Hostname)
 			}
 
-			*websitesGet = append(*websitesGet, api.WebsiteGet{
+			websitesGet = append(websitesGet, api.WebsiteGet{
 				Hostname: w.Hostname,
 				Summary: api.NewOptWebsiteGetSummary(api.WebsiteGetSummary{
 					Visitors: views.Visitors,
@@ -110,13 +110,15 @@ func (h *Handler) GetWebsites(ctx context.Context, params api.GetWebsitesParams)
 		// Otherwise, return only hostnames
 	} else {
 		for _, w := range websites {
-			*websitesGet = append(*websitesGet, api.WebsiteGet{
+			websitesGet = append(websitesGet, api.WebsiteGet{
 				Hostname: w.Hostname,
 			})
 		}
 	}
 
-	return websitesGet, nil
+	return &api.GetWebsitesOKHeaders{
+		Response: websitesGet,
+	}, nil
 }
 
 func (h *Handler) GetWebsitesID(ctx context.Context, params api.GetWebsitesIDParams) (api.GetWebsitesIDRes, error) {
@@ -139,8 +141,10 @@ func (h *Handler) GetWebsitesID(ctx context.Context, params api.GetWebsitesIDPar
 		return ErrUnauthorised(model.ErrWebsiteNotFound), nil
 	}
 
-	return &api.WebsiteGet{
-		Hostname: website.Hostname,
+	return &api.WebsiteGetHeaders{
+		Response: api.WebsiteGet{
+			Hostname: website.Hostname,
+		},
 	}, nil
 }
 
@@ -194,8 +198,10 @@ func (h *Handler) PatchWebsitesID(ctx context.Context, req *api.WebsitePatch, pa
 		h.hostnames.Add(req.Hostname.Value)
 	}
 
-	return &api.WebsiteGet{
-		Hostname: website.Hostname,
+	return &api.WebsiteGetHeaders{
+		Response: api.WebsiteGet{
+			Hostname: website.Hostname,
+		},
 	}, nil
 }
 
@@ -233,7 +239,9 @@ func (h *Handler) PostWebsites(ctx context.Context, req *api.WebsiteCreate) (api
 	// Add hostname to cache
 	h.hostnames.Add(req.Hostname)
 
-	return &api.WebsiteGet{
-		Hostname: req.Hostname,
+	return &api.WebsiteGetHeaders{
+		Response: api.WebsiteGet{
+			Hostname: req.Hostname,
+		},
 	}, nil
 }

--- a/dashboard/app/api/client.ts
+++ b/dashboard/app/api/client.ts
@@ -105,6 +105,20 @@ const client = async (
 		});
 	}
 
+	// Check X-API-Commit header to see if the server commit sha is different from the client commit sha stored in local storage
+	const commit = res.headers.get('x-api-commit');
+	if (commit) {
+		const clientCommit = window.localStorage.getItem('medama-version');
+		// If the client commit is null, it means that the client is running for the first time.
+		if (clientCommit === null) {
+			window.localStorage.setItem('medama-version', commit);
+		} else if (clientCommit !== commit) {
+			window.localStorage.setItem('medama-version', commit);
+			// Hard reload the page to update the client with the latest changes.
+			window.location.reload();
+		}
+	}
+
 	return res;
 };
 

--- a/dashboard/app/api/types.d.ts
+++ b/dashboard/app/api/types.d.ts
@@ -901,6 +901,7 @@ export interface components {
         /** @description 400 Bad Request. */
         BadRequestError: {
             headers: {
+                "X-API-Commit": components["headers"]["X-API-Commit"];
                 [name: string]: unknown;
             };
             content: {
@@ -919,6 +920,7 @@ export interface components {
         /** @description 401 Unauthorised. */
         UnauthorisedError: {
             headers: {
+                "X-API-Commit": components["headers"]["X-API-Commit"];
                 [name: string]: unknown;
             };
             content: {
@@ -937,6 +939,7 @@ export interface components {
         /** @description 403 Forbidden. */
         ForbiddenError: {
             headers: {
+                "X-API-Commit": components["headers"]["X-API-Commit"];
                 [name: string]: unknown;
             };
             content: {
@@ -955,6 +958,7 @@ export interface components {
         /** @description 404 Not Found. */
         NotFoundError: {
             headers: {
+                "X-API-Commit": components["headers"]["X-API-Commit"];
                 [name: string]: unknown;
             };
             content: {
@@ -973,6 +977,7 @@ export interface components {
         /** @description 409 Conflict Found. */
         ConflictError: {
             headers: {
+                "X-API-Commit": components["headers"]["X-API-Commit"];
                 [name: string]: unknown;
             };
             content: {
@@ -991,6 +996,7 @@ export interface components {
         /** @description 500 Unexpected Internal Server Error. */
         InternalServerError: {
             headers: {
+                "X-API-Commit": components["headers"]["X-API-Commit"];
                 [name: string]: unknown;
             };
             content: {
@@ -1048,7 +1054,10 @@ export interface components {
         Offset: number;
     };
     requestBodies: never;
-    headers: never;
+    headers: {
+        /** @description A custom header used to identify the commit of the API. This can be used to force reload the client if the API has been updated. */
+        "X-API-Commit": string;
+    };
     pathItems: never;
 }
 export type $defs = Record<string, never>;
@@ -1072,6 +1081,7 @@ export interface operations {
                 headers: {
                     /** @description Set the cookie for the session. */
                     "Set-Cookie": string;
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content?: never;
@@ -1098,6 +1108,7 @@ export interface operations {
                 headers: {
                     /** @description Destroy the cookie for the session. */
                     "Set-Cookie": string;
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content?: never;
@@ -1184,6 +1195,7 @@ export interface operations {
             /** @description User Found */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1211,6 +1223,7 @@ export interface operations {
             /** @description Success No Content */
             204: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content?: never;
@@ -1242,6 +1255,7 @@ export interface operations {
             /** @description Success */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1271,6 +1285,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1299,6 +1314,7 @@ export interface operations {
             /** @description Returns a list of websites. */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1327,6 +1343,7 @@ export interface operations {
             /** @description Created */
             201: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1358,6 +1375,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1388,6 +1406,7 @@ export interface operations {
             /** @description Success No Content */
             204: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content?: never;
@@ -1422,6 +1441,7 @@ export interface operations {
             /** @description Success */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1486,6 +1506,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1551,6 +1572,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1616,6 +1638,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1683,6 +1706,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1749,6 +1773,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1815,6 +1840,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1881,6 +1907,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -1947,6 +1974,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2013,6 +2041,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2079,6 +2108,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2145,6 +2175,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2213,6 +2244,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {
@@ -2277,6 +2309,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    "X-API-Commit": components["headers"]["X-API-Commit"];
                     [name: string]: unknown;
                 };
                 content: {


### PR DESCRIPTION
A common issue with SPAs is that the server may update itself, but the browser cached SPA will not leading to errors for dashboard users. This now includes a new `X-API-Commit` header that returns the server short Git commit SHA in every request. 

If there is a mismatch between the client `localStorage` and server, the browser will force reload with the new uncached client.