### PR TITLE
build: use debian image for build to sync glibc with distroless

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,9 @@ jobs:
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
-    concurrency: deploy-group # ensure only one action runs at a time
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    concurrency: deploy-group
+    # Run only if Docker publish was successful or it is a manual workflow deployment.
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1
 
-FROM ubuntu:latest AS build
+FROM debian:bookworm AS build
 
 ARG VERSION=development
 ARG COMMIT_SHA=development


### PR DESCRIPTION
Seems like DuckDB updated their base `glibc` requirements which broke building apps on Debian based images.

Unfortunately, we can't easily switch away from Debian since we rely on it for our final distroless images, which is a big reason why our Docker images are tiny. For now I'll merge this until a new release for DuckDB is released.

Related: https://github.com/marcboeker/go-duckdb/issues/461