### PR TITLE
ci(build): fail fast on edge concurrency group

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -10,16 +10,20 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+concurrency:
+  group: docker-edge-group
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
 jobs:
   publish-docker-edge:
     name: Publish Docker edge image
     runs-on: ubuntu-latest
-    concurrency: docker-edge-group # ensure only one action runs at a time
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -7,16 +7,20 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+concurrency:
+  group: docker-latest-group
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
 jobs:
   publish-docker-latest:
     name: Publish Docker latest image
     runs-on: ubuntu-latest
-    concurrency: docker-latest-group # ensure only one action runs at a time
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
If we have a new edge docker release starting, we should cancel the previous one to speed up release times.