### PR TITLE
fix(core): https redirect middleware uses invalid localhost

### DIFF
--- a/core/middlewares/https.go
+++ b/core/middlewares/https.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const httpsProtocol = "https://"
-
 // HTTPSRedirect returns a middleware that redirects HTTP requests to HTTPS.
 func HTTPSRedirect(isSSL bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -32,26 +30,18 @@ func HTTPSRedirectFunc(isSSL bool) http.HandlerFunc {
 }
 
 func redirectToHTTPS(w http.ResponseWriter, r *http.Request) {
-	var sb strings.Builder
-
-	// Pre-allocate the buffer size for the redirect URL.
-	sb.Grow(len(httpsProtocol) + len(r.Host) + len(r.URL.RequestURI()))
-
-	sb.WriteString(httpsProtocol)
-
 	// Remove the port from the host if it exists as we are redirecting to the default HTTPS port.
 	host, _, err := net.SplitHostPort(r.Host)
 	if err != nil {
 		host = r.Host
 	}
 
-	sb.WriteString(host)
-	sb.WriteString(r.URL.RequestURI())
+	url := "https://" + host + r.URL.RequestURI()
 
 	// Close old HTTP connection.
 	w.Header().Set("Connection", "close")
 
-	http.Redirect(w, r, sb.String(), http.StatusMovedPermanently)
+	http.Redirect(w, r, url, http.StatusMovedPermanently)
 }
 
 func shouldRedirect(r *http.Request, isSSL bool) bool {
@@ -60,13 +50,11 @@ func shouldRedirect(r *http.Request, isSSL bool) bool {
 		return false
 	}
 
-	if !isSSL && isLocalhost(r.Host) {
+	isLocalhost := r.Host == "localhost" || strings.HasPrefix(r.Host, "localhost:") || strings.HasPrefix(r.Host, "127.")
+
+	if !isSSL && isLocalhost {
 		return false
 	}
 
 	return true
-}
-
-func isLocalhost(host string) bool {
-	return host == "localhost" || strings.HasPrefix(host, "127.") || strings.HasPrefix(host, "192.168.")
 }


### PR DESCRIPTION
The new automatic redirect doesn't work very well when allocating localhost with a port.

`host == "localhost"` is invalid since host could be something like `localhost:8080` instead.