### PR TITLE
ci(build): remove go build flags for aarch64

### DIFF
--- a/core/Taskfile.yaml
+++ b/core/Taskfile.yaml
@@ -120,8 +120,6 @@ tasks:
       - echo "linux/arm64 build done"
     env:
       CGO_ENABLED: "1"
-      CC: "aarch64-linux-gnu-gcc"
-      CXX: "aarch64-linux-gnu-g++"
       GOOS: "linux"
       GOARCH: "arm64"
       GOFLAGS: "-buildvcs=false"


### PR DESCRIPTION
Since the ManyLinux image is natively aarch64, we don't need the additional CC and CXX flags.