### PR TITLE
ci: include version and commit in docker images

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -22,10 +22,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Save GitHub tag and commit sha to environment
+        run: |
+          echo "VERSION=Edge" >> $GITHUB_ENV
+          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -53,6 +56,9 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            COMMIT_SHA=${{ env.COMMIT_SHA }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -22,6 +22,9 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -19,10 +19,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Save GitHub tag and commit sha to environment
+        run: |
+          echo "VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -49,6 +52,9 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            COMMIT_SHA=${{ env.COMMIT_SHA }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -19,6 +19,9 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@
 
 FROM jdxcode/mise:latest AS build
 
+ARG VERSION=development
+ARG COMMIT=development
+
+ENV VERSION=${VERSION}
+ENV COMMIT_SHA=${COMMIT}
+
 WORKDIR /app
 
 # Install unzip dependency for bun
@@ -30,7 +36,7 @@ RUN bun install --frozen-lockfile
 
 # Copy the rest of the source code
 COPY . .
-RUN --mount=type=cache,target=${GOCACHE} ~/bin/task core:release
+RUN --mount=type=cache,target=${GOCACHE} ~/bin/task core:release:docker
 
 # Build the final image
 FROM gcr.io/distroless/cc-debian12

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@
 FROM jdxcode/mise:latest AS build
 
 ARG VERSION=development
-ARG COMMIT=development
+ARG COMMIT_SHA=development
 
 ENV VERSION=${VERSION}
-ENV COMMIT_SHA=${COMMIT}
+ENV COMMIT_SHA=${COMMIT_SHA}
 
 WORKDIR /app
 
@@ -33,6 +33,9 @@ RUN --mount=type=cache,target=${GOCACHE} \
 	cd core && go mod download && cd ..
 
 RUN bun install --frozen-lockfile
+
+# Verify environment variables
+RUN echo "VERSION=${VERSION}" && echo "COMMIT_SHA=${COMMIT_SHA}"
 
 # Copy the rest of the source code
 COPY . .

--- a/core/Taskfile.yaml
+++ b/core/Taskfile.yaml
@@ -91,6 +91,7 @@ tasks:
   # Centralise Docker release command into here for simpler maintenance instead of specifying
   # within Dockerfile
   release:docker:
+    deps: [generate]
     cmds:
       - go build -o ./bin/main -ldflags "-s -w -X main.Version=$VERSION -X main.Commit=$COMMIT_SHA" -trimpath -tags "no_duckdb_arrow" ./cmd/
       - chmod +x ./bin/main
@@ -99,6 +100,7 @@ tasks:
       CGO_ENABLED: "1"
 
   release:linux:amd64:
+    deps: [generate]
     cmds:
       - go build -o ./bin/medama_linux_amd64 -ldflags "-s -w -X main.Version=$VERSION -X main.Commit=$COMMIT_SHA" -trimpath -tags "no_duckdb_arrow" ./cmd/
       - chmod +x ./bin/medama_linux_amd64
@@ -109,6 +111,7 @@ tasks:
       GOARCH: "amd64"
 
   release:linux:arm64:
+    deps: [generate]
     cmds:
       - go build -o ./bin/medama_linux_arm64 -ldflags "-s -w -X main.Version=$VERSION -X main.Commit=$COMMIT_SHA" -trimpath -tags "no_duckdb_arrow" ./cmd/
       - chmod +x ./bin/medama_linux_arm64
@@ -121,6 +124,7 @@ tasks:
       GOARCH: "arm64"
 
   release:darwin:amd64:
+    deps: [generate]
     cmds:
       - go build -o ./bin/medama_darwin_amd64 -ldflags "-s -w -X main.Version=$VERSION -X main.Commit=$COMMIT_SHA" -trimpath -tags "no_duckdb_arrow" ./cmd/
       - chmod +x ./bin/medama_darwin_amd64
@@ -131,6 +135,7 @@ tasks:
       GOARCH: "amd64"
 
   release:darwin:arm64:
+    deps: [generate]
     cmds:
       - go build -o ./bin/medama_darwin_arm64 -ldflags "-s -w -X main.Version=$VERSION -X main.Commit=$COMMIT_SHA" -trimpath -tags "no_duckdb_arrow" ./cmd/
       - chmod +x ./bin/medama_darwin_arm64

--- a/core/Taskfile.yaml
+++ b/core/Taskfile.yaml
@@ -88,6 +88,16 @@ tasks:
     env:
       CGO_ENABLED: "1"
 
+  # Centralise Docker release command into here for simpler maintenance instead of specifying
+  # within Dockerfile
+  release:docker:
+    cmds:
+      - go build -o ./bin/main -ldflags "-s -w -X main.Version=$VERSION -X main.Commit=$COMMIT_SHA" -trimpath -tags "no_duckdb_arrow" ./cmd/
+      - chmod +x ./bin/main
+      - echo "docker build done"
+    env:
+      CGO_ENABLED: "1"
+
   release:linux:amd64:
     cmds:
       - go build -o ./bin/medama_linux_amd64 -ldflags "-s -w -X main.Version=$VERSION -X main.Commit=$COMMIT_SHA" -trimpath -tags "no_duckdb_arrow" ./cmd/


### PR DESCRIPTION
The Docker images were not getting the commit sha and version embedded into the final binary. This can affect our dashboard clients as they typically rely on the commit SHA to forcefully refresh themselves if there is a new update. 