### PR TITLE
feat(core): add profiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@
 core/**/main
 core/**/bin
 core/**/client
+
+# Output of pprof files
+**/*.prof

--- a/core/cmd/config.go
+++ b/core/cmd/config.go
@@ -26,6 +26,8 @@ type ServerConfig struct {
 	TimeoutIdle  time.Duration
 
 	// Misc settings.
+	// Enable /debug/pprof endpoints.
+	Profiler       bool `env:"PROFILER"`
 	UseEnvironment bool
 	DemoMode       bool `env:"DEMO_MODE"`
 
@@ -64,6 +66,7 @@ const (
 	DefaultLoggerLevel = "info"
 
 	// Misc constants.
+	DefaultProfiler = false
 	DefaultDemoMode = false
 )
 
@@ -84,6 +87,7 @@ func NewServerConfig(useEnv bool, version string, commit string) (*ServerConfig,
 		TimeoutRead:          DefaultTimeoutRead,
 		TimeoutWrite:         DefaultTimeoutWrite,
 		TimeoutIdle:          DefaultTimeoutIdle,
+		Profiler:             DefaultProfiler,
 		UseEnvironment:       useEnv,
 		DemoMode:             DefaultDemoMode,
 		Version:              version,

--- a/fly.toml
+++ b/fly.toml
@@ -16,6 +16,7 @@ APP_DATABASE_HOST = '/db/app.db'
 PORT = '8080'
 LEVEL = 'debug'
 DEMO_MODE = 'true'
+PROFILER = 'true'
 
 [[mounts]]
 source = 'medama_db'


### PR DESCRIPTION
This adds `/debug/pprof` profiling endpoints if the `-profiler` flag is used. This should let us profile CPU and memory usage and determine exactly what could be better optimised.

This also enables it on the demo website so we have a real world benchmark that we can follow.