### PR TITLE
perf(core): reduce allocs for ping event and use a pool

### DIFF
--- a/core/.golangci.yml
+++ b/core/.golangci.yml
@@ -39,6 +39,7 @@ linters:
     - exhaustruct
     - forcetypeassert
     - godox
+    - gochecknoglobals
     - interfacebloat
     - ireturn
     - lll


### PR DESCRIPTION
This adds a `sync.Pool` to reduce allocations for `strings.Reader` on `/ping`. This should reduce GC pressure a little bit on larger websites.