### PR TITLE
feat(dashboard): add basic dark mode styles and theme toggle

### DIFF
--- a/dashboard/app/components/index/WebsiteCard.module.css
+++ b/dashboard/app/components/index/WebsiteCard.module.css
@@ -1,5 +1,5 @@
 .card {
-	color: var(--text-grey);
+	color: var(--text-dark);
 	padding: 16px;
 	border: 1px solid var(--border-muted);
 	border-radius: 8px;
@@ -13,7 +13,7 @@
 	}
 
 	&:visited {
-		color: var(--text-grey);
+		color: var(--text-dark);
 	}
 
 	p {

--- a/dashboard/app/components/layout/Header.tsx
+++ b/dashboard/app/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import {
 	Burger,
+	Button,
 	Drawer,
 	type DrawerProps,
 	Flex,
@@ -7,9 +8,8 @@ import {
 	type MantineSize,
 	Stack,
 	Text,
-	Button,
+	useComputedColorScheme,
 	useMantineColorScheme,
-	useComputedColorScheme
 } from '@mantine/core';
 import { Link, useLocation, useRouteLoaderData } from '@remix-run/react';
 
@@ -131,22 +131,18 @@ const MobileDrawer = ({
 	</Drawer.Root>
 );
 
-const ThemeToggleButton = ({
-}: any) => {
-	const { colorScheme, setColorScheme } = useMantineColorScheme();
+const ThemeToggleButton = () => {
+	const { setColorScheme } = useMantineColorScheme();
 	const computedColorScheme = useComputedColorScheme('light');
 	return (
-		<Button onClick={() => setColorScheme(computedColorScheme === 'dark' ? 'light' : 'dark')} title="Toogle theme">
-			{computedColorScheme == 'dark' && (
-				<span>
-					Dark
-				</span>
-			)}
-			{computedColorScheme != 'dark' && (
-				<span>
-					Light
-				</span>
-			)}
+		<Button
+			onClick={() =>
+				setColorScheme(computedColorScheme === 'dark' ? 'light' : 'dark')
+			}
+			title="Toogle theme"
+		>
+			{computedColorScheme === 'dark' && <span>Dark</span>}
+			{computedColorScheme !== 'dark' && <span>Light</span>}
 		</Button>
 	);
 };

--- a/dashboard/app/components/layout/Header.tsx
+++ b/dashboard/app/components/layout/Header.tsx
@@ -7,6 +7,9 @@ import {
 	type MantineSize,
 	Stack,
 	Text,
+	Button,
+	useMantineColorScheme,
+	useComputedColorScheme
 } from '@mantine/core';
 import { Link, useLocation, useRouteLoaderData } from '@remix-run/react';
 
@@ -128,6 +131,25 @@ const MobileDrawer = ({
 	</Drawer.Root>
 );
 
+const ThemeToggleButton = ({
+}: any) => {
+	const { colorScheme, setColorScheme } = useMantineColorScheme();
+	const computedColorScheme = useComputedColorScheme('light');
+	return (
+		<Button onClick={() => setColorScheme(computedColorScheme === 'dark' ? 'light' : 'dark')} title="Toogle theme">
+			{computedColorScheme == 'dark' && (
+				<span>
+					Dark
+				</span>
+			)}
+			{computedColorScheme != 'dark' && (
+				<span>
+					Light
+				</span>
+			)}
+		</Button>
+	);
+};
 export const Header = () => {
 	const data = useRouteLoaderData<RootLoaderData>('root');
 	const isLoggedIn = Boolean(data?.isLoggedIn);
@@ -154,6 +176,7 @@ export const Header = () => {
 					</Group>
 				)}
 				<Group justify="flex-end">
+					<ThemeToggleButton></ThemeToggleButton>
 					<LoginButton isLoggedIn={isLoggedIn} visibleFrom="xs" />
 					<Burger
 						classNames={{ root: classes.burger }}

--- a/dashboard/app/components/settings/WebsiteSelector.module.css
+++ b/dashboard/app/components/settings/WebsiteSelector.module.css
@@ -27,7 +27,7 @@
 	height: 100%;
 	width: var(--radix-dropdown-menu-trigger-width);
 
-	background-color: white;
+	background-color: var(--bg-light);
 	border: 1px solid var(--border-muted);
 	border-radius: 8px;
 
@@ -46,7 +46,7 @@
 	justify-content: flex-start;
 
 	color: var(--text-dark);
-	background-color: white;
+	background-color: var(--bg-light);
 
 	border: none;
 	border-radius: 8px;

--- a/dashboard/app/components/stats/Filter.module.css
+++ b/dashboard/app/components/stats/Filter.module.css
@@ -34,13 +34,13 @@
 	justify-content: space-between;
 
 	color: var(--text-dark);
-	background-color: white;
+	background-color: var(--bg-light);
 
 	border: 1px solid var(--border-light);
 	border-radius: 4px;
 
 	&:hover {
-		background-color: var(--text-light);
+		background-color: var(--bg-light);
 	}
 
 	&:focus,
@@ -62,13 +62,13 @@
 	padding: 0 10px 0 14px;
 
 	color: var(--text-dark);
-	background-color: white;
+	background-color: var(--bg-light);
 
 	border: 1px solid var(--border-light);
 	border-radius: 4px;
 
 	&:hover {
-		background-color: var(--text-light);
+		background-color: var(--bg-light);
 	}
 
 	&:focus,
@@ -95,7 +95,7 @@
 	height: 200px;
 	width: var(--radix-dropdown-menu-trigger-width);
 
-	background-color: white;
+	background-color: var(--bg-light);
 	border: 1px solid var(--border-muted);
 	border-radius: 4px;
 }
@@ -110,7 +110,7 @@
 	justify-content: flex-start;
 
 	color: var(--text-dark);
-	background-color: white;
+	background-color: var(--bg-light);
 
 	border: none;
 	border-radius: 4px;

--- a/dashboard/app/components/stats/Table.module.css
+++ b/dashboard/app/components/stats/Table.module.css
@@ -11,7 +11,7 @@
 	padding: 12px;
 	margin-right: 16px;
 
-	background-color: var(--text-light);
+	background-color: var(--bg-light);
 	border-radius: 8px;
 }
 

--- a/dashboard/app/components/stats/Tabs.module.css
+++ b/dashboard/app/components/stats/Tabs.module.css
@@ -15,7 +15,7 @@
 
 .root {
 	min-height: 393px;
-	background-color: var(--text-light);
+	background-color: var(--bg-light);
 	border-radius: 8px;
 }
 

--- a/dashboard/app/styles/global.css
+++ b/dashboard/app/styles/global.css
@@ -109,6 +109,30 @@
 	--default-monospace-font-family: "Reddit Mono Variable", monospace;
 }
 
+:root[data-mantine-color-scheme="dark"]{
+	/* Text Colors */
+	--text-light: #fcfcfc;
+	--text-dark: #fcfcfc;
+	--text-disabled: #8e9cb4;
+	--text-grey: #7e8c94;
+	--text-muted: #6a777e;
+	--text-red: #fa5252;
+
+	/* Background Colors */
+	--bg-light: #1b1e24;
+	--bg-grey: #262a31;
+	--bg-grey-dark: #111111;
+	--bg-grey-disabled: #111111;
+	--bg-dark: #111111;
+	--bg-grey-blue: #262a31;
+	--bg-grey-blue-dark: #1b1e24;
+	--bg-red-danger: #eb5757;
+	--bg-red-danger-dark: #c53030;
+
+	--badge-positive: #79a346;
+	--badge-negative: #b46934;
+}
+
 body {
 	margin: 0;
 	display: flex;

--- a/dashboard/app/styles/global.css
+++ b/dashboard/app/styles/global.css
@@ -109,7 +109,7 @@
 	--default-monospace-font-family: "Reddit Mono Variable", monospace;
 }
 
-:root[data-mantine-color-scheme="dark"]{
+:root[data-mantine-color-scheme="dark"] {
 	/* Text Colors */
 	--text-light: #fcfcfc;
 	--text-dark: #fcfcfc;


### PR DESCRIPTION
Adds a basic dark theme by overriding relevant colors. Some hard-coded light theme colors were also replaced with the equivalent CSS variables
.
This also adds a toggle next to the logout button to switch between themes:
<img width="224" height="93" alt="image" src="https://github.com/user-attachments/assets/b289b680-ad4f-49e5-9ba7-70421546597f" />

<img width="232" height="106" alt="image" src="https://github.com/user-attachments/assets/9c9804e8-ee70-4253-a141-3e2cbb3c6a30" />

For now, the button just uses text to indicate the current theme, as I did not feel like looking for icons available under the proper license.

