### PR TITLE
fix(dashboard): use stream timeout over abort delay

### DIFF
--- a/dashboard/Taskfile.yaml
+++ b/dashboard/Taskfile.yaml
@@ -49,3 +49,4 @@ tasks:
     cmds:
       - bun run typecheck
       - bun run lint:ci
+      - task: build

--- a/dashboard/app/entry.client.tsx
+++ b/dashboard/app/entry.client.tsx
@@ -1,0 +1,12 @@
+import { RemixBrowser } from "@remix-run/react";
+import { startTransition, StrictMode } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <RemixBrowser />
+    </StrictMode>
+  );
+});

--- a/dashboard/app/entry.client.tsx
+++ b/dashboard/app/entry.client.tsx
@@ -1,12 +1,12 @@
-import { RemixBrowser } from "@remix-run/react";
-import { startTransition, StrictMode } from "react";
-import { hydrateRoot } from "react-dom/client";
+import { RemixBrowser } from '@remix-run/react';
+import { StrictMode, startTransition } from 'react';
+import { hydrateRoot } from 'react-dom/client';
 
 startTransition(() => {
-  hydrateRoot(
-    document,
-    <StrictMode>
-      <RemixBrowser />
-    </StrictMode>
-  );
+	hydrateRoot(
+		document,
+		<StrictMode>
+			<RemixBrowser />
+		</StrictMode>,
+	);
 });

--- a/dashboard/app/entry.server.tsx
+++ b/dashboard/app/entry.server.tsx
@@ -21,24 +21,23 @@ export default function handleRequest(
 
 	return prohibitOutOfOrderStreaming
 		? handleBotRequest(
-			request,
-			responseStatusCode,
-			responseHeaders,
-			remixContext,
-		)
+				request,
+				responseStatusCode,
+				responseHeaders,
+				remixContext,
+			)
 		: handleBrowserRequest(
-			request,
-			responseStatusCode,
-			responseHeaders,
-			remixContext,
-		);
+				request,
+				responseStatusCode,
+				responseHeaders,
+				remixContext,
+			);
 }
 
 function isBotRequest(userAgent: string | null) {
 	if (!userAgent) {
 		return false;
 	}
-
 
 	return isbot(userAgent);
 }
@@ -52,10 +51,7 @@ function handleBotRequest(
 	return new Promise((resolve, reject) => {
 		let shellRendered = false;
 		const { pipe, abort } = renderToPipeableStream(
-			<RemixServer
-				context={remixContext}
-				url={request.url}
-			/>,
+			<RemixServer context={remixContext} url={request.url} />,
 			{
 				onAllReady() {
 					shellRendered = true;
@@ -89,7 +85,6 @@ function handleBotRequest(
 			},
 		);
 
-
 		// Automatically timeout the React renderer after 6 seconds, which ensures
 		// React has enough time to flush down the rejected boundary contents
 		setTimeout(abort, streamTimeout + 1000);
@@ -105,10 +100,7 @@ function handleBrowserRequest(
 	return new Promise((resolve, reject) => {
 		let shellRendered = false;
 		const { pipe, abort } = renderToPipeableStream(
-			<RemixServer
-				context={remixContext}
-				url={request.url}
-			/>,
+			<RemixServer context={remixContext} url={request.url} />,
 			{
 				onShellReady() {
 					shellRendered = true;

--- a/dashboard/app/entry.server.tsx
+++ b/dashboard/app/entry.server.tsx
@@ -1,0 +1,149 @@
+import { PassThrough } from 'node:stream';
+
+import type { AppLoadContext, EntryContext } from '@remix-run/node';
+import { createReadableStreamFromReadable } from '@remix-run/node';
+import { RemixServer } from '@remix-run/react';
+import { isbot } from 'isbot';
+import { renderToPipeableStream } from 'react-dom/server';
+
+// Reject/cancel all pending promises after 5 seconds
+export const streamTimeout = 5000;
+
+export default function handleRequest(
+	request: Request,
+	responseStatusCode: number,
+	responseHeaders: Headers,
+	remixContext: EntryContext,
+	_loadContext: AppLoadContext,
+) {
+	const prohibitOutOfOrderStreaming =
+		isBotRequest(request.headers.get('user-agent')) || remixContext.isSpaMode;
+
+	return prohibitOutOfOrderStreaming
+		? handleBotRequest(
+			request,
+			responseStatusCode,
+			responseHeaders,
+			remixContext,
+		)
+		: handleBrowserRequest(
+			request,
+			responseStatusCode,
+			responseHeaders,
+			remixContext,
+		);
+}
+
+function isBotRequest(userAgent: string | null) {
+	if (!userAgent) {
+		return false;
+	}
+
+
+	return isbot(userAgent);
+}
+
+function handleBotRequest(
+	request: Request,
+	responseStatusCode: number,
+	responseHeaders: Headers,
+	remixContext: EntryContext,
+) {
+	return new Promise((resolve, reject) => {
+		let shellRendered = false;
+		const { pipe, abort } = renderToPipeableStream(
+			<RemixServer
+				context={remixContext}
+				url={request.url}
+			/>,
+			{
+				onAllReady() {
+					shellRendered = true;
+					const body = new PassThrough();
+					const stream = createReadableStreamFromReadable(body);
+
+					responseHeaders.set('Content-Type', 'text/html');
+
+					resolve(
+						new Response(stream, {
+							headers: responseHeaders,
+							status: responseStatusCode,
+						}),
+					);
+
+					pipe(body);
+				},
+				onShellError(error: unknown) {
+					reject(error);
+				},
+				onError(error: unknown) {
+					// biome-ignore lint/style/noParameterAssign: code generated.
+					responseStatusCode = 500;
+					// Log streaming rendering errors from inside the shell.  Don't log
+					// errors encountered during initial shell rendering since they'll
+					// reject and get logged in handleDocumentRequest.
+					if (shellRendered) {
+						console.error(error);
+					}
+				},
+			},
+		);
+
+
+		// Automatically timeout the React renderer after 6 seconds, which ensures
+		// React has enough time to flush down the rejected boundary contents
+		setTimeout(abort, streamTimeout + 1000);
+	});
+}
+
+function handleBrowserRequest(
+	request: Request,
+	responseStatusCode: number,
+	responseHeaders: Headers,
+	remixContext: EntryContext,
+) {
+	return new Promise((resolve, reject) => {
+		let shellRendered = false;
+		const { pipe, abort } = renderToPipeableStream(
+			<RemixServer
+				context={remixContext}
+				url={request.url}
+			/>,
+			{
+				onShellReady() {
+					shellRendered = true;
+					const body = new PassThrough();
+					const stream = createReadableStreamFromReadable(body);
+
+					responseHeaders.set('Content-Type', 'text/html');
+
+					resolve(
+						new Response(stream, {
+							headers: responseHeaders,
+							status: responseStatusCode,
+						}),
+					);
+
+					pipe(body);
+				},
+				onShellError(error: unknown) {
+					reject(error);
+				},
+				onError(error: unknown) {
+					// biome-ignore lint/style/noParameterAssign: code generated.
+					responseStatusCode = 500;
+					// Log streaming rendering errors from inside the shell.  Don't log
+					// errors encountered during initial shell rendering since they'll
+					// reject and get logged in handleDocumentRequest.
+					if (shellRendered) {
+						console.error(error);
+					}
+				},
+			},
+		);
+
+		// Automatically timeout the React renderer after 6 seconds, which ensures
+		// React has enough time to flush down the rejected boundary contents
+		setTimeout(abort, streamTimeout + 1000);
+	});
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,6 +9,7 @@
 		"preview": "vite preview",
 		"generate": "openapi-typescript ../core/openapi.yaml -o ./app/api/types.d.ts --default-non-nullable false",
 		"lint": "biome check --write .",
+		"check": "biome check --write .",
 		"lint:ci": "biome check .",
 		"typecheck": "tsc"
 	},


### PR DESCRIPTION
Abort delay is deprecated for React Router v7 migration.