### PR TITLE
ci(build): build arm images natively

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -32,10 +32,6 @@ jobs:
             runner: ubuntu-24.04-arm
             platform: linux/arm64
 
-    outputs:
-      digest: ${{ steps.push.outputs.digest }}
-      metadata: ${{ steps.meta.outputs.json }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -84,8 +80,15 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.platform }}
 
-  create-manifest-and-attest:
-    name: Create multi-arch manifest and attest
+      - name: Generate attestation for this image
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  create-manifest:
+    name: Create multi-arch manifest
     runs-on: ubuntu-latest
     needs: build
 
@@ -116,17 +119,3 @@ jobs:
               ${tag}-amd64 \
               ${tag}-arm64
           done
-
-      - name: Generate artifact attestation for AMD64
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ needs.build.outputs.amd64.digest }}
-          push-to-registry: true
-
-      - name: Generate artifact attestation for ARM64
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ needs.build.outputs.arm64.digest }}
-          push-to-registry: true

--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -29,7 +29,7 @@ jobs:
             platform: linux/amd64
           - id: arm64
             arch: arm64
-            runner: ubuntu-24.04-arm64
+            runner: ubuntu-24.04-arm
             platform: linux/arm64
 
     outputs:

--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -21,7 +21,6 @@ jobs:
     name: Build ${{ matrix.arch }} image
     runs-on: ${{ matrix.runner }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - id: amd64

--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -17,9 +17,23 @@ permissions:
   id-token: write
 
 jobs:
-  publish-docker-edge:
-    name: Publish Docker edge image
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.arch }} image
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm64
+            platform: linux/arm64
+
+    outputs:
+      image-digest: ${{ steps.push.outputs.digest }}
+      metadata: ${{ steps.meta.outputs.json }}
 
     steps:
       - name: Checkout code
@@ -47,10 +61,13 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=false
+            suffix=-${{ matrix.arch }}
           tags: |
             type=edge,branch=main
             type=sha,format=short
           labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
             org.opencontainers.image.licenses=Apache-2.0
 
       - name: Build and push Docker image
@@ -64,11 +81,51 @@ jobs:
             COMMIT_SHA=${{ env.COMMIT_SHA }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
 
-      - name: Generate artifact attestation
+  create-manifest-and-attest:
+    name: Create multi-arch manifest and attest
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for manifest
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: latest=false
+          tags: |
+            type=edge,branch=main
+            type=sha,format=short
+
+      - name: Create and push multi-arch manifest
+        run: |
+          for tag in $(echo '${{ steps.meta.outputs.tags }}' | tr ',' '\n'); do
+            echo "Creating manifest for tag: ${tag}"
+            docker buildx imagetools create \
+              --tag ${tag} \
+              ${tag}-amd64 \
+              ${tag}-arm64
+          done
+
+      - name: Generate artifact attestation for AMD64
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ needs.build.outputs.amd64.image-digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation for ARM64
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ needs.build.outputs.arm64.image-digest }}
           push-to-registry: true

--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -24,15 +24,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: amd64
+          - id: amd64
+            arch: amd64
             runner: ubuntu-latest
             platform: linux/amd64
-          - arch: arm64
+          - id: arm64
+            arch: arm64
             runner: ubuntu-24.04-arm64
             platform: linux/arm64
 
     outputs:
-      image-digest: ${{ steps.push.outputs.digest }}
+      digest: ${{ steps.push.outputs.digest }}
       metadata: ${{ steps.meta.outputs.json }}
 
     steps:
@@ -119,13 +121,13 @@ jobs:
       - name: Generate artifact attestation for AMD64
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ needs.build.outputs.amd64.image-digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ needs.build.outputs.amd64.digest }}
           push-to-registry: true
 
       - name: Generate artifact attestation for ARM64
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ needs.build.outputs.arm64.image-digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ needs.build.outputs.arm64.digest }}
           push-to-registry: true

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -33,10 +33,6 @@ jobs:
             runner: ubuntu-24.04-arm
             platform: linux/arm64
 
-    outputs:
-      digest: ${{ steps.push.outputs.digest }}
-      metadata: ${{ steps.meta.outputs.json }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -84,8 +80,15 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.platform }}
 
-  create-manifest-and-attest:
-    name: Create multi-arch manifest and attest
+      - name: Generate attestation for this image
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  create-manifest:
+    name: Create multi-arch manifest
     runs-on: ubuntu-latest
     needs: build
 
@@ -115,17 +118,3 @@ jobs:
               ${tag}-amd64 \
               ${tag}-arm64
           done
-
-      - name: Generate artifact attestation for AMD64
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ needs.build.outputs.amd64.digest }}
-          push-to-registry: true
-
-      - name: Generate artifact attestation for ARM64
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ needs.build.outputs.arm64.digest }}
-          push-to-registry: true

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -18,9 +18,23 @@ permissions:
   id-token: write
 
 jobs:
-  publish-docker-latest:
-    name: Publish Docker latest image
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.arch }} image
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm64
+            platform: linux/arm64
+
+    outputs:
+      image-digest: ${{ steps.push.outputs.digest }}
+      metadata: ${{ steps.meta.outputs.json }}
 
     steps:
       - name: Checkout code
@@ -48,9 +62,12 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=true
+            suffix=-${{ matrix.arch }}
           tags: |
             type=ref,event=tag
           labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
             org.opencontainers.image.licenses=Apache-2.0
 
       - name: Build and push Docker image
@@ -64,11 +81,50 @@ jobs:
             COMMIT_SHA=${{ env.COMMIT_SHA }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
 
-      - name: Generate artifact attestation
+  create-manifest-and-attest:
+    name: Create multi-arch manifest and attest
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for manifest
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: latest=true
+          tags: |
+            type=ref,event=tag
+
+      - name: Create and push multi-arch manifest
+        run: |
+          for tag in $(echo '${{ steps.meta.outputs.tags }}' | tr ',' '\n'); do
+            echo "Creating manifest for tag: ${tag}"
+            docker buildx imagetools create \
+              --tag ${tag} \
+              ${tag}-amd64 \
+              ${tag}-arm64
+          done
+
+      - name: Generate artifact attestation for AMD64
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ needs.build.outputs.amd64.image-digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation for ARM64
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ needs.build.outputs.arm64.image-digest }}
           push-to-registry: true

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -25,15 +25,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: amd64
+          - id: amd64
+            arch: amd64
             runner: ubuntu-latest
             platform: linux/amd64
-          - arch: arm64
+          - id: arm64
+            arch: arm64
             runner: ubuntu-24.04-arm64
             platform: linux/arm64
 
     outputs:
-      image-digest: ${{ steps.push.outputs.digest }}
+      digest: ${{ steps.push.outputs.digest }}
       metadata: ${{ steps.meta.outputs.json }}
 
     steps:
@@ -118,13 +120,13 @@ jobs:
       - name: Generate artifact attestation for AMD64
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ needs.build.outputs.amd64.image-digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ needs.build.outputs.amd64.digest }}
           push-to-registry: true
 
       - name: Generate artifact attestation for ARM64
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ needs.build.outputs.arm64.image-digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ needs.build.outputs.arm64.digest }}
           push-to-registry: true

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -30,7 +30,7 @@ jobs:
             platform: linux/amd64
           - id: arm64
             arch: arm64
-            runner: ubuntu-24.04-arm64
+            runner: ubuntu-24.04-arm
             platform: linux/arm64
 
     outputs:

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -22,7 +22,6 @@ jobs:
     name: Build ${{ matrix.arch }} image
     runs-on: ${{ matrix.runner }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - id: amd64


### PR DESCRIPTION
This should massively improve Docker ARM64 build times by removing QEMU emulation.