### PR TITLE
fix(core): reduce sensitivity of rate limiter

### DIFF
--- a/core/middlewares/ratelimit.go
+++ b/core/middlewares/ratelimit.go
@@ -14,8 +14,8 @@ import (
 const (
 	// Total number of unique IP prefixes to track.
 	cacheSize         = 65536
-	defaultLimit      = 100
-	defaultWindow     = 1 * time.Minute
+	defaultLimit      = 10000
+	defaultWindow     = 5 * time.Minute
 	ipv4DefaultPrefix = 24
 	ipv6DefaultPrefix = 48
 )

--- a/fly.toml
+++ b/fly.toml
@@ -29,9 +29,6 @@ auto_start_machines = true
 min_machines_running = 1
 processes = ['app']
 
-[http_service.concurrency]
-type = "requests"
-
 [[vm]]
 memory = '1024mb'
 cpu_kind = 'shared'


### PR DESCRIPTION
100 requests might be too sensitive when considering the dashboard requests + filtering.